### PR TITLE
fix: add content-type for html files on dev server

### DIFF
--- a/packages/slidev/node/plugins/config.ts
+++ b/packages/slidev/node/plugins/config.ts
@@ -68,6 +68,7 @@ export function createConfigPlugin(options: ResolvedSlidevOptions): Plugin {
       return () => {
         server.middlewares.use(async(req, res, next) => {
           if (req.url!.endsWith('.html')) {
+            res.setHeader('Content-Type', 'text/html')
             res.statusCode = 200
             res.end(await getIndexHtml(options))
             return


### PR DESCRIPTION
Missing Content-Type (`text/html`) will cause DevServer not works with domains, likes using public port forwardings on [GitHub Codespaces](https://github.com/features/codespaces).

![image](https://user-images.githubusercontent.com/2399123/127616911-33158ace-f189-45c5-a3c3-0c3b9c5cdc24.png)
