### PR TITLE
feat: shortcuts configuration

### DIFF
--- a/packages/client/logic/shortcuts.ts
+++ b/packages/client/logic/shortcuts.ts
@@ -36,44 +36,32 @@ export function strokeShortcut(key: KeyFilter, fn: Fn) {
 }
 
 export function registerShortcuts() {
-  // user custuom shortcuts
-  const custuomShortcuts = setupShortcuts()
+  const customShortcuts = setupShortcuts()
 
-  // default global shortcuts
-  new Map<string, ShortcutOptions>([
-    { key: 'space', fn: next, autoRepeat: true },
-    { key: 'right', fn: next, autoRepeat: true },
-    { key: 'left', fn: prev, autoRepeat: true },
-    { key: 'pageDown', fn: next, autoRepeat: true },
-    { key: 'pageUp', fn: prev, autoRepeat: true },
-    { key: 'up', fn: () => prevSlide(false), autoRepeat: true },
-    { key: 'down', fn: nextSlide, autoRepeat: true },
-    { key: 'shift_left', fn: () => prevSlide(false), autoRepeat: true },
-    { key: 'shift_right', fn: nextSlide, autoRepeat: true },
-    { key: 'd', fn: toggleDark },
-    { key: 'o', fn: toggleOverview },
-    { key: 'escape', fn: () => showOverview.value = false },
-    { key: 'g', fn: () => showGotoDialog.value = !showGotoDialog.value },
-    ...custuomShortcuts,
-  ]
-    .map((shortcutOptions: ShortcutOptions) => [shortcutOptions.key, shortcutOptions]))
-    .forEach((config) => {
-      shortcut(config.key, config.fn, config.autoRepeat)
-    })
+  const shortcuts = new Map<string, ShortcutOptions>(
+    [
+      { key: 'space', fn: next, autoRepeat: true },
+      { key: 'right', fn: next, autoRepeat: true },
+      { key: 'left', fn: prev, autoRepeat: true },
+      { key: 'pageDown', fn: next, autoRepeat: true },
+      { key: 'pageUp', fn: prev, autoRepeat: true },
+      { key: 'up', fn: () => prevSlide(false), autoRepeat: true },
+      { key: 'down', fn: nextSlide, autoRepeat: true },
+      { key: 'shift_left', fn: () => prevSlide(false), autoRepeat: true },
+      { key: 'shift_right', fn: nextSlide, autoRepeat: true },
+      { key: 'd', fn: toggleDark },
+      { key: 'o', fn: toggleOverview },
+      { key: 'escape', fn: () => showOverview.value = false },
+      { key: 'g', fn: () => showGotoDialog.value = !showGotoDialog.value },
+      ...customShortcuts,
+    ]
+      .map((options: ShortcutOptions) => [options.key, options]),
+  )
 
-  // shortcut('space', next, true)
-  // shortcut('right', next, true)
-  // shortcut('left', prev, true)
-  // shortcut('pageDown', next, true)
-  // shortcut('pageUp', prev, true)
-  // shortcut('up', () => prevSlide(false), true)
-  // shortcut('down', nextSlide, true)
-  // shortcut('shift_left', () => prevSlide(false), true)
-  // shortcut('shift_right', nextSlide, true)
-  // shortcut('d', toggleDark)
-  // shortcut('o', toggleOverview)
-  // shortcut('escape', () => showOverview.value = false)
-  // shortcut('g', () => showGotoDialog.value = !showGotoDialog.value)
+  shortcuts.forEach((options) => {
+    if (options.fn)
+      shortcut(options.key, options.fn, options.autoRepeat)
+  })
 
   strokeShortcut('f', () => fullscreen.toggle())
 }

--- a/packages/client/logic/shortcuts.ts
+++ b/packages/client/logic/shortcuts.ts
@@ -1,6 +1,6 @@
 import { Fn, not, and, onKeyStroke, KeyFilter } from '@vueuse/core'
 import { watch } from 'vue'
-import { ShortcutOptions } from 'packages/types/src/setups'
+import type { ShortcutOptions } from '@slidev/types'
 import { fullscreen, magicKeys, shortcutsEnabled, isInputting, toggleOverview, showGotoDialog, showOverview, isOnFocus } from '../state'
 import setupShortcuts from '../setup/shortcuts'
 import { toggleDark } from './dark'

--- a/packages/client/logic/shortcuts.ts
+++ b/packages/client/logic/shortcuts.ts
@@ -1,6 +1,8 @@
 import { Fn, not, and, onKeyStroke, KeyFilter } from '@vueuse/core'
 import { watch } from 'vue'
+import { ShortcutOptions } from 'packages/types/src/setups'
 import { fullscreen, magicKeys, shortcutsEnabled, isInputting, toggleOverview, showGotoDialog, showOverview, isOnFocus } from '../state'
+import setupShortcuts from '../setup/shortcuts'
 import { toggleDark } from './dark'
 import { next, nextSlide, prev, prevSlide } from './nav'
 
@@ -34,19 +36,44 @@ export function strokeShortcut(key: KeyFilter, fn: Fn) {
 }
 
 export function registerShortcuts() {
-  // global shortcuts
-  shortcut('space', next, true)
-  shortcut('right', next, true)
-  shortcut('left', prev, true)
-  shortcut('pageDown', next, true)
-  shortcut('pageUp', prev, true)
-  shortcut('up', () => prevSlide(false), true)
-  shortcut('down', nextSlide, true)
-  shortcut('shift_left', () => prevSlide(false), true)
-  shortcut('shift_right', nextSlide, true)
-  shortcut('d', toggleDark)
+  // user custuom shortcuts
+  const custuomShortcuts = setupShortcuts()
+
+  // default global shortcuts
+  new Map<string, ShortcutOptions>([
+    { key: 'space', fn: next, autoRepeat: true },
+    { key: 'right', fn: next, autoRepeat: true },
+    { key: 'left', fn: prev, autoRepeat: true },
+    { key: 'pageDown', fn: next, autoRepeat: true },
+    { key: 'pageUp', fn: prev, autoRepeat: true },
+    { key: 'up', fn: () => prevSlide(false), autoRepeat: true },
+    { key: 'down', fn: nextSlide, autoRepeat: true },
+    { key: 'shift_left', fn: () => prevSlide(false), autoRepeat: true },
+    { key: 'shift_right', fn: nextSlide, autoRepeat: true },
+    { key: 'd', fn: toggleDark },
+    { key: 'o', fn: toggleOverview },
+    { key: 'escape', fn: () => showOverview.value = false },
+    { key: 'g', fn: () => showGotoDialog.value = !showGotoDialog.value },
+    ...custuomShortcuts,
+  ]
+    .map((shortcutOptions: ShortcutOptions) => [shortcutOptions.key, shortcutOptions]))
+    .forEach((config) => {
+      shortcut(config.key, config.fn, config.autoRepeat)
+    })
+
+  // shortcut('space', next, true)
+  // shortcut('right', next, true)
+  // shortcut('left', prev, true)
+  // shortcut('pageDown', next, true)
+  // shortcut('pageUp', prev, true)
+  // shortcut('up', () => prevSlide(false), true)
+  // shortcut('down', nextSlide, true)
+  // shortcut('shift_left', () => prevSlide(false), true)
+  // shortcut('shift_right', nextSlide, true)
+  // shortcut('d', toggleDark)
+  // shortcut('o', toggleOverview)
+  // shortcut('escape', () => showOverview.value = false)
+  // shortcut('g', () => showGotoDialog.value = !showGotoDialog.value)
+
   strokeShortcut('f', () => fullscreen.toggle())
-  shortcut('o', toggleOverview)
-  shortcut('escape', () => showOverview.value = false)
-  shortcut('g', () => showGotoDialog.value = !showGotoDialog.value)
 }

--- a/packages/client/setup/shortcuts.ts
+++ b/packages/client/setup/shortcuts.ts
@@ -1,12 +1,24 @@
 /* __imports__ */
 
-import { ShortcutOptions } from 'packages/types/src/setups'
-import * as nav from '../logic/nav'
+import { ShortcutOptions, Nav } from '@slidev/types'
+import { next, prev, nextSlide, prevSlide, downloadPDF } from '../logic/nav'
+import { toggleDark } from '../logic/dark'
+import { toggleOverview, showGotoDialog, showOverview } from '../state'
 
 export default function setupShortcuts() {
   // @ts-expect-error
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const injection_arg = nav
+  const injection_arg: Nav = {
+    next,
+    prev,
+    nextSlide,
+    prevSlide,
+    downloadPDF,
+    toggleDark,
+    toggleOverview,
+    escapeOverview: () => showOverview.value = false,
+    showGotoDialog: () => showGotoDialog.value = !showGotoDialog.value,
+  }
 
   // eslint-disable-next-line prefer-const
   let injection_return: Array<ShortcutOptions> = []

--- a/packages/client/setup/shortcuts.ts
+++ b/packages/client/setup/shortcuts.ts
@@ -1,0 +1,17 @@
+/* __imports__ */
+
+import { ShortcutOptions } from 'packages/types/src/setups'
+import * as nav from '../logic/nav'
+
+export default function setupShortcuts() {
+  // @ts-expect-error
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const injection_arg = nav
+
+  // eslint-disable-next-line prefer-const
+  let injection_return: Array<ShortcutOptions> = []
+
+  /* __injections__ */
+
+  return injection_return
+}

--- a/packages/client/setup/shortcuts.ts
+++ b/packages/client/setup/shortcuts.ts
@@ -1,6 +1,6 @@
 /* __imports__ */
 
-import { ShortcutOptions, Nav } from '@slidev/types'
+import { ShortcutOptions, NavOperations } from '@slidev/types'
 import { next, prev, nextSlide, prevSlide, downloadPDF } from '../logic/nav'
 import { toggleDark } from '../logic/dark'
 import { toggleOverview, showGotoDialog, showOverview } from '../state'
@@ -8,7 +8,7 @@ import { toggleOverview, showGotoDialog, showOverview } from '../state'
 export default function setupShortcuts() {
   // @ts-expect-error
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const injection_arg: Nav = {
+  const injection_arg: NavOperations = {
     next,
     prev,
     nextSlide,

--- a/packages/types/src/setups.ts
+++ b/packages/types/src/setups.ts
@@ -41,7 +41,7 @@ export interface NavOperations {
 
 export interface ShortcutOptions {
   key: string
-  fn: () => void
+  fn?: () => void
   autoRepeat?: boolean
 }
 

--- a/packages/types/src/setups.ts
+++ b/packages/types/src/setups.ts
@@ -32,8 +32,11 @@ export interface Nav {
   prev: () => Promise<void>
   nextSlide: () => void
   prevSlide: () => Promise<void>
-  go: (page: number, clicks?: number) => Promise<void>
   downloadPDF: () => Promise<void>
+  toggleDark: () => void
+  toggleOverview: () => void
+  escapeOverview: () => void
+  showGotoDialog: () => void
 }
 
 export interface ShortcutOptions {

--- a/packages/types/src/setups.ts
+++ b/packages/types/src/setups.ts
@@ -27,6 +27,21 @@ export interface ShikiOptions {
 
 export type MermaidOptions = (typeof mermaid.initialize) extends (a: infer A) => any ? A : never
 
+export interface Nav {
+  next: () => void
+  prev: () => Promise<void>
+  nextSlide: () => void
+  prevSlide: () => Promise<void>
+  go: (page: number, clicks?: number) => Promise<void>
+  downloadPDF: () => Promise<void>
+}
+
+export interface ShortcutOptions {
+  key: string
+  fn: () => void
+  autoRepeat?: boolean
+}
+
 // node side
 export type ShikiSetup = (shiki: typeof Shiki) => Awaitable<ShikiOptions | undefined>
 export type KatexSetup = () => Awaitable<Partial<KatexOptions> | undefined>
@@ -36,6 +51,7 @@ export type WindiSetup = () => Awaitable<Partial<WindiCssOptions> | undefined>
 export type MonacoSetup = (m: typeof monaco) => Awaitable<void>
 export type AppSetup = (context: AppContext) => Awaitable<void>
 export type MermaidSetup = () => Partial<MermaidOptions> | undefined
+export type ShortcutsSetup = (nav: Nav) => Array<ShortcutOptions>
 
 export function defineShikiSetup(fn: ShikiSetup) {
   return fn
@@ -58,5 +74,9 @@ export function defineMermaidSetup(fn: MermaidSetup) {
 }
 
 export function defineKatexSetup(fn: KatexSetup) {
+  return fn
+}
+
+export function defineShortcutsSetup(fn: ShortcutsSetup) {
   return fn
 }

--- a/packages/types/src/setups.ts
+++ b/packages/types/src/setups.ts
@@ -27,7 +27,7 @@ export interface ShikiOptions {
 
 export type MermaidOptions = (typeof mermaid.initialize) extends (a: infer A) => any ? A : never
 
-export interface Nav {
+export interface NavOperations {
   next: () => void
   prev: () => Promise<void>
   nextSlide: () => void
@@ -54,7 +54,7 @@ export type WindiSetup = () => Awaitable<Partial<WindiCssOptions> | undefined>
 export type MonacoSetup = (m: typeof monaco) => Awaitable<void>
 export type AppSetup = (context: AppContext) => Awaitable<void>
 export type MermaidSetup = () => Partial<MermaidOptions> | undefined
-export type ShortcutsSetup = (nav: Nav) => Array<ShortcutOptions>
+export type ShortcutsSetup = (nav: NavOperations) => Array<ShortcutOptions>
 
 export function defineShikiSetup(fn: ShikiSetup) {
   return fn


### PR DESCRIPTION
Fixes #209 

Add shortcuts configuration.

Create `./setup/shortcuts.ts` with the following content:

```ts
import { defineShortcutsSetup, NavOperations } from '@slidev/types'

export default defineShortcutsSetup((nav: NavOperations) => {
  return [
    {
      key: 'enter',
      fn: () => nav.next(),
      autoRepeat: true,
    },
    {
      key: 'backspace',
      fn: () => nav.prev(),
      autoRepeat: true,
    },
  ]
})
```

Related type declaration:

```ts
export interface NavOperations {
  next: () => void
  prev: () => Promise<void>
  nextSlide: () => void
  prevSlide: () => Promise<void>
  downloadPDF: () => Promise<void>
  toggleDark: () => void
  toggleOverview: () => void
  escapeOverview: () => void
  showGotoDialog: () => void
}

export interface ShortcutOptions {
  key: string
  fn: () => void
  autoRepeat?: boolean
}

export type ShortcutsSetup = (nav: NavOperations) => Array<ShortcutOptions>

export function defineShortcutsSetup(fn: ShortcutsSetup) {
  return fn
}
```