### PR TITLE
fix: download with routerMode=hash

### DIFF
--- a/packages/slidev/node/build.ts
+++ b/packages/slidev/node/build.ts
@@ -117,6 +117,7 @@ export async function build(
       dark: options.data.config.colorSchema === 'dark',
       width: 1920,
       height: Math.round(1920 / options.data.config.aspectRatio),
+      routerMode: options.data.config.routerMode,
     })
     server.close()
   }


### PR DESCRIPTION
Fixes the generated PDF when combining `download: true` and `routerMode: hash`.

The generated PDF contained n times the first page (here is an exemple: https://nlepage.github.io/build-userfriendly-cli-tool-talk/main/slidev-exported.pdf).

Thanks for the awesome project!