### PR TITLE
fix: PDF when build with download=true, routeMode=hash and a base path

### DIFF
--- a/packages/slidev/node/export.ts
+++ b/packages/slidev/node/export.ts
@@ -89,10 +89,10 @@ export async function exportSlides({
   async function go(no: number, clicks?: string) {
     progress.update(no)
 
-    const path = `${base}${no}?print${withClicks ? '=clicks' : ''}${clicks ? `&clicks=${clicks}` : ''}`
+    const path = `${no}?print${withClicks ? '=clicks' : ''}${clicks ? `&clicks=${clicks}` : ''}`
     const url = routerMode === 'hash'
-      ? `http://localhost:${port}/#${path}`
-      : `http://localhost:${port}${path}`
+      ? `http://localhost:${port}${base}#${path}`
+      : `http://localhost:${port}${base}${path}`
 
     await page.goto(url, {
       waitUntil: 'networkidle',


### PR DESCRIPTION
Following #425

This one fixes the generated PDF file when building with `download: true`, `routerMode: hash`, and using a base path.

Tested the modifications with these four combinations:
 - `routerMode: history` and `slidev build`
 - `routerMode: history` and `slidev build --base /test/`
 - `routerMode: hash` and `slidev build`
 - `routerMode: hash` and `slidev build --base /test/`
