### PR TITLE
fix(v-click-hide): the route for v-click-hide

### DIFF
--- a/cypress/fixtures/basic/slides.md
+++ b/cypress/fixtures/basic/slides.md
@@ -110,5 +110,6 @@ Left
 <div class="cy-content-hide">
   <div v-click-hide>A</div>
   <div v-click-hide>B</div>
-  <div v-click-hide>C</div>
+  <div v-click>C</div>
+  <div v-click-hide>D</div>
 </div>

--- a/cypress/fixtures/basic/slides.md
+++ b/cypress/fixtures/basic/slides.md
@@ -102,3 +102,13 @@ Left
   <div v-click.hide="4">D</div>
   <v-click hide><div>E</div></v-click>
 </div>
+
+---
+
+# Page 10
+
+<div class="cy-content-hide">
+  <div v-click-hide>A</div>
+  <div v-click-hide>B</div>
+  <div v-click-hide>C</div>
+</div>

--- a/cypress/integration/examples/basic.spec.ts
+++ b/cypress/integration/examples/basic.spec.ts
@@ -124,5 +124,35 @@ context('Basic', () => {
     cy
       .url()
       .should('eq', 'http://localhost:3030/10')
+    
+    cy.get('body')
+      .type('{RightArrow}')
+
+    cy
+      .url()
+      .should('eq', 'http://localhost:3030/10?clicks=1')
+    
+    cy.get('.cy-content-hide .slidev-vclick-target:not(.slidev-vclick-hidden)')
+      .should('have.text', 'BC')
+    
+    cy.get('body')
+      .type('{RightArrow}')
+    
+    cy.get('.cy-content-hide .slidev-vclick-target:not(.slidev-vclick-hidden)')
+      .should('have.text', 'C')
+    
+    cy.get('body')
+      .type('{RightArrow}')
+    
+    cy
+      .url()
+      .should('eq', 'http://localhost:3030/10?clicks=3')
+    
+    cy.get('body')
+      .type('{RightArrow}')
+
+    cy
+      .url()
+      .should('eq', 'http://localhost:3030/11')
   })
 })

--- a/cypress/integration/examples/basic.spec.ts
+++ b/cypress/integration/examples/basic.spec.ts
@@ -133,20 +133,26 @@ context('Basic', () => {
       .should('eq', 'http://localhost:3030/10?clicks=1')
 
     cy.get('.cy-content-hide .slidev-vclick-target:not(.slidev-vclick-hidden)')
-      .should('have.text', 'BC')
+      .should('have.text', 'BD')
 
     cy.get('body')
       .type('{RightArrow}')
 
     cy.get('.cy-content-hide .slidev-vclick-target:not(.slidev-vclick-hidden)')
-      .should('have.text', 'C')
+      .should('have.text', 'D')
+
+    cy.get('body')
+      .type('{RightArrow}')
+
+    cy.get('.cy-content-hide .slidev-vclick-target:not(.slidev-vclick-hidden)')
+      .should('have.text', 'CD')
 
     cy.get('body')
       .type('{RightArrow}')
 
     cy
       .url()
-      .should('eq', 'http://localhost:3030/10?clicks=3')
+      .should('eq', 'http://localhost:3030/10?clicks=4')
 
     cy.get('body')
       .type('{RightArrow}')

--- a/cypress/integration/examples/basic.spec.ts
+++ b/cypress/integration/examples/basic.spec.ts
@@ -124,30 +124,30 @@ context('Basic', () => {
     cy
       .url()
       .should('eq', 'http://localhost:3030/10')
-    
+
     cy.get('body')
       .type('{RightArrow}')
 
     cy
       .url()
       .should('eq', 'http://localhost:3030/10?clicks=1')
-    
+
     cy.get('.cy-content-hide .slidev-vclick-target:not(.slidev-vclick-hidden)')
       .should('have.text', 'BC')
-    
+
     cy.get('body')
       .type('{RightArrow}')
-    
+
     cy.get('.cy-content-hide .slidev-vclick-target:not(.slidev-vclick-hidden)')
       .should('have.text', 'C')
-    
+
     cy.get('body')
       .type('{RightArrow}')
-    
+
     cy
       .url()
       .should('eq', 'http://localhost:3030/10?clicks=3')
-    
+
     cy.get('body')
       .type('{RightArrow}')
 

--- a/packages/client/modules/directives.ts
+++ b/packages/client/modules/directives.ts
@@ -162,7 +162,13 @@ export default function createDirectives() {
           if ((isPrintMode.value && !isPrintWithClicks.value) || dirInject(dir, injectionClicksDisabled)?.value)
             return
 
+          const elements = dirInject(dir, injectionClicksElements)
           const clicks = dirInject(dir, injectionClicks)
+
+          const prev = elements?.value?.length || 0
+
+          if (elements && !elements?.value?.includes(el))
+            elements.value.push(el)
 
           el?.classList.toggle(CLASS_VCLICK_TARGET, true)
 
@@ -170,7 +176,10 @@ export default function createDirectives() {
             watch(
               clicks,
               () => {
-                const hide = (clicks?.value || 0) > dir.value
+                const c = clicks?.value ?? 0
+                const hide = dir.value != null
+                  ? c >= dir.value
+                  : c > prev
                 el.classList.toggle(CLASS_VCLICK_HIDDEN, hide)
                 el.classList.toggle(CLASS_VCLICK_HIDDEN_EXP, hide)
               },


### PR DESCRIPTION
`v-click-hide` route not work, because `elements` has nothig.

Fix it as how `v-click` work.

Fix #323.