### PR TITLE
chore: fix typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,10 +38,10 @@ To run Slidev locally, you can run
 pnpm demo:dev
 ```
 
-Or with the stater template
+Or with the starter template
 
 ```bash
-pnpm demo:stater
+pnpm demo:starter
 ```
 
 The server will restart automatically every time the builds get updated.

--- a/docs/custom/index.md
+++ b/docs/custom/index.md
@@ -18,7 +18,7 @@ download: true
 highlighter: 'prism'
 # enable monaco editor, default to dev only
 monaco: 'dev'
-# infomation for your slides, can be a markdown string
+# information for your slides, can be a markdown string
 info: |
   ## Slidev
 

--- a/docs/guide/install.md
+++ b/docs/guide/install.md
@@ -2,7 +2,7 @@
 
 ## Starter Template
 
-The best way to get started is using our official stater template.
+The best way to get started is using our official starter template.
 
 With NPM:
 

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -35,7 +35,7 @@ export interface SlidevConfig {
    */
   download: boolean | string
   /**
-   * Infomation shows on the built SPA
+   * Information shows on the built SPA
    * Can be a markdown string
    *
    * @default true


### PR DESCRIPTION
Fixed 2 typos:

1. Replacing occurrences of `stater` with `starter` 
2. Updating occurrences of `infomation` with `information`