### PR TITLE
chore: fix typo in CLI help options

### DIFF
--- a/packages/slidev/node/cli.ts
+++ b/packages/slidev/node/cli.ts
@@ -365,7 +365,7 @@ function commonOptions(args: Argv<{}>) {
     .option('theme', {
       alias: 't',
       type: 'string',
-      describe: 'overide theme',
+      describe: 'override theme',
     })
 }
 


### PR DESCRIPTION
Discovered this typo while looking at arg formatting help, this PR fixes the typo in "overide" => "override"