### PR TITLE
feat(v-click): add prior and current class state

### DIFF
--- a/packages/client/modules/directives.ts
+++ b/packages/client/modules/directives.ts
@@ -59,7 +59,7 @@ export default function createDirectives() {
                     index = elements?.value.indexOf(el) || 0
 
                   // If dir hasn't set the value, then the index should be
-                  // click count - 1 in elements
+                  // click count minus 1 in elements
                   if (dir.value === undefined)
                     index = c - 1 >= 0 ? c - 1 : 0
 

--- a/packages/client/modules/directives.ts
+++ b/packages/client/modules/directives.ts
@@ -11,6 +11,7 @@ export const CLASS_VCLICK_HIDDEN = 'slidev-vclick-hidden'
 export const CLASS_VCLICK_GONE = 'slidev-vclick-gone'
 export const CLASS_VCLICK_HIDDEN_EXP = 'slidev-vclick-hidden-explicitly'
 export const CLASS_VCLICK_CURRENT = 'slidev-vclick-current'
+export const CLASS_VCLICK_PRIOR = 'slidev-vclick-prior'
 
 function dirInject<T = unknown>(dir: DirectiveBinding<any>, key: InjectionKey<T> | string, defaultValue?: T): T | undefined {
   return (dir.instance?.$ as any).provides[key as any] ?? defaultValue
@@ -51,17 +52,23 @@ export default function createDirectives() {
                 // reset all element CLASS_VCLICK_CURRENT to false
                 el.classList.toggle(CLASS_VCLICK_CURRENT, false)
                 if (show) {
+                  let index
                   if (dir.value != null && dir.value === c) {
-                    const index = elements?.value.indexOf(el) || 0
-                    const currentEl = elements?.value[index] as HTMLElement
-                    currentEl.classList.toggle(CLASS_VCLICK_CURRENT, true)
+                    index = elements?.value.indexOf(el) || 0
                   }
                   if (dir.value === undefined) {
-                    const index = c - 1 >= 0 ? c - 1 : 0
+                    index = c - 1 >= 0 ? c - 1 : 0
+                  }
+                  if (index != null && index <= prev) {
                     const currentEl = elements?.value[index] as HTMLElement
-                    currentEl ? currentEl.classList.toggle(CLASS_VCLICK_CURRENT, true) : null
+                    
+                    currentEl.classList.toggle(CLASS_VCLICK_PRIOR, false)
+                    currentEl.classList.toggle(CLASS_VCLICK_CURRENT, true)
                   }
                 }
+                
+                if (!el.classList.contains(CLASS_VCLICK_CURRENT))
+                  el.classList.toggle(CLASS_VCLICK_PRIOR, show)
               },
               { immediate: true },
             )

--- a/packages/client/modules/directives.ts
+++ b/packages/client/modules/directives.ts
@@ -59,7 +59,7 @@ export default function createDirectives() {
                   if (dir.value === undefined) {
                     const index = c - 1 >= 0 ? c - 1 : 0
                     const currentEl = elements?.value[index] as HTMLElement
-                    currentEl.classList.toggle(CLASS_VCLICK_CURRENT, true)
+                    currentEl ? currentEl.classList.toggle(CLASS_VCLICK_CURRENT, true) : null
                   }
                 }
               },

--- a/packages/client/modules/directives.ts
+++ b/packages/client/modules/directives.ts
@@ -49,24 +49,30 @@ export default function createDirectives() {
                 if (!el.classList.contains(CLASS_VCLICK_HIDDEN_EXP))
                   el.classList.toggle(CLASS_VCLICK_HIDDEN, !show)
 
-                // reset all element CLASS_VCLICK_CURRENT to false
+                // Reset all elements CLASS_VCLICK_CURRENT to false
                 el.classList.toggle(CLASS_VCLICK_CURRENT, false)
                 if (show) {
                   let index
-                  if (dir.value != null && dir.value === c) {
+                  // If dir has set the value, and dir.value equal click count,
+                  // then set index as current element index in elements
+                  if (dir.value != null && dir.value === c)
                     index = elements?.value.indexOf(el) || 0
-                  }
-                  if (dir.value === undefined) {
+
+                  // If dir hasn't set the value, then the index should be
+                  // click count - 1 in elements
+                  if (dir.value === undefined)
                     index = c - 1 >= 0 ? c - 1 : 0
-                  }
+
                   if (index != null && index <= prev) {
                     const currentEl = elements?.value[index] as HTMLElement
-                    
+
+                    // Remove CLASS_VCLICK_PRIOR and add CLASS_VCLICK_CURRENT
                     currentEl.classList.toggle(CLASS_VCLICK_PRIOR, false)
                     currentEl.classList.toggle(CLASS_VCLICK_CURRENT, true)
                   }
                 }
-                
+
+                // Set CLASS_VCLICK_PRIOR if element not have CLASS_VCLICK_CURRENT
                 if (!el.classList.contains(CLASS_VCLICK_CURRENT))
                   el.classList.toggle(CLASS_VCLICK_PRIOR, show)
               },

--- a/packages/client/modules/directives.ts
+++ b/packages/client/modules/directives.ts
@@ -10,6 +10,7 @@ export const CLASS_VCLICK_TARGET = 'slidev-vclick-target'
 export const CLASS_VCLICK_HIDDEN = 'slidev-vclick-hidden'
 export const CLASS_VCLICK_GONE = 'slidev-vclick-gone'
 export const CLASS_VCLICK_HIDDEN_EXP = 'slidev-vclick-hidden-explicitly'
+export const CLASS_VCLICK_CURRENT = 'slidev-vclick-current'
 
 function dirInject<T = unknown>(dir: DirectiveBinding<any>, key: InjectionKey<T> | string, defaultValue?: T): T | undefined {
   return (dir.instance?.$ as any).provides[key as any] ?? defaultValue
@@ -46,6 +47,21 @@ export default function createDirectives() {
                   : c > prev
                 if (!el.classList.contains(CLASS_VCLICK_HIDDEN_EXP))
                   el.classList.toggle(CLASS_VCLICK_HIDDEN, !show)
+
+                // reset all element CLASS_VCLICK_CURRENT to false
+                el.classList.toggle(CLASS_VCLICK_CURRENT, false)
+                if (show) {
+                  if (dir.value != null && dir.value === c) {
+                    const index = elements?.value.indexOf(el) || 0
+                    const currentEl = elements?.value[index] as HTMLElement
+                    currentEl.classList.toggle(CLASS_VCLICK_CURRENT, true)
+                  }
+                  if (dir.value === undefined) {
+                    const index = c - 1 >= 0 ? c - 1 : 0
+                    const currentEl = elements?.value[index] as HTMLElement
+                    currentEl.classList.toggle(CLASS_VCLICK_CURRENT, true)
+                  }
+                }
               },
               { immediate: true },
             )


### PR DESCRIPTION
Feature design comes from #217 

I know little about vue3, so doesn't implement `before`, `current` etc props which ask in the issue yet.

I have tested 3 possible ways to use it:
1. Just add `v-click`
```html
<div v-click>1</div>

<div v-click>2</div>

<div v-click>3</div>
```

2. Set all `v-click` with order

```html
<div v-click="2">1</div>

<div v-click="1">2</div>

<div v-click="3">3</div>
```

3. Set part of `v-click` with order
```html
<div v-click="2">1</div>

<div v-click="1">2</div>

<div v-click>3</div>
```

You can see more details in `directives.ts`, I write some comments to explain them.

This implement is base on the order deign you have done. 

I think the better way of the user specific order  is maintain a map:
Key is the click order
Value is the element

Then we can easily read `?clicks=x`, the x to find the element in the map and show or hide it. 

Therefore, we need to set a default order value for `v-click` when initialize one element. 

If you like the way I said, I will try to do it. 