### PR TITLE
fix: forced create symbolic link

### DIFF
--- a/demo/starter/package.json
+++ b/demo/starter/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "dev": "ln -sF ../../packages/create-app/template/slides.md slides.md && nodemon -w '../../packages/slidev/dist/*.js' --exec 'slidev ./slides.md --open=false --log=info'",
+    "dev": "ln -sFf ../../packages/create-app/template/slides.md slides.md && nodemon -w '../../packages/slidev/dist/*.js' --exec 'slidev ./slides.md --open=false --log=info'",
     "build": "slidev build",
     "export": "slidev export"
   },


### PR DESCRIPTION
## Problem

`pnpm demo:dev` cannot recreate a symbolic link at ubuntu-18.04.

```
pnpm demo:dev

> @0.13.10 demo:dev /home/solenoid/ghq/github.com/mikanIchinose/slidev
> pnpm -C demo/starter run dev


> @ dev /home/solenoid/ghq/github.com/mikanIchinose/slidev/demo/starter
> ln -sF ../../packages/create-app/template/slides.md slides.md && nodemon -w '../../packages/slidev/dist/*.js' --exec 'slidev ./slides.md --open=false --log=info'

ln: failed to create symbolic link 'slides.md': File exists
 ERROR  Command failed with exit code 1.
 ERROR  Command failed with exit code 1.
```

## Solution

add option `-f` at `dev` script of  `demo/starter/packege.json`