### PR TITLE
fix: cli prompts

### DIFF
--- a/packages/create-app/index.js
+++ b/packages/create-app/index.js
@@ -32,10 +32,9 @@ async function init() {
     const { projectName } = await prompts({
       type: 'text',
       name: 'projectName',
-      message: 'Project name:',
-      initial: 'slidev',
+      message: 'Project name: (slidev)',
     })
-    targetDir = projectName.trim()
+    targetDir = projectName.trim() || 'slidev'
   }
   const packageName = await getValidPackageName(targetDir)
   const root = path.join(cwd, targetDir)

--- a/packages/create-app/index.js
+++ b/packages/create-app/index.js
@@ -35,7 +35,7 @@ async function init() {
       message: 'Project name:',
       initial: 'slidev',
     })
-    targetDir = projectName
+    targetDir = projectName.trim()
   }
   const packageName = await getValidPackageName(targetDir)
   const root = path.join(cwd, targetDir)


### PR DESCRIPTION
for me, at the first time I create the **slidev** app

at the step of giving `project name`, the `slidev` is default (actually I think  that should be put  at the question) 


 if you want to rename it , just type your name directly, but I didn't know it firstly and kept typing `backspace`  😅

in this operation, I typed two `space` unexpectedly and I didn't notice it, so the generated directory is with the `space` prefix

that's why I can't  `cd` into it 😅