### PR TITLE
fix(cli): not open browser by default

### DIFF
--- a/packages/slidev/node/cli.ts
+++ b/packages/slidev/node/cli.ts
@@ -32,7 +32,7 @@ cli.command(
     })
     .option('open', {
       alias: 'o',
-      default: true,
+      default: false,
       type: 'boolean',
       describe: 'open in browser',
     })


### PR DESCRIPTION
Currently, the dev server automatically opens a new browser tab/window when running `dev`, but this can be confusing to users (especially on MacOS, where it shuffles the windows around).

Also, it is currently not possible to opt out this effect.

Disabling it by default seems like the best solution to me, since users are not forced to use the immediate open functionality, but can still opt in to this behaviour using the `--open` flag.