### PR TITLE
fix: codemirror overlaps, close #14

### DIFF
--- a/packages/client/internals/Editor.vue
+++ b/packages/client/internals/Editor.vue
@@ -170,6 +170,6 @@ const editorLink = computed(() => {
 
 <style lang="postcss">
 .CodeMirror {
-  @apply px-3 py-2 h-full overflow-auto bg-transparent font-mono text-sm;
+  @apply px-3 py-2 h-full overflow-auto bg-transparent font-mono text-sm z-0;
 }
 </style>


### PR DESCRIPTION
Fixed code overlaps when open editor panel and slides overview.
Related issue #14.
