### PR TITLE
chore: typo

### DIFF
--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -73,7 +73,7 @@ export interface SlidevConfig {
    */
   aspectRatio: number
   /**
-   * The actual width fro slides canvas.
+   * The actual width for slides canvas.
    * unit in px.
    *
    * @default '980'


### PR DESCRIPTION
`fro` to `for`