### PR TITLE
docs(syntax): fix the tweet component usage

### DIFF
--- a/docs/guide/syntax.md
+++ b/docs/guide/syntax.md
@@ -26,8 +26,8 @@ console.log('Hello, World!')
 You can directly use Windi CSS and Vue components to style and enrich your slides.
 
 <div class="p-3">
-  <Tweet :id="20" />
-<div>
+  <Tweet id="20" />
+</div>
 ~~~
 
 ## Front Matter & Layouts


### PR DESCRIPTION
With the v-bind `:id` prop, the Tweet component doesn't always work.

e.g.
`@antfu7`'s pinned tweet doesn't render with the prepending colon (:).
`<Tweet :id="1389800180002672641" />` doesn't work
but `<Tweet id="1389800180002672641" />` works.

Also, the closing `div` doesn't have slash, causing a server error.