### PR TITLE
fix: filter head title when it is styled using html tags

### DIFF
--- a/packages/client/setup/root.ts
+++ b/packages/client/setup/root.ts
@@ -7,6 +7,7 @@ import { router } from '../routes'
 import configs from '/@slidev/configs'
 // @ts-expect-error
 import serverState from '/@server-ref/state'
+import { stripMarkdownHTMLTags } from '../utils'
 
 export default function setupRoot() {
   // @ts-expect-error
@@ -16,7 +17,7 @@ export default function setupRoot() {
   /* __injections__ */
 
   useHead({
-    title: configs.title ? `${configs.title} - Slidev` : 'Slidev',
+    title: configs.title ? `${stripMarkdownHTMLTags(configs.title)} - Slidev` : 'Slidev',
   })
 
   // sync with server state

--- a/packages/client/utils.ts
+++ b/packages/client/utils.ts
@@ -1,8 +1,14 @@
 import type { RouteRecordRaw } from 'vue-router'
 
+const REGEX_HTML_TAGS_IN_MARKDOWN = /(?<!\\)<(.*?)[^\\]>/g
+
 export function getSlideClass(route?: RouteRecordRaw) {
   const no = route?.meta?.slide?.no
   if (no != null)
     return `slidev-page-${no}`
   return ''
+}
+
+export function stripMarkdownHTMLTags(markdown: string) {
+  return markdown.replace(REGEX_HTML_TAGS_IN_MARKDOWN, '')
 }


### PR DESCRIPTION
This PR filters unescaped HTML tags in the head title.

## Background

Currently, head title can be styled using HTML tags:

For example,

```markdown
# <span style="color:red">Composable</span> Vue
```

However, because it is also directly fed to the browser tab title like this:
https://github.com/slidevjs/slidev/blob/3afc764ffa628f06d7bd11fbd4f5a751e3777e9a/packages/client/setup/root.ts#L18-L20

So the literals would straight show up in the browser tab, being something like `<span style="color:red">Composable...`, which is obviously not very ideal.

## Solution

This PR utilizes the regular expression to filter unescaped HTML tags in the head title when calling `useHead`.

The regular expression being:
```ts
const REGEX_HTML_TAGS_IN_MARKDOWN = /(?<!\\)<(.*?)[^\\]>/g
```

Note that escaping using slashes would be allowed by this regular expression. For instance, markdown `\<span style="color:red"\>` would mean literal `<span style="color:red">`.