### PR TITLE
fix: support section matter

### DIFF
--- a/packages/parser/src/core.ts
+++ b/packages/parser/src/core.ts
@@ -45,7 +45,7 @@ export function prettify(data: SlidevMarkdown) {
 
 function matter(code: string) {
   let data: any = {}
-  const content = code.replace(/^---([\s\S]*?)---/,
+  const content = code.replace(/^---.*\r?\n([\s\S]*?)---/,
     (_, d) => {
       data = YAML.load(d)
       if (!isObject(data))
@@ -110,12 +110,12 @@ export function parse(
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i].trimRight()
-    if (line.match(/^---+$/)) {
+    if (line.match(/^---+/)) {
       slice(i)
 
       const next = lines[i + 1]
       // found frontmatter, skip next dash
-      if (line.length === 3 && !next?.match(/^\s*$/)) {
+      if (line.match(/^---([^-].*)?$/) && !next?.match(/^\s*$/)) {
         start = i
         for (i += 1; i < lines.length; i++) {
           if (lines[i].trimRight().match(/^---$/))

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -58,4 +58,32 @@ f
     expect(data.slides[2].frontmatter)
       .toEqual({ layout: 'z' })
   })
+
+  it('parse section matter', () => {
+    const data = parse(`
+a
+
+---
+
+b
+
+---section2
+layout: z
+---
+c
+----   section 3
+d
+---- section-4
+e
+
+---
+
+f
+
+`)
+    expect(data.slides.map(i => i.content.trim()))
+      .toEqual(Array.from('abcdef'))
+    expect(data.slides[2].frontmatter)
+      .toEqual({ layout: 'z' })
+  })
 })


### PR DESCRIPTION
## Problems
Example:
```markdown
---
title: One
---

---
title: Two
---
```

AST:
![image](https://user-images.githubusercontent.com/13805071/120144070-de9e1000-c213-11eb-9eef-da780c5756f7.png)


Prettier will format it to
```diff
 ---
 title: One
 ---
 
 ---
-title: Two
----
+
+## title: Two
```

## Solution
inspired by [section-matter](https://github.com/jonschlinkert/section-matter), add some text after the first `---`, Prettier will just add a blank line before the second `---`.

```diff
 ---
 title: One
 ---

 --- section 2
 title: Two
+
 ---
```

