### PR TITLE
feat: shortcuts auto repeating

### DIFF
--- a/packages/client/logic/shortcuts.ts
+++ b/packages/client/logic/shortcuts.ts
@@ -5,19 +5,31 @@ import { next, nextSlide, prev, prevSlide } from './nav'
 
 const _shortcut = and(not(isInputing), not(isOnFocus), shortcutsEnabled)
 
-export function shortcut(key: string, fn: Fn) {
-  return whenever(and(magicKeys[key], _shortcut), fn, { flush: 'sync' })
+export function shortcut(key: string, fn: Fn, autoRepeat: boolean = false) {
+  let count = 0;
+  const f = () => {
+    if (autoRepeat && magicKeys.current.has(key)) {
+      setTimeout(() => f(), Math.max(1000 - count * 40, 200))
+      count++
+    }
+    else {
+      count = 0
+    }
+    fn()
+  }
+  if (!autoRepeat)
+    return whenever(and(magicKeys[key], _shortcut), f, { flush: 'sync' })
 }
 
 export function registerShotcuts() {
   // global shortcuts
-  shortcut('space', next)
-  shortcut('right', next)
-  shortcut('left', prev)
-  shortcut('up', () => prevSlide(false))
-  shortcut('down', nextSlide)
-  shortcut('shift_left', () => prevSlide(false))
-  shortcut('shift_right', nextSlide)
+  shortcut('space', next, true)
+  shortcut('right', next, true)
+  shortcut('left', prev, true)
+  shortcut('up', () => prevSlide(false), true)
+  shortcut('down', nextSlide, true)
+  shortcut('shift_left', () => prevSlide(false), true)
+  shortcut('shift_right', nextSlide, true)
   shortcut('d', toggleDark)
   shortcut('f', () => fullscreen.toggle())
   shortcut('o', toggleOverview)


### PR DESCRIPTION
Currently, keeping right pressed does nothing more than just pressing it once. The event should auto repeat if the key combination is still pressed. 
This PR is an untested work. I have not built slidev, I just wanted to try it out and ask if you thought it was a good idea. I actually modified the code in github's default, so it might not even build. If you think that the idea is worth a bit of work I will put it.