### PR TITLE
docs(slides): fix a small grammatical error

### DIFF
--- a/packages/create-app/template/slides.md
+++ b/packages/create-app/template/slides.md
@@ -128,7 +128,7 @@ function updateUser(id: number, update: User) {
 
 You can use Vue components directly inside your slides.
 
-We have provided a few built-in components like `<Tweet/>` and `<Youtube/>` that you can use directly use. And add your custom components are also super easy.
+We have provided a few built-in components like `<Tweet/>` and `<Youtube/>` that you can use directly. And adding your custom components is also super easy.
 
 ```html
 <Counter :count="10" />


### PR DESCRIPTION
Just found your tool today, it's really cool. Was going through the demo and found this little error.