### PR TITLE
don't alter in code-block style tags

### DIFF
--- a/packages/parser/src/core.ts
+++ b/packages/parser/src/core.ts
@@ -125,6 +125,9 @@ export function parse(
     // skip code block
     else if (line.startsWith('```')) {
       for (i += 1; i < lines.length; i++) {
+        if (lines[i]?.includes('<style'))
+          lines[i] = lines[i].replace('<style', '<style ___in-code-block___')
+
         if (lines[i].startsWith('```'))
           break
       }

--- a/packages/slidev/node/plugins/markdown.ts
+++ b/packages/slidev/node/plugins/markdown.ts
@@ -118,6 +118,10 @@ export function transformPageCSS(md: string, id: string) {
   const result = md.replace(
     /(\n<style[^>]*?>)([\s\S]+?)(<\/style>)/g,
     (full, start, css, end) => {
+      if (start.includes('in-code-block')) {
+        start = start.replace('<style ___in-code-block___', '<style')
+        return `${start}${css}${end}`
+      }
       if (!start.includes('scoped'))
         start = start.replace('<style', '<style scoped')
       return `${start}\n.slidev-page-${page}{${css}}${end}`


### PR DESCRIPTION
I've ran in a problem where I have <style> tag in a code block (e.g. vue), which are not supposed to be altered as they are not part of the slide styles.