### PR TITLE
Plotly asset

### DIFF
--- a/packages/client/builtin/Plotly.vue
+++ b/packages/client/builtin/Plotly.vue
@@ -8,12 +8,12 @@ Usage:
 -->
 
 <script setup lang="ts">
-import { defineProps } from "vue";
+import { defineProps } from 'vue'
 defineProps<{
-  link: string; // plotly link for chart
-  width?: number;
-  height?: number;
-}>();
+  link: string // plotly link for chart
+  width?: number
+  height?: number
+}>()
 </script>
 
 <template>

--- a/packages/client/builtin/Plotly.vue
+++ b/packages/client/builtin/Plotly.vue
@@ -1,0 +1,30 @@
+<!--
+Wrapper for embedded plotly charts - export your chart from chart-studio
+
+WARNING: Layout of page must be set to none, charts only work in fullscreen mode reliably
+
+Usage:
+<Plotly link="//plotly.com/~jorekai/3.embed"/>
+-->
+
+<script setup lang="ts">
+import { defineProps } from "vue";
+defineProps<{
+  link: string; // plotly link for chart
+  width?: number;
+  height?: number;
+}>();
+</script>
+
+<template>
+  <iframe
+    title="Plotly"
+    :width="width || `100%`"
+    :height="height || `100%`"
+    style="position: absolute"
+    frameborder="0"
+    scrolling="no"
+    :src="link + '?modebar=false&link=false'"
+    allowfullscreen
+  ></iframe>
+</template>


### PR DESCRIPTION
Hey thought I'd publish a small component I used for my thesis' presentation. It supports a fullscreen Plotly embedded widget by wrapping the iframe like the youtube component. Proceed how you want to :), maybe others will need it too.

Usage:

1.  Create chart [here](https://chart-studio.plotly.com)
2.  Make use of it! (edit: set slide _layout: none_)
    ```vue
    <Plotly link="//plotly.com/~jorekai/3.embed"/>
    // setting width and height is not recommended
    <Plotly link="//plotly.com/~jorekai/3.embed"/ width="100px" height="100px">
    ```
