### PR TITLE
fix: resolve global import

### DIFF
--- a/packages/slidev/node/plugins/extendConfig.ts
+++ b/packages/slidev/node/plugins/extendConfig.ts
@@ -1,12 +1,11 @@
 import { dirname, join } from 'path'
 import { InlineConfig, mergeConfig, Plugin } from 'vite'
 import isInstalledGlobally from 'is-installed-globally'
-import resolveGlobal from 'resolve-global'
 import { uniq } from '@antfu/utils'
 import { getIndexHtml } from '../common'
 import { dependencies } from '../../../client/package.json'
 import { ResolvedSlidevOptions } from '../options'
-import { resolveImportPath, toAtFS } from '../utils'
+import { resolveImportPath, resolveGlobalImportPath, toAtFS } from '../utils'
 import { searchForWorkspaceRoot } from '../vite/searchRoot'
 
 const EXCLUDE = [
@@ -55,7 +54,7 @@ export function createConfigPlugin(options: ResolvedSlidevOptions): Plugin {
               searchForWorkspaceRoot(options.cliRoot),
               ...(
                 isInstalledGlobally
-                  ? [dirname(resolveGlobal('@slidev/client/package.json')), dirname(resolveGlobal('katex/package.json'))]
+                  ? [dirname(resolveGlobalImportPath('@slidev/client/package.json')), dirname(resolveGlobalImportPath('katex/package.json'))]
                   : []
               ),
             ]),

--- a/packages/slidev/node/utils.ts
+++ b/packages/slidev/node/utils.ts
@@ -1,7 +1,8 @@
+import { join } from 'path'
 import { ensurePrefix, slash } from '@antfu/utils'
 import isInstalledGlobally from 'is-installed-globally'
 import { sync as resolve } from 'resolve'
-import resolveGlobal from 'resolve-global'
+import globalDirs from 'global-dirs'
 import type Token from 'markdown-it/lib/token'
 import { ResolvedFontOptions } from '@slidev/types'
 
@@ -21,7 +22,12 @@ export function resolveImportPath(importName: string, ensure = false) {
 
   if (isInstalledGlobally) {
     try {
-      return resolveGlobal(importName)
+      return require.resolve(join(globalDirs.yarn.packages, importName))
+    }
+    catch {}
+
+    try {
+      return require.resolve(join(globalDirs.npm.packages, importName))
     }
     catch {}
   }
@@ -30,6 +36,25 @@ export function resolveImportPath(importName: string, ensure = false) {
     throw new Error(`Failed to resolve package "${importName}"`)
 
   return undefined
+}
+
+export function resolveGlobalImportPath(importName: string): string {
+  try {
+    return resolve(importName, { preserveSymlinks: false, basedir: __dirname })
+  }
+  catch {}
+
+  try {
+    return require.resolve(join(globalDirs.yarn.packages, importName))
+  }
+  catch {}
+
+  try {
+    return require.resolve(join(globalDirs.npm.packages, importName))
+  }
+  catch {}
+
+  throw new Error(`Failed to resolve global package "${importName}"`)
 }
 
 export function stringifyMarkdownTokens(tokens: Token[]) {

--- a/packages/slidev/package.json
+++ b/packages/slidev/package.json
@@ -59,6 +59,7 @@
     "debug": "^4.3.2",
     "fast-glob": "^3.2.7",
     "fs-extra": "^10.0.0",
+    "global-dirs": "^3.0.0",
     "import-from": "^4.0.0",
     "is-installed-globally": "^0.4.0",
     "jiti": "^1.12.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -240,6 +240,7 @@ importers:
       fast-deep-equal: ^3.1.3
       fast-glob: ^3.2.7
       fs-extra: ^10.0.0
+      global-dirs: ^3.0.0
       import-from: ^4.0.0
       is-installed-globally: ^0.4.0
       jiti: ^1.12.9
@@ -287,6 +288,7 @@ importers:
       debug: 4.3.2
       fast-glob: 3.2.7
       fs-extra: 10.0.0
+      global-dirs: 3.0.0
       import-from: 4.0.0
       is-installed-globally: 0.4.0
       jiti: 1.12.9


### PR DESCRIPTION
Fix #409 

When global installed, resolve `@slidev/client` and `katex` from `__dirname`.