### PR TITLE
feat: add shift+space to move to the previous page

### DIFF
--- a/packages/create-app/template/slides.md
+++ b/packages/create-app/template/slides.md
@@ -82,7 +82,7 @@ Hover on the bottom-left corner to see the navigation's controls panel, [learn m
 |     |     |
 | --- | --- |
 | <kbd>right</kbd> / <kbd>space</kbd>| next animation or slide |
-| <kbd>left</kbd> | previous animation or slide |
+| <kbd>left</kbd>  / <kbd>shift</kbd><kbd>space</kbd> | previous animation or slide |
 | <kbd>up</kbd> | previous slide |
 | <kbd>down</kbd> | next slide |
 

--- a/packages/create-theme/template/example.md
+++ b/packages/create-theme/template/example.md
@@ -43,7 +43,7 @@ Hover on the bottom-left corner to see the navigation's controls panel
 |     |     |
 | --- | --- |
 | <kbd>space</kbd> / <kbd>tab</kbd> / <kbd>right</kbd> | next animation or slide |
-| <kbd>left</kbd> | previous animation or slide |
+| <kbd>left</kbd>  / <kbd>shift</kbd><kbd>space</kbd> | previous animation or slide |
 | <kbd>up</kbd> | previous slide |
 | <kbd>down</kbd> | next slide |
 

--- a/packages/slidev/template.md
+++ b/packages/slidev/template.md
@@ -82,7 +82,7 @@ Hover on the bottom-left corner to see the navigation's controls panel, [learn m
 |     |     |
 | --- | --- |
 | <kbd>right</kbd> / <kbd>space</kbd>| next animation or slide |
-| <kbd>left</kbd> | previous animation or slide |
+| <kbd>left</kbd>  / <kbd>shift</kbd><kbd>space</kbd>| previous animation or slide |
 | <kbd>up</kbd> | previous slide |
 | <kbd>down</kbd> | next slide |
 

--- a/packages/types/src/setups.ts
+++ b/packages/types/src/setups.ts
@@ -3,7 +3,7 @@ import type { Awaitable } from '@antfu/utils'
 import type { IThemeRegistration, ILanguageRegistration, Highlighter as ShikiHighlighter } from 'shiki'
 import type * as Shiki from 'shiki'
 import type * as monaco from 'monaco-editor'
-import type { App } from 'vue'
+import type { App, Ref } from 'vue'
 import type { Router } from 'vue-router'
 import type mermaid from 'mermaid'
 import type { KatexOptions } from 'katex'
@@ -40,7 +40,7 @@ export interface NavOperations {
 }
 
 export interface ShortcutOptions {
-  key: string
+  key: string | Ref<boolean>
   fn?: () => void
   autoRepeat?: boolean
 }


### PR DESCRIPTION
Hi, thanks for making Slidev! This was already brought up in #1. But as far as I understand this issue is not resolved yet. The commit https://github.com/slidevjs/slidev/commit/68b5d0658cc4a4cfc174607f700f794676140559 only added the <kbd>shift</kbd><kbd>left</kbd> and the <kbd>shift</kbd><kbd>right</kbd> shortcuts, but didn't implement switching to the previous slide using the proposed <kbd>shift</kbd><kbd>space</kbd> shortcut.

I tried to just add

```js
{ key: 'shift_space', fn: () => prevSlide(false), autoRepeat: true },
```

to

https://github.com/slidevjs/slidev/blob/8cce79a382ab8ad3ca26958ab68b52e07da4b410/packages/client/logic/shortcuts.ts#L43-L51

but this led to the problem that pressing <kbd>shift</kbd><kbd>space</kbd> also triggers the callback for <kbd>space</kbd>. As far as I understand this is somewhat of a limitation of the `useMagicKeys` (see this [minimal reproducer](https://play.vueuse.org/#N4IgDghgxg1hDmBTAziAXAbVAOwgW0XRADcBXRAWgBNE8BLEAGhGQHtSAnKQtEU7MDHhMQNZFA50wAFzqtsRAGrkABABFadFQAoAFhAA2AMxV1sKgGIdE2KLoCUp5CogqaxRAdZgz8FaVkDOmkATxcDLwB3ZxD2FWlWFUjJaUQVAFVsOg8OZEMVZTSAGToAIw4ISRQVI1YOAtUAJhUAMhUAZhFOAyJdaWkwZDQAemH+QXgAOihWPGGyShp6YaDS4bMaAA9JlDxJgCtUAF9GHHweEAABBdJkRGHkfWsqETZObiJxoRExCSlZeREADKT0QVAaiHSd38gWCdBQky6HB6vD6AyGoy+Uxmc2u5Fu90elTBlwArJMAAyTACM62wWx2yD2hxAJzOBCIeMQBOGM2sr3YXAuWJ+KD+MjkCl4AGFWBFEFAAeZWCYUHdsLJ8oUVLK8GBWMg4fIMrDZCgkSiQGjBiMxgIhNNZsMuTy+YgyZSaXSGbsDscALrMIx0AzmtCgACCYDAkwW6FAqT1BggqWBkG4TnCbHikngSGeSV0NhUjzoRmkAH1kOm0nRnGBrMg7lQ0AAdbDtgA8VGyAD4VECaypgMAS0OjkdO8Me8Re12Z-3B9A0iCy9Jh6PS+Wq+PJ9O++3XuLpEQ6Hq6uvRwSALIIOhQADSiBCziONQ4sxUAHIXXdeXVEC-dt2xmbBkEvMdl0YEtdDXHdlxUN8AF5-DuW94HvJ8X20exWWYWU6h7XBUljch4xARMwGTVNeG7bJ2xUGp5GkJDWxAPB5FYNiGJUUp4FYkAgngPoKFJCkKTcSoYDQKgpNE8TuPMGpQ02ASAD8VBmAxFMY1JNhYtjuA1RAOB0lQwAExozNKQiTIEj9+BoKhFLnJTO2rCBzD0gyQAAFk2bSQF7EcVGIQxVAnKcPOwVzGPcyAvMQfSBKZSSOGkoSRIATnEtLpO8aBghCeS2JUPABOkCgrKC692GhELk1KTxEL3aLXKnBcj0kGRT3PDgIJoYNsEQAAFD9BkQ99Py-BYgI7elECG0bxuQbRgB4xrPDQAdpEkbB4EYHiwoMchtoAOVIPAmo4Q7sCOXCJyOIA)). To my understanding <kbd>shift</kbd><kbd>left</kbd> and the <kbd>shift</kbd><kbd>right</kbd> shortcuts have the same problem.

I solved this in this PR by modifying the `shortcut` function and `ShortcutOptions` interface to also accept `Ref<boolean>` and passing `and(space, not(shift))` as key.

Another option would be to change the `useMagicKeys` in VueUse. Maybe this could be solved by adding a `noModifier` option or allow keys like `space~shift`, which would then be translated to `and(space, not(shift))`?