### PR TITLE
fix: catch cli open shortcut errors

### DIFF
--- a/packages/slidev/node/cli.ts
+++ b/packages/slidev/node/cli.ts
@@ -158,7 +158,7 @@ cli.command(
             sh.action()
           }
           catch (err) {
-            console.error(`error occurred while executing shortcut ${sh.fullname}: ${err}`)
+            console.error(`Failed to execute shortcut ${sh.fullname}`, err)
           }
         }
       })

--- a/packages/slidev/node/cli.ts
+++ b/packages/slidev/node/cli.ts
@@ -126,18 +126,21 @@ cli.command(
     const SHORTCUTS = [
       {
         name: 'r',
+        fullname: 'restart',
         action() {
           initServer()
         },
       },
       {
         name: 'o',
+        fullname: 'open',
         action() {
           openBrowser(`http://localhost:${port}`)
         },
       },
       {
         name: 'e',
+        fullname: 'edit',
         action() {
           exec(`code "${entry}"`)
         },
@@ -149,9 +152,15 @@ cli.command(
       process.stdin.setEncoding('utf8')
       process.stdin.on('data', (data) => {
         const str = data.toString().trim().toLowerCase()
-        const sh = SHORTCUTS.filter(item => item.name === str)[0]
-        if (sh)
-          sh.action()
+        const [sh] = SHORTCUTS.filter(item => item.name === str)
+        if (sh) {
+          try {
+            sh.action()
+          }
+          catch (err) {
+            console.error(`error occurred while executing shortcut ${sh.fullname}: ${err}`)
+          }
+        }
       })
     }
 


### PR DESCRIPTION
Sometimes, the `slidev --open` shortcut command fails (such as browser not exist), and it causes the entire development server to fail.
I'm trying to add a catch statement to suppress this situation