### PR TITLE
fix: removing broken import in create-theme

### DIFF
--- a/packages/create-theme/template/styles/index.ts
+++ b/packages/create-theme/template/styles/index.ts
@@ -1,5 +1,4 @@
 // inherit from base layouts, remove it to get full customizations
 import '@slidev/client/styles/layouts-base.css'
-import './main.css'
 import './layout.css'
 import './code.css'


### PR DESCRIPTION
`./styles/main.css` is required by the `create-theme` package, however, it was removed in [a prior commit](https://github.com/slidevjs/slidev/commit/e61c7f894065bc4b299048e737120eb15c6bcd68#diff-218165a8ed3169515a1607c50db704ce52c29489e2d5300dffb08204eb59febb).

This causes a Vite server error as it expects the main.css file. The proposed PR removes said import.