### PR TITLE
fix: Non-number slideScale causing mispositioning

### DIFF
--- a/packages/client/internals/Settings.vue
+++ b/packages/client/internals/Settings.vue
@@ -3,10 +3,10 @@ import { slideScale } from '../state'
 import SelectList from './SelectList.vue'
 import type { SelectionItem } from './types'
 
-const items: SelectionItem<number | null>[] = [
+const items: SelectionItem<number>[] = [
   {
     display: 'Fit',
-    value: null,
+    value: 0,
   },
   {
     display: '1:1',

--- a/packages/client/internals/SlideContainer.vue
+++ b/packages/client/internals/SlideContainer.vue
@@ -33,7 +33,7 @@ if (props.width) {
 const screenAspect = computed(() => width.value / height.value)
 
 const scale = computed(() => {
-  if (props.scale != null)
+  if (props.scale)
     return props.scale
   if (screenAspect.value < slideAspect)
     return width.value / slideWidth

--- a/packages/client/state/index.ts
+++ b/packages/client/state/index.ts
@@ -20,7 +20,7 @@ export const isOnFocus = computed(() => ['BUTTON', 'A'].includes(activeElement.v
 
 export const currentCamera = useStorage<string>('slidev-camera', 'default')
 export const currentMic = useStorage<string>('slidev-mic', 'default')
-export const slideScale = useStorage<number>('slidev-scale', null)
+export const slideScale = useStorage<number>('slidev-scale', 0)
 
 export const showEditor = useStorage('slidev-show-editor', false)
 export const editorWidth = useStorage('slidev-editor-width', isClient ? window.innerWidth * 0.4 : 100)


### PR DESCRIPTION
Fix #173 / #177.

Using `null` in number typed `slideScale` would also make Vue runtime type checking fail.

But notice this fix gives special meaning to value `0`, replacing the original `null`.