### PR TITLE
docs: fix a typo in the Youtube component usage

### DIFF
--- a/packages/client/builtin/Youtube.vue
+++ b/packages/client/builtin/Youtube.vue
@@ -3,7 +3,7 @@ A simple wrapper for embeded YouTube videos
 
 Usage:
 
-<YouTube id="luoMHjh-XcQ" />
+<Youtube id="luoMHjh-XcQ" />
 -->
 
 <script setup lang="ts">


### PR DESCRIPTION
As per the title, the usage of the Youtube component contains a typo.