### PR TITLE
feat: perform terminal shortcuts on keypress

### DIFF
--- a/packages/slidev/node/cli.ts
+++ b/packages/slidev/node/cli.ts
@@ -3,6 +3,7 @@ import path from 'path'
 import net from 'net'
 import os from 'os'
 import { exec } from 'child_process'
+import * as readline from 'readline'
 import fs from 'fs-extra'
 import openBrowser from 'open'
 import yargs, { Argv } from 'yargs'
@@ -150,15 +151,23 @@ cli.command(
     function bindShortcut() {
       process.stdin.resume()
       process.stdin.setEncoding('utf8')
-      process.stdin.on('data', (data) => {
-        const str = data.toString().trim().toLowerCase()
-        const [sh] = SHORTCUTS.filter(item => item.name === str)
-        if (sh) {
-          try {
-            sh.action()
-          }
-          catch (err) {
-            console.error(`Failed to execute shortcut ${sh.fullname}`, err)
+      readline.emitKeypressEvents(process.stdin)
+      if (process.stdin.isTTY)
+        process.stdin.setRawMode(true)
+
+      process.stdin.on('keypress', (str, key) => {
+        if (key.ctrl && key.name === 'c') {
+          process.exit()
+        }
+        else {
+          const [sh] = SHORTCUTS.filter(item => item.name === str)
+          if (sh) {
+            try {
+              sh.action()
+            }
+            catch (err) {
+              console.error(`Failed to execute shortcut ${sh.fullname}`, err)
+            }
           }
         }
       })


### PR DESCRIPTION
### Why?
Right now we need to press `r/o/e` and then press enter to perform the shortcut. It should be better to just perform the shortcut on keypress event

PS: While running dev server, we still need to press enter every time, since nodemon is also waiting for keys to be pressed (i.e. "rs" to restart server), we're running into a conflict because nodemon has commandeered process.stdin.