### PR TITLE
fix(client): nav control focus (Triggered with next page/animation at the same time)

### DIFF
--- a/packages/client/internals/MenuButton.vue
+++ b/packages/client/internals/MenuButton.vue
@@ -22,7 +22,7 @@ onClickOutside(el, () => {
 
 <template>
   <div ref="el" class="flex relative">
-    <div :class="{ disabled }" @click="value = !value" @keyup.space.prevent>
+    <div :class="{ disabled }" @click="value = !value">
       <slot name="button" :class="{ disabled }" />
     </div>
     <div

--- a/packages/client/internals/MenuButton.vue
+++ b/packages/client/internals/MenuButton.vue
@@ -22,7 +22,7 @@ onClickOutside(el, () => {
 
 <template>
   <div ref="el" class="flex relative">
-    <div :class="{ disabled }" @click="value = !value">
+    <div :class="{ disabled }" @click="value = !value" @keyup.space.prevent>
       <slot name="button" :class="{ disabled }" />
     </div>
     <div

--- a/packages/client/internals/MenuButton.vue
+++ b/packages/client/internals/MenuButton.vue
@@ -22,9 +22,9 @@ onClickOutside(el, () => {
 
 <template>
   <div ref="el" class="flex relative">
-    <div :class="{ disabled }" @click="value = !value">
+    <button :class="{ disabled }" @click="value = !value">
       <slot name="button" :class="{ disabled }" />
-    </div>
+    </button>
     <div
       v-show="value"
       class="rounded-md bg-main shadow absolute bottom-10 left-0 z-20"

--- a/packages/client/internals/NavControls.vue
+++ b/packages/client/internals/NavControls.vue
@@ -7,41 +7,42 @@ import { configs } from '../env'
 import RecordingControls from './RecordingControls.vue'
 import Settings from './Settings.vue'
 import MenuButton from './MenuButton.vue'
-
 defineProps({
   mode: {
     default: 'fixed',
   },
 })
-
 const md = breakpoints.smaller('md')
 const { isFullscreen, toggle: toggleFullscreen } = fullscreen
-
 const presenterLink = computed(() => `${location.origin}/presenter/${currentPage.value}`)
 const nonPresenterLink = computed(() => `${location.origin}/${currentPage.value}`)
-
+const root = ref<HTMLDivElement>()
+const onMouseLeave = () => {
+  if (root.value && activeElement.value && root.value.contains(activeElement.value))
+    activeElement.value.blur()
+}
 </script>
 
 <template>
-  <nav ref="root" class="flex flex-wrap-reverse text-xl p-2 gap-1">
-    <button class="icon-btn" @click="toggleFullscreen" @keyup.space.prevent>
+  <nav ref="root" class="flex flex-wrap-reverse text-xl p-2 gap-1" @mouseleave="onMouseLeave">
+    <button class="icon-btn" @click="toggleFullscreen">
       <carbon:minimize v-if="isFullscreen" />
       <carbon:maximize v-else />
     </button>
 
-    <button class="icon-btn" :class="{ disabled: !hasPrev }" @click="prev" @keyup.space.prevent>
+    <button class="icon-btn" :class="{ disabled: !hasPrev }" @click="prev">
       <carbon:arrow-left />
     </button>
 
-    <button class="icon-btn" :class="{ disabled: !hasNext }" title="Next" @click="next" @keyup.space.prevent>
+    <button class="icon-btn" :class="{ disabled: !hasNext }" title="Next" @click="next">
       <carbon:arrow-right />
     </button>
 
-    <button class="icon-btn" title="Slides overview" @click="toggleOverview" @keyup.space.prevent>
+    <button class="icon-btn" title="Slides overview" @click="toggleOverview">
       <carbon:apps />
     </button>
 
-    <button class="icon-btn" title="Toggle dark mode" @click="toggleDark" @keyup.space.prevent>
+    <button class="icon-btn" title="Toggle dark mode" @click="toggleDark">
       <carbon-moon v-if="isDark" />
       <carbon-sun v-else />
     </button>
@@ -63,17 +64,17 @@ const nonPresenterLink = computed(() => `${location.origin}/${currentPage.value}
         <carbon:user-speaker />
       </a>
 
-      <button v-if="!isPresenter" class="icon-btn <md:hidden" @click="showEditor = !showEditor" @keyup.space.prevent>
+      <button v-if="!isPresenter" class="icon-btn <md:hidden" @click="showEditor = !showEditor">
         <carbon:edit />
       </button>
     </template>
     <template v-else>
-      <button v-if="configs.download" class="icon-btn" @click="downloadPDF" @keyup.space.prevent>
+      <button v-if="configs.download" class="icon-btn" @click="downloadPDF">
         <carbon:download />
       </button>
     </template>
 
-    <button v-if="configs.info" class="icon-btn" @click="showInfoDialog = !showInfoDialog" @keyup.space.prevent>
+    <button v-if="configs.info" class="icon-btn" @click="showInfoDialog = !showInfoDialog">
       <carbon:information />
     </button>
 
@@ -95,7 +96,7 @@ const nonPresenterLink = computed(() => `${location.origin}/${currentPage.value}
     <div class="h-40px flex" p="l-1 t-0.5 r-2" text="sm leading-2">
       <div class="my-auto">
         {{ currentPage }}
-        <span class="opacity-50">/ {{ total + 1 }}</span>
+        <span class="opacity-50">/ {{ total }}</span>
       </div>
     </div>
   </nav>

--- a/packages/client/internals/NavControls.vue
+++ b/packages/client/internals/NavControls.vue
@@ -95,7 +95,7 @@ const nonPresenterLink = computed(() => `${location.origin}/${currentPage.value}
     <div class="h-40px flex" p="l-1 t-0.5 r-2" text="sm leading-2">
       <div class="my-auto">
         {{ currentPage }}
-        <span class="opacity-50">/ {{ total }}</span>
+        <span class="opacity-50">/ {{ total + 1 }}</span>
       </div>
     </div>
   </nav>

--- a/packages/client/internals/NavControls.vue
+++ b/packages/client/internals/NavControls.vue
@@ -20,33 +20,28 @@ const { isFullscreen, toggle: toggleFullscreen } = fullscreen
 const presenterLink = computed(() => `${location.origin}/presenter/${currentPage.value}`)
 const nonPresenterLink = computed(() => `${location.origin}/${currentPage.value}`)
 
-const root = ref<HTMLDivElement>()
-const onMouseLeave = () => {
-  if (root.value && activeElement.value && root.value.contains(activeElement.value))
-    activeElement.value.blur()
-}
 </script>
 
 <template>
-  <nav ref="root" class="flex flex-wrap-reverse text-xl p-2 gap-1" @mouseleave="onMouseLeave">
-    <button class="icon-btn" @click="toggleFullscreen">
+  <nav ref="root" class="flex flex-wrap-reverse text-xl p-2 gap-1">
+    <button class="icon-btn" @click="toggleFullscreen" @keyup.space.prevent>
       <carbon:minimize v-if="isFullscreen" />
       <carbon:maximize v-else />
     </button>
 
-    <button class="icon-btn" :class="{ disabled: !hasPrev }" @click="prev">
+    <button class="icon-btn" :class="{ disabled: !hasPrev }" @click="prev" @keyup.space.prevent>
       <carbon:arrow-left />
     </button>
 
-    <button class="icon-btn" :class="{ disabled: !hasNext }" title="Next" @click="next">
+    <button class="icon-btn" :class="{ disabled: !hasNext }" title="Next" @click="next" @keyup.space.prevent>
       <carbon:arrow-right />
     </button>
 
-    <button class="icon-btn" title="Slides overview" @click="toggleOverview">
+    <button class="icon-btn" title="Slides overview" @click="toggleOverview" @keyup.space.prevent>
       <carbon:apps />
     </button>
 
-    <button class="icon-btn" title="Toggle dark mode" @click="toggleDark">
+    <button class="icon-btn" title="Toggle dark mode" @click="toggleDark" @keyup.space.prevent>
       <carbon-moon v-if="isDark" />
       <carbon-sun v-else />
     </button>
@@ -68,17 +63,17 @@ const onMouseLeave = () => {
         <carbon:user-speaker />
       </a>
 
-      <button v-if="!isPresenter" class="icon-btn <md:hidden" @click="showEditor = !showEditor">
+      <button v-if="!isPresenter" class="icon-btn <md:hidden" @click="showEditor = !showEditor" @keyup.space.prevent>
         <carbon:edit />
       </button>
     </template>
     <template v-else>
-      <button v-if="configs.download" class="icon-btn" @click="downloadPDF">
+      <button v-if="configs.download" class="icon-btn" @click="downloadPDF" @keyup.space.prevent>
         <carbon:download />
       </button>
     </template>
 
-    <button v-if="configs.info" class="icon-btn" @click="showInfoDialog = !showInfoDialog">
+    <button v-if="configs.info" class="icon-btn" @click="showInfoDialog = !showInfoDialog" @keyup.space.prevent>
       <carbon:information />
     </button>
 

--- a/packages/client/internals/NavControls.vue
+++ b/packages/client/internals/NavControls.vue
@@ -7,15 +7,19 @@ import { configs } from '../env'
 import RecordingControls from './RecordingControls.vue'
 import Settings from './Settings.vue'
 import MenuButton from './MenuButton.vue'
+
 defineProps({
   mode: {
     default: 'fixed',
   },
 })
+
 const md = breakpoints.smaller('md')
 const { isFullscreen, toggle: toggleFullscreen } = fullscreen
+
 const presenterLink = computed(() => `${location.origin}/presenter/${currentPage.value}`)
 const nonPresenterLink = computed(() => `${location.origin}/${currentPage.value}`)
+
 const root = ref<HTMLDivElement>()
 const onMouseLeave = () => {
   if (root.value && activeElement.value && root.value.contains(activeElement.value))

--- a/packages/client/state/index.ts
+++ b/packages/client/state/index.ts
@@ -15,7 +15,7 @@ export const isScreenVertical = computed(() => windowSize.width.value <= windowS
 export const fullscreen = useFullscreen(isClient ? document.body : null)
 
 export const activeElement = useActiveElement()
-export const isInputing = computed(() => ['INPUT', 'TEXTAREA'].includes(activeElement.value?.tagName || '') || activeElement.value?.classList.contains('CodeMirror-code'))
+export const isInputing = computed(() => ['INPUT', 'TEXTAREA', 'BUTTON', 'A'].includes(activeElement.value?.tagName || '') || activeElement.value?.classList.contains('CodeMirror-code'))
 
 export const currentCamera = useStorage<string>('slidev-camera', 'default')
 export const currentMic = useStorage<string>('slidev-mic', 'default')


### PR DESCRIPTION
Hi Anthony,

I noticed that you have fixed this issue. However, the same problem also occurs if my mouse does not leave the navigation bar. 

I think your solution is already perfect, just provide another solution for you to check. 😄 

Furthermore, I find that the total page number on the navigation bar is always 1 less than the actual one, and I fix it by adding 1. 😄 