### PR TITLE
fix: use viewBox attribute instead of height when scaling Mermaid diagrams

### DIFF
--- a/packages/client/builtin/Mermaid.vue
+++ b/packages/client/builtin/Mermaid.vue
@@ -13,7 +13,6 @@ pie
 -->
 
 <script setup lang="ts">
-import { log } from 'debug'
 import { defineProps, computed, getCurrentInstance, ref, watch, watchEffect } from 'vue'
 import { renderMermaid } from '../modules/mermaid'
 

--- a/packages/client/builtin/Mermaid.vue
+++ b/packages/client/builtin/Mermaid.vue
@@ -13,6 +13,7 @@ pie
 -->
 
 <script setup lang="ts">
+import { log } from 'debug'
 import { defineProps, computed, getCurrentInstance, ref, watch, watchEffect } from 'vue'
 import { renderMermaid } from '../modules/mermaid'
 
@@ -26,24 +27,24 @@ const vm = getCurrentInstance()
 const el = ref<HTMLDivElement>()
 const svgObj = computed(() => renderMermaid(props.code || '', Object.assign({ theme: props.theme }, vm!.attrs)))
 const html = computed(() => svgObj.value)
-const actuallHeight = ref<number>()
+const actualHeight = ref<number>()
 
 watch(html, () => {
-  actuallHeight.value = undefined
+  actualHeight.value = undefined
 })
 
 watchEffect(() => {
   const svgEl = el.value?.children?.[0] as SVGElement | undefined
-  if (svgEl && svgEl.hasAttribute('width') && actuallHeight.value == null) {
-    const v = parseFloat(svgEl.getAttribute('height') || '')
-    actuallHeight.value = isNaN(v) ? undefined : v
+  if (svgEl && svgEl.hasAttribute('viewBox') && actualHeight.value == null) {
+    const v = parseFloat(svgEl.getAttribute('viewBox')?.split(' ')[3] || '')
+    actualHeight.value = isNaN(v) ? undefined : v
   }
 }, { flush: 'post' })
 
 watchEffect(() => {
   const svgEl = el.value?.children?.[0] as SVGElement | undefined
-  if (svgEl != null && props.scale != null && actuallHeight.value != null) {
-    svgEl.setAttribute('height', `${actuallHeight.value * props.scale}`)
+  if (svgEl != null && props.scale != null && actualHeight.value != null) {
+    svgEl.setAttribute('height', `${actualHeight.value * props.scale}`)
     svgEl.removeAttribute('width')
     svgEl.removeAttribute('style')
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,6 +128,20 @@ importers:
       '@slidev/types': link:../../packages/types
       nodemon: 2.0.7
 
+  demo/composable-vue-cn:
+    specifiers:
+      '@slidev/cli': workspace:*
+      '@slidev/theme-default': ^0.19.1
+      '@slidev/theme-seriph': ^0.19.1
+      '@slidev/types': workspace:*
+      nodemon: ^2.0.7
+    devDependencies:
+      '@slidev/cli': link:../../packages/slidev
+      '@slidev/theme-default': 0.19.1
+      '@slidev/theme-seriph': 0.19.1
+      '@slidev/types': link:../../packages/types
+      nodemon: 2.0.7
+
   demo/starter:
     specifiers:
       '@slidev/cli': workspace:*

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,20 +128,6 @@ importers:
       '@slidev/types': link:../../packages/types
       nodemon: 2.0.7
 
-  demo/composable-vue-cn:
-    specifiers:
-      '@slidev/cli': workspace:*
-      '@slidev/theme-default': ^0.19.1
-      '@slidev/theme-seriph': ^0.19.1
-      '@slidev/types': workspace:*
-      nodemon: ^2.0.7
-    devDependencies:
-      '@slidev/cli': link:../../packages/slidev
-      '@slidev/theme-default': 0.19.1
-      '@slidev/theme-seriph': 0.19.1
-      '@slidev/types': link:../../packages/types
-      nodemon: 2.0.7
-
   demo/starter:
     specifiers:
       '@slidev/cli': workspace:*


### PR DESCRIPTION
Hi,

In the new scaling method introduced earlier, the mermaid SVG's original `height` attribute is used. However, in some cases, the SVG returned my mermaidjs has a `height` attribute equal to "100%" which makes the scaling non consistent.

Using the viewBox attribute of the SVG should solve this issue, since `height/viewBox[3]` can directly be interpreted as a scaling factor for the SVGs.

Thanks!

/CN 