### PR TITLE
docs: improve some formulations in the themes documentation

### DIFF
--- a/docs/themes/gallery.md
+++ b/docs/themes/gallery.md
@@ -1,8 +1,8 @@
 # Themes Gallery
 
-Browser awesome themes available for Slidev here.
+Browse awesome themes available for Slidev here.
 
-Read more about [how to use a theme](/themes/use), or [write one your own](/themes/write-a-theme) and share with the community!
+Read more about [how to use a theme](/themes/use), or [how to write your own](/themes/write-a-theme) and share with the community!
 
 ## Official Themes
 

--- a/docs/themes/use.md
+++ b/docs/themes/use.md
@@ -10,11 +10,9 @@ theme: seriph
 
 You can either directly start the server and it will show up the prompt to install the theme automatically for you
 
-<div class="language-md">
-<pre>
-<span class="token keyword">?</span> Does not found theme <span class="token string">"@slidev/theme-seriph"</span> in your project, do you want to install it now? › (Y/n)
-</pre>
-</div>
+```
+? The theme was not found in your project, would you like to install it now? › (Y/n)
+```
 
 or you can install the theme manually via
 
@@ -22,6 +20,6 @@ or you can install the theme manually via
 $ npm install @slidev/theme-seriph
 ```
 
-And let's all, enjoy the new theme! Refer to the theme's readme for more details about the usage.
+And that's all, enjoy the new theme! For more details about the usage, you can refer to the theme's README.
 
-Want to share your theme? Read more about [how to write a theme](/themes/write-a-theme).
+Want to share your theme? Learn about [how to write a theme](/themes/write-a-theme).

--- a/docs/themes/use.md
+++ b/docs/themes/use.md
@@ -10,9 +10,11 @@ theme: seriph
 
 You can either directly start the server and it will show up the prompt to install the theme automatically for you
 
-```
-? The theme was not found in your project, would you like to install it now? › (Y/n)
-```
+<div class="language-md">
+<pre>
+<span class="token keyword">?</span> Does not found theme <span class="token string">"@slidev/theme-seriph"</span> in your project, do you want to install it now? › (Y/n)
+</pre>
+</div>
 
 or you can install the theme manually via
 

--- a/docs/themes/write-a-theme.md
+++ b/docs/themes/write-a-theme.md
@@ -1,12 +1,12 @@
 # Write a Theme
 
-To get started, we recommend you use our generator to scaffolding your first theme
+To get started, we recommend you use our generator for scaffolding your first theme
 
 ```bash
 $ npm init slidev-theme
 ```
 
-Then you can modify and play with it. Also, refer to the [official themes](/themes/gallery) as examples.
+Then you can modify and play with it. You can also refer to the [official themes](/themes/gallery) as examples.
 
 ## Capability
 
@@ -43,13 +43,13 @@ Optionally, you can also add some scripts to your `packages.json`
 }
 ```
 
-To publish your theme, simply run `npm publish` and you are good to go. There is not build process required (which means you can directly publish `.vue` and `.ts` files, Slidev is smart enough to understand them).
+To publish your theme, simply run `npm publish` and you are good to go. There is no build process required (which means you can directly publish `.vue` and `.ts` files, Slidev is smart enough to understand them).
 
 Theme contribution points follow the same conventions as local customization, please refer to [the docs for the naming conventions](/custom/). 
 
 ## Color Schema
 
-By default, Slidev assumes themes are supporting both light mode and dark mode. If you only want your theme be presented in a designed color schema, you will need to specify it explicitly in `package.json`
+By default, Slidev assumes themes support both light mode and dark mode. If you only want your theme be presented in a designed color schema, you will need to specify it explicitly in `package.json`
 
 ```json
 // package.json
@@ -67,11 +67,11 @@ By default, Slidev assumes themes are supporting both light mode and dark mode. 
 
 ## Highlighter
 
-Syntax highlighting colors are also provided in the theme. We support both [Prism](https://prismjs.com/) and [Shiki](https://github.com/shikijs/shiki), [read more here](/custom/highlighters).
+Syntax highlighting colors are also provided in the theme. We support both [Prism](https://prismjs.com/) and [Shiki](https://github.com/shikijs/shiki). For more information please refer to [the syntax highlighting docs](/custom/highlighters).
 
-You can support one of them or both. Refer to the default theme for configurations examples [prism.css](https://github.com/slidevjs/slidev/blob/main/packages/theme-default/styles/prism.css) / [setup/shiki.ts](https://github.com/slidevjs/slidev/blob/main/packages/theme-default/setup/shiki.ts).
+You can support either one of them, or both. Refer to the default theme for configurations examples [prism.css](https://github.com/slidevjs/slidev/blob/main/packages/theme-default/styles/prism.css) / [shiki.ts](https://github.com/slidevjs/slidev/blob/main/packages/theme-default/setup/shiki.ts).
 
-Also, remember to provide the information in `package.json`
+Also, remember to specify the supported highlighters in your `package.json`
 
 ```json
 // package.json

--- a/docs/themes/write-a-theme.md
+++ b/docs/themes/write-a-theme.md
@@ -69,7 +69,7 @@ By default, Slidev assumes themes support both light mode and dark mode. If you 
 
 Syntax highlighting colors are also provided in the theme. We support both [Prism](https://prismjs.com/) and [Shiki](https://github.com/shikijs/shiki). For more information please refer to [the syntax highlighting docs](/custom/highlighters).
 
-You can support either one of them, or both. Refer to the default theme for configurations examples [prism.css](https://github.com/slidevjs/slidev/blob/main/packages/theme-default/styles/prism.css) / [shiki.ts](https://github.com/slidevjs/slidev/blob/main/packages/theme-default/setup/shiki.ts).
+You can support either one of them, or both. Refer to the default theme for configurations examples [`./styles/prism.css`](https://github.com/slidevjs/slidev/blob/main/packages/theme-default/styles/prism.css) / [`./setup/shiki.ts`](https://github.com/slidevjs/slidev/blob/main/packages/theme-default/setup/shiki.ts).
 
 Also, remember to specify the supported highlighters in your `package.json`
 


### PR DESCRIPTION
I fixed some typos and reformulated some sentences in the themes docs.

Feel free to pick and choose among the larger changes — some are a matter of taste.