### PR TITLE
feat(shortcuts): expose toggleDrawing in NavOperations

### DIFF
--- a/packages/client/setup/shortcuts.ts
+++ b/packages/client/setup/shortcuts.ts
@@ -4,6 +4,7 @@ import { ShortcutOptions, NavOperations } from '@slidev/types'
 import { next, prev, nextSlide, prevSlide, downloadPDF } from '../logic/nav'
 import { toggleDark } from '../logic/dark'
 import { toggleOverview, showGotoDialog, showOverview } from '../state'
+import { drawingEnabled } from '../logic/drawings'
 
 export default function setupShortcuts() {
   // @ts-expect-error
@@ -16,6 +17,7 @@ export default function setupShortcuts() {
     downloadPDF,
     toggleDark,
     toggleOverview,
+    toggleDrawing: () => drawingEnabled.value = !drawingEnabled.value,
     escapeOverview: () => showOverview.value = false,
     showGotoDialog: () => showGotoDialog.value = !showGotoDialog.value,
   }

--- a/packages/types/src/setups.ts
+++ b/packages/types/src/setups.ts
@@ -42,6 +42,7 @@ export interface NavOperations {
   downloadPDF: () => Promise<void>
   toggleDark: () => void
   toggleOverview: () => void
+  toggleDrawing: () => void
   escapeOverview: () => void
   showGotoDialog: () => void
 }


### PR DESCRIPTION
Hi, 

I needed to create a shortcut to toggle drawings but current API didn't expose it. 
So in this PR i  exposed it through the NavOperations object. 

The changes seem fine to me, but i couldn't figure out how to test it locally. So if someone knows how to do that, please test this before merging the PR. 

Thanks ! 