### PR TITLE
docs: configure automated development environments

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,22 @@
+# List the start up tasks. Learn more https://www.gitpod.io/docs/config-start-tasks/
+tasks:
+  - before: npm i -g pnpm
+    init: |
+      pnpm install
+      pnpm build
+    command: pnpm demo:dev
+
+# List the ports to expose. Learn more https://www.gitpod.io/docs/config-ports/
+ports:
+  - port: 3030
+    onOpen: open-preview
+
+# List the VS Code extensions to install. Learn more https://www.gitpod.io/docs/vscode-extensions/
+vscode:
+  extensions:
+    - "antfu.vite"
+    - "johnsoncodehk.volar"
+    - "antfu.iconify"
+    - "dbaeumer.vscode-eslint"
+    - "voorjaar.windicss-intellisense"
+    - "csstools.postcss"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,13 @@ Excited to hear that you are interested in contributing to this project! Thanks!
 
 Documentations are now moved to [`slidevjs/docs`](https://github.com/slidevjs/docs) repo.
 
-## Setup
+## Setup (in your browser)
+
+You can contribute through a development environment in your browser by clicking the following button:
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/slidevjs/slidev)
+
+## Setup (locally)
 
 This project uses [`pnpm`](https://pnpm.io/) to manage the dependencies, install it if you haven't via
 


### PR DESCRIPTION
## Overview

This PR introduces a `.gitpod.yml` configuration file to enable ephemeral, browser-based development environments based on www.gitpod.io. It automates the [CONTRIBUTING.md](CONTRIBUTING.md) instructions and starts Slidev automatically with `pnpm demo:dev`

## Testing

Until this PR is merged, please use the following button to test what the development environment experience will be like:

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/mikenikles/slidev/tree/configure-automated-dev-environments)

The above button uses my own branch which has Gitpod Prebuilds configured. See the next session on how to enable that for `slidevjs/slidev` and why it is beneficial.

## Future Work

In order to get the best experience, the `slidevjs/slidev` repository will have to [enable Gitpod Prebuilds](https://www.gitpod.io/docs/prebuilds/#on-github) so that the development environment gets built every time there is a new commit pushed to the repository. With that enabled, anyone who starts a new development environment in their browser does not have to wait for any installation and build tasks to complete since they happened as part of a prebuild phase.
