### PR TITLE
feat(v-click): use order map to order v-click

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,3 +1,4 @@
 {
-  "baseUrl": "http://localhost:3030"
+  "baseUrl": "http://localhost:3030",
+  "chromeWebSecurity": false
 }

--- a/cypress/fixtures/basic/slides.md
+++ b/cypress/fixtures/basic/slides.md
@@ -90,3 +90,14 @@ layout: two-cols
 # Left
 
 Left
+
+---
+
+# Page 9
+
+<div class="cy-content">
+  <div v-click="3">A</div>
+  <div v-click="2">B</div>
+  <div v-click="1">C</div>
+  <div v-click.hide="4">D</div>
+</div>

--- a/cypress/fixtures/basic/slides.md
+++ b/cypress/fixtures/basic/slides.md
@@ -100,4 +100,5 @@ Left
   <div v-click="2">B</div>
   <div v-click="1">C</div>
   <div v-click.hide="4">D</div>
+  <v-click hide><div>E</div></v-click>
 </div>

--- a/cypress/integration/examples/basic.spec.ts
+++ b/cypress/integration/examples/basic.spec.ts
@@ -39,6 +39,10 @@ context('Basic', () => {
       .should('have.text', '<div>{{$slidev.nav.currentPage}}</div>')
       .get('#page-root > #slide-container > #slide-content > .slidev-page-5 > p')
       .should('have.text', 'Current Page: 5')
+  })
+
+  it('should nav correctly', () => {
+    goPage(5)
 
     cy.get('body')
       .type('{DownArrow}')
@@ -69,10 +73,55 @@ context('Basic', () => {
       .type('{UpArrow}')
       .url()
       .should('eq', 'http://localhost:3030/6')
+  })
 
+  it('named slots', () => {
     goPage(8)
 
     cy.get('.col-right')
       .contains('Right')
+  })
+
+  it('clicks map', () => {
+    goPage(9)
+
+    cy
+      .url()
+      .should('eq', 'http://localhost:3030/9')
+
+    cy.get('body')
+      .type('{RightArrow}')
+
+    cy
+      .url()
+      .should('eq', 'http://localhost:3030/9?clicks=1')
+
+    cy.get('.cy-content .slidev-vclick-target:not(.slidev-vclick-hidden)')
+      .should('have.text', 'CD')
+
+    cy.get('body')
+      .type('{RightArrow}')
+      .type('{RightArrow}')
+
+    cy.get('.cy-content .slidev-vclick-target:not(.slidev-vclick-hidden)')
+      .should('have.text', 'ABCD')
+
+    // v-click.hide
+    cy.get('body')
+      .type('{RightArrow}')
+
+    cy.get('.cy-content .slidev-vclick-target:not(.slidev-vclick-hidden)')
+      .should('have.text', 'ABC')
+
+    cy
+      .url()
+      .should('eq', 'http://localhost:3030/9?clicks=4')
+
+    cy.get('body')
+      .type('{RightArrow}')
+
+    cy
+      .url()
+      .should('eq', 'http://localhost:3030/10')
   })
 })

--- a/cypress/integration/examples/basic.spec.ts
+++ b/cypress/integration/examples/basic.spec.ts
@@ -97,17 +97,18 @@ context('Basic', () => {
       .should('eq', 'http://localhost:3030/9?clicks=1')
 
     cy.get('.cy-content .slidev-vclick-target:not(.slidev-vclick-hidden)')
-      .should('have.text', 'CD')
+      .should('have.text', 'CDE')
 
     cy.get('body')
       .type('{RightArrow}')
       .type('{RightArrow}')
 
     cy.get('.cy-content .slidev-vclick-target:not(.slidev-vclick-hidden)')
-      .should('have.text', 'ABCD')
+      .should('have.text', 'ABCDE')
 
     // v-click.hide
     cy.get('body')
+      .type('{RightArrow}')
       .type('{RightArrow}')
 
     cy.get('.cy-content .slidev-vclick-target:not(.slidev-vclick-hidden)')
@@ -115,7 +116,7 @@ context('Basic', () => {
 
     cy
       .url()
-      .should('eq', 'http://localhost:3030/9?clicks=4')
+      .should('eq', 'http://localhost:3030/9?clicks=5')
 
     cy.get('body')
       .type('{RightArrow}')

--- a/packages/client/builtin/VClick.ts
+++ b/packages/client/builtin/VClick.ts
@@ -15,7 +15,7 @@ export default defineComponent({
     },
     hide: {
       type: Boolean,
-      default: null,
+      default: false,
     },
   },
   render() {

--- a/packages/client/builtin/VClick.ts
+++ b/packages/client/builtin/VClick.ts
@@ -13,8 +13,12 @@ export default defineComponent({
       type: [Number, String],
       default: null,
     },
+    hide: {
+      type: Boolean,
+      default: null,
+    },
   },
   render() {
-    return createVNode(VClicks, { every: 99999, at: this.at }, { default: this.$slots.default })
+    return createVNode(VClicks, { every: 99999, at: this.at, hide: this.hide }, { default: this.$slots.default })
   },
 })

--- a/packages/client/builtin/VClicks.ts
+++ b/packages/client/builtin/VClicks.ts
@@ -17,6 +17,10 @@ export default defineComponent({
       type: [Number, String],
       default: null,
     },
+    hide: {
+      type: Boolean,
+      default: null,
+    },
   },
   render() {
     const click = resolveDirective('click')!
@@ -24,8 +28,8 @@ export default defineComponent({
 
     const applyDirective = (node: VNode, directive: Directive, delta: number) => {
       if (this.at != null)
-        return withDirectives(node, [[directive, +this.at + delta]])
-      return withDirectives(node, [[directive]])
+        return withDirectives(node, [[directive, +this.at + delta, '', { hide: this.hide }]])
+      return withDirectives(node, [[directive, undefined, '', { hide: this.hide }]])
     }
 
     let defaults = this.$slots.default?.()

--- a/packages/client/builtin/VClicks.ts
+++ b/packages/client/builtin/VClicks.ts
@@ -29,7 +29,7 @@ export default defineComponent({
     const applyDirective = (node: VNode, directive: Directive, delta: number) => {
       if (this.at != null)
         return withDirectives(node, [[directive, +this.at + delta, '', { hide: this.hide }]])
-      return withDirectives(node, [[directive, undefined, '', { hide: this.hide }]])
+      return withDirectives(node, [[directive, null, '', { hide: this.hide }]])
     }
 
     let defaults = this.$slots.default?.()

--- a/packages/client/internals/SlideWrapper.ts
+++ b/packages/client/internals/SlideWrapper.ts
@@ -1,6 +1,6 @@
 import { useVModel } from '@vueuse/core'
 import { provide, defineComponent, h } from 'vue'
-import { injectionClicks, injectionClicksDisabled, injectionClicksElements } from '../modules/directives'
+import { injectionClicks, injectionClicksDisabled, injectionClicksElements, injectionOrderMap } from '../modules/directives'
 
 export default defineComponent({
   props: {
@@ -11,6 +11,10 @@ export default defineComponent({
     clicksElements: {
       type: Array,
       default: () => [] as Element[],
+    },
+    clicksOrderMap: {
+      type: Map,
+      default: () => new Map<number, HTMLElement[]>(),
     },
     clicksDisabled: {
       type: Boolean,
@@ -25,12 +29,14 @@ export default defineComponent({
     const clicks = useVModel(props, 'clicks', emit)
     const clicksElements = useVModel(props, 'clicksElements', emit)
     const clicksDisabled = useVModel(props, 'clicksDisabled', emit)
+    const clickOrderMap = useVModel(props, 'clicksOrderMap', emit)
 
     clicksElements.value.length = 0
 
     provide(injectionClicks, clicks)
     provide(injectionClicksDisabled, clicksDisabled)
     provide(injectionClicksElements, clicksElements)
+    provide(injectionOrderMap, clickOrderMap)
   },
   render() {
     if (this.$props.is)

--- a/packages/client/internals/SlideWrapper.ts
+++ b/packages/client/internals/SlideWrapper.ts
@@ -29,14 +29,14 @@ export default defineComponent({
     const clicks = useVModel(props, 'clicks', emit)
     const clicksElements = useVModel(props, 'clicksElements', emit)
     const clicksDisabled = useVModel(props, 'clicksDisabled', emit)
-    const clickOrderMap = useVModel(props, 'clicksOrderMap', emit)
+    const clicksOrderMap = useVModel(props, 'clicksOrderMap', emit)
 
     clicksElements.value.length = 0
 
     provide(injectionClicks, clicks)
     provide(injectionClicksDisabled, clicksDisabled)
     provide(injectionClicksElements, clicksElements)
-    provide(injectionOrderMap, clickOrderMap)
+    provide(injectionOrderMap, clicksOrderMap)
   },
   render() {
     if (this.$props.is)

--- a/packages/client/modules/directives.ts
+++ b/packages/client/modules/directives.ts
@@ -44,9 +44,9 @@ export default function createDirectives() {
           if (dir.value === null)
             dir.value = elements?.value.length
 
-          // If orderMap didn't have dir.value, then initializ it.
-          // Or we move current element to the first of order array
-          // to make sure the after click current state.
+          // If orderMap didn't have dir.value aka the order key, then initializ it.
+          // If key exists, then move current element to the first of order array to
+          // make sure the v-after set correct CLASS_VCLICK_CURRENT state.
           if (!orderMap?.value.has(dir.value)) {
             orderMap?.value.set(dir.value, [el])
           }
@@ -73,15 +73,15 @@ export default function createDirectives() {
                 if (hide)
                   el.classList.toggle(CLASS_VCLICK_HIDDEN, show)
 
-                // Reset CLASS_VCLICK_CURRENT to false
+                // Reset CLASS_VCLICK_CURRENT to false.
                 el.classList.toggle(CLASS_VCLICK_CURRENT, false)
 
                 const currentElArray = orderMap?.value.get(c)
                 currentElArray?.forEach((cEl, idx) => {
                   // Reset CLASS_VCLICK_PRIOR to false
                   cEl.classList.toggle(CLASS_VCLICK_PRIOR, false)
-                  // If the element is the last of order array, then set it
-                  // as CLASS_VCLICK_CURRENT, others set as CLASS_VCLICK_PRIOR
+                  // If the element is the last of order array, then set it as
+                  // CLASS_VCLICK_CURRENT state, others set as CLASS_VCLICK_PRIOR state.
                   if (idx === currentElArray.length - 1)
                     cEl.classList.toggle(CLASS_VCLICK_CURRENT, true)
                   else
@@ -121,9 +121,9 @@ export default function createDirectives() {
           if (dir.value === undefined)
             dir.value = elements?.value.length
 
-          // If click's order before after is bigger than after, the order map will not
-          // contain the key of after, so we need to set it first, the move after element
-          // to last of the order array
+          // If a v-click order before v-after is lower than v-after, the order map will
+          // not contain the key for v-after, so we need to set it first, then move v-after
+          // to the last of order array.
           if (orderMap?.value.has(dir.value))
             orderMap?.value.get(dir.value)?.push(el)
           else
@@ -139,7 +139,7 @@ export default function createDirectives() {
                 if (!el.classList.contains(CLASS_VCLICK_HIDDEN_EXP))
                   el.classList.toggle(CLASS_VCLICK_HIDDEN, !show)
 
-                // Reset CLASS_VCLICK_CURRENT to false
+                // Reset CLASS_VCLICK_CURRENT to false.
                 el.classList.toggle(CLASS_VCLICK_CURRENT, false)
 
                 if (!el.classList.contains(CLASS_VCLICK_CURRENT))

--- a/packages/client/modules/directives.ts
+++ b/packages/client/modules/directives.ts
@@ -162,13 +162,7 @@ export default function createDirectives() {
           if ((isPrintMode.value && !isPrintWithClicks.value) || dirInject(dir, injectionClicksDisabled)?.value)
             return
 
-          const elements = dirInject(dir, injectionClicksElements)
           const clicks = dirInject(dir, injectionClicks)
-
-          const prev = elements?.value?.length || 0
-
-          if (elements && !elements?.value?.includes(el))
-            elements.value.push(el)
 
           el?.classList.toggle(CLASS_VCLICK_TARGET, true)
 
@@ -176,11 +170,7 @@ export default function createDirectives() {
             watch(
               clicks,
               () => {
-                const c = clicks?.value ?? 0
-                const hide = dir.value != null
-                  ? c >= dir.value
-                  : c > prev
-
+                const hide = (clicks?.value || 0) > dir.value
                 el.classList.toggle(CLASS_VCLICK_HIDDEN, hide)
                 el.classList.toggle(CLASS_VCLICK_HIDDEN_EXP, hide)
               },

--- a/packages/client/modules/directives.ts
+++ b/packages/client/modules/directives.ts
@@ -10,10 +10,14 @@ export const CLASS_VCLICK_TARGET = 'slidev-vclick-target'
 export const CLASS_VCLICK_HIDDEN = 'slidev-vclick-hidden'
 export const CLASS_VCLICK_GONE = 'slidev-vclick-gone'
 export const CLASS_VCLICK_HIDDEN_EXP = 'slidev-vclick-hidden-explicitly'
+export const CLASS_VCLICK_CURRENT = 'slidev-vclick-current'
+export const CLASS_VCLICK_PRIOR = 'slidev-vclick-prior'
 
 function dirInject<T = unknown>(dir: DirectiveBinding<any>, key: InjectionKey<T> | string, defaultValue?: T): T | undefined {
   return (dir.instance?.$ as any).provides[key as any] ?? defaultValue
 }
+
+const orderMap = new Map<number, HTMLElement[]>()
 
 export default function createDirectives() {
   return {
@@ -34,6 +38,23 @@ export default function createDirectives() {
           if (elements && !elements?.value?.includes(el))
             elements.value.push(el)
 
+          // Set default dir.value
+          if (dir.value === undefined)
+            dir.value = elements?.value.length
+
+          // If orderMap didn't have dir.value, then initializ it.
+          // Or we move current element to the first of order array
+          // to make sure the after click current state.
+          if (!orderMap.has(dir.value)) {
+            orderMap.set(dir.value, [el])
+          }
+          else {
+            if (!orderMap.get(dir.value)?.includes(el)) {
+              const afterClicks = orderMap.get(dir.value) || []
+              orderMap.set(dir.value, [el].concat(afterClicks))
+            }
+          }
+
           el?.classList.toggle(CLASS_VCLICK_TARGET, true)
 
           if (clicks) {
@@ -46,6 +67,24 @@ export default function createDirectives() {
                   : c > prev
                 if (!el.classList.contains(CLASS_VCLICK_HIDDEN_EXP))
                   el.classList.toggle(CLASS_VCLICK_HIDDEN, !show)
+
+                // Reset CLASS_VCLICK_CURRENT to false
+                el.classList.toggle(CLASS_VCLICK_CURRENT, false)
+
+                const currentElArray = orderMap.get(c)
+                currentElArray?.forEach((cEl, idx) => {
+                  // Reset CLASS_VCLICK_PRIOR to false
+                  cEl.classList.toggle(CLASS_VCLICK_PRIOR, false)
+                  // If the element is the last of order array, then set it
+                  // as CLASS_VCLICK_CURRENT, others set as CLASS_VCLICK_PRIOR
+                  if (idx === currentElArray.length - 1)
+                    cEl.classList.toggle(CLASS_VCLICK_CURRENT, true)
+                  else
+                    cEl.classList.toggle(CLASS_VCLICK_PRIOR, true)
+                })
+
+                if (!el.classList.contains(CLASS_VCLICK_CURRENT))
+                  el.classList.toggle(CLASS_VCLICK_PRIOR, show)
               },
               { immediate: true },
             )
@@ -72,6 +111,18 @@ export default function createDirectives() {
 
           const prev = elements?.value.length
 
+          // Set default dir.value
+          if (dir.value === undefined)
+            dir.value = elements?.value.length
+
+          // If click's order before after is bigger than after, the order map will not
+          // contain the key of after, so we need to set it first, the move after element
+          // to last of the order array
+          if (orderMap.has(dir.value))
+            orderMap.get(dir.value)?.push(el)
+          else
+            orderMap.set(dir.value, [el])
+
           el?.classList.toggle(CLASS_VCLICK_TARGET, true)
 
           if (clicks) {
@@ -81,6 +132,12 @@ export default function createDirectives() {
                 const show = (clicks.value ?? 0) >= (dir.value ?? prev ?? 0)
                 if (!el.classList.contains(CLASS_VCLICK_HIDDEN_EXP))
                   el.classList.toggle(CLASS_VCLICK_HIDDEN, !show)
+
+                // Reset CLASS_VCLICK_CURRENT to false
+                el.classList.toggle(CLASS_VCLICK_CURRENT, false)
+
+                if (!el.classList.contains(CLASS_VCLICK_CURRENT))
+                  el.classList.toggle(CLASS_VCLICK_PRIOR, show)
               },
               { immediate: true },
             )

--- a/packages/client/modules/directives.ts
+++ b/packages/client/modules/directives.ts
@@ -33,6 +33,8 @@ export default function createDirectives() {
           const clicks = dirInject(dir, injectionClicks)
           const orderMap = dirInject(dir, injectionOrderMap)
 
+          const hide = dir.modifiers.hide
+
           const prev = elements?.value?.length || 0
 
           if (elements && !elements?.value?.includes(el))
@@ -67,6 +69,9 @@ export default function createDirectives() {
                   : c > prev
                 if (!el.classList.contains(CLASS_VCLICK_HIDDEN_EXP))
                   el.classList.toggle(CLASS_VCLICK_HIDDEN, !show)
+
+                if (hide)
+                  el.classList.toggle(CLASS_VCLICK_HIDDEN, show)
 
                 // Reset CLASS_VCLICK_CURRENT to false
                 el.classList.toggle(CLASS_VCLICK_CURRENT, false)
@@ -157,7 +162,13 @@ export default function createDirectives() {
           if ((isPrintMode.value && !isPrintWithClicks.value) || dirInject(dir, injectionClicksDisabled)?.value)
             return
 
+          const elements = dirInject(dir, injectionClicksElements)
           const clicks = dirInject(dir, injectionClicks)
+
+          const prev = elements?.value?.length || 0
+
+          if (elements && !elements?.value?.includes(el))
+            elements.value.push(el)
 
           el?.classList.toggle(CLASS_VCLICK_TARGET, true)
 
@@ -165,7 +176,11 @@ export default function createDirectives() {
             watch(
               clicks,
               () => {
-                const hide = (clicks?.value || 0) > dir.value
+                const c = clicks?.value ?? 0
+                const hide = dir.value != null
+                  ? c >= dir.value
+                  : c > prev
+
                 el.classList.toggle(CLASS_VCLICK_HIDDEN, hide)
                 el.classList.toggle(CLASS_VCLICK_HIDDEN_EXP, hide)
               },

--- a/packages/client/modules/directives.ts
+++ b/packages/client/modules/directives.ts
@@ -41,7 +41,7 @@ export default function createDirectives() {
             elements.value.push(el)
 
           // Set default dir.value
-          if (dir.value === undefined)
+          if (dir.value === null)
             dir.value = elements?.value.length
 
           // If orderMap didn't have dir.value, then initializ it.

--- a/packages/client/modules/directives.ts
+++ b/packages/client/modules/directives.ts
@@ -70,7 +70,7 @@ export default function createDirectives() {
                 if (!el.classList.contains(CLASS_VCLICK_HIDDEN_EXP))
                   el.classList.toggle(CLASS_VCLICK_HIDDEN, !show)
 
-                if (hide)
+                if (hide !== false && hide !== undefined)
                   el.classList.toggle(CLASS_VCLICK_HIDDEN, show)
 
                 // Reset CLASS_VCLICK_CURRENT to false.

--- a/packages/client/modules/directives.ts
+++ b/packages/client/modules/directives.ts
@@ -44,7 +44,7 @@ export default function createDirectives() {
           if (dir.value === null)
             dir.value = elements?.value.length
 
-          // If orderMap didn't have dir.value aka the order key, then initializ it.
+          // If orderMap didn't have dir.value aka the order key, then initialize it.
           // If key exists, then move current element to the first of order array to
           // make sure the v-after set correct CLASS_VCLICK_CURRENT state.
           if (!orderMap?.value.has(dir.value)) {

--- a/packages/client/modules/directives.ts
+++ b/packages/client/modules/directives.ts
@@ -4,6 +4,7 @@ import { isPrintMode, isPrintWithClicks } from '../logic/nav'
 
 export const injectionClicks: InjectionKey<Ref<number>> = Symbol('v-click-clicks')
 export const injectionClicksElements: InjectionKey<Ref<(Element | string)[]>> = Symbol('v-click-clicks-elements')
+export const injectionOrderMap: InjectionKey<Ref<Map<number, HTMLElement[]>>> = Symbol('v-click-clicks-order-map')
 export const injectionClicksDisabled: InjectionKey<Ref<boolean>> = Symbol('v-click-clicks-disabled')
 
 export const CLASS_VCLICK_TARGET = 'slidev-vclick-target'
@@ -16,8 +17,6 @@ export const CLASS_VCLICK_PRIOR = 'slidev-vclick-prior'
 function dirInject<T = unknown>(dir: DirectiveBinding<any>, key: InjectionKey<T> | string, defaultValue?: T): T | undefined {
   return (dir.instance?.$ as any).provides[key as any] ?? defaultValue
 }
-
-const orderMap = new Map<number, HTMLElement[]>()
 
 export default function createDirectives() {
   return {
@@ -32,6 +31,7 @@ export default function createDirectives() {
 
           const elements = dirInject(dir, injectionClicksElements)
           const clicks = dirInject(dir, injectionClicks)
+          const orderMap = dirInject(dir, injectionOrderMap)
 
           const prev = elements?.value?.length || 0
 
@@ -45,13 +45,13 @@ export default function createDirectives() {
           // If orderMap didn't have dir.value, then initializ it.
           // Or we move current element to the first of order array
           // to make sure the after click current state.
-          if (!orderMap.has(dir.value)) {
-            orderMap.set(dir.value, [el])
+          if (!orderMap?.value.has(dir.value)) {
+            orderMap?.value.set(dir.value, [el])
           }
           else {
-            if (!orderMap.get(dir.value)?.includes(el)) {
-              const afterClicks = orderMap.get(dir.value) || []
-              orderMap.set(dir.value, [el].concat(afterClicks))
+            if (!orderMap?.value.get(dir.value)?.includes(el)) {
+              const afterClicks = orderMap?.value.get(dir.value) || []
+              orderMap?.value.set(dir.value, [el].concat(afterClicks))
             }
           }
 
@@ -71,7 +71,7 @@ export default function createDirectives() {
                 // Reset CLASS_VCLICK_CURRENT to false
                 el.classList.toggle(CLASS_VCLICK_CURRENT, false)
 
-                const currentElArray = orderMap.get(c)
+                const currentElArray = orderMap?.value.get(c)
                 currentElArray?.forEach((cEl, idx) => {
                   // Reset CLASS_VCLICK_PRIOR to false
                   cEl.classList.toggle(CLASS_VCLICK_PRIOR, false)
@@ -108,6 +108,7 @@ export default function createDirectives() {
 
           const elements = dirInject(dir, injectionClicksElements)
           const clicks = dirInject(dir, injectionClicks)
+          const orderMap = dirInject(dir, injectionOrderMap)
 
           const prev = elements?.value.length
 
@@ -118,10 +119,10 @@ export default function createDirectives() {
           // If click's order before after is bigger than after, the order map will not
           // contain the key of after, so we need to set it first, the move after element
           // to last of the order array
-          if (orderMap.has(dir.value))
-            orderMap.get(dir.value)?.push(el)
+          if (orderMap?.value.has(dir.value))
+            orderMap?.value.get(dir.value)?.push(el)
           else
-            orderMap.set(dir.value, [el])
+            orderMap?.value.set(dir.value, [el])
 
           el?.classList.toggle(CLASS_VCLICK_TARGET, true)
 


### PR DESCRIPTION
As I said in #272 .

I add a order map to record `v-click` order.

`orderMap` struct is:

```ts
orderMap: Map<number, HTMLElement[]>
```

Key is order `number`
Value is `HTMLElement` array

For `v-click` which not set their order, they will set their order as their index in `elements`.

The reason for using array as map value is for `v-after`.

When initialize one `v-after` element, it will push itself to the last of array.

Then, we can set the last item of array to `current` state, the others items to `prior` state.

This implement is better than the #271, it looks more elegant.

For simplfy `v-click-hide`, I add `hide` prop for `<v-click />`.

And I think it will be better the `v-click-hide` just call some thing like `<v-click hide />`, but don't know how to implement it.

Still, the state design comes from #217