### PR TITLE
refactor: use type based defineProps

### DIFF
--- a/packages/client/layouts/iframe-left.vue
+++ b/packages/client/layouts/iframe-left.vue
@@ -1,14 +1,5 @@
 <script setup lang="ts">
-import { defineProps, ref } from 'vue'
-const props = defineProps({
-  class: {
-    type: String,
-  },
-  url: {
-    type: String,
-  },
-})
-const url = ref(props.url)
+const props = defineProps<{ class?: string; url: string }>()
 </script>
 
 <template>

--- a/packages/client/layouts/iframe-right.vue
+++ b/packages/client/layouts/iframe-right.vue
@@ -1,14 +1,5 @@
 <script setup lang="ts">
-import { defineProps, ref } from 'vue'
-const props = defineProps({
-  class: {
-    type: String,
-  },
-  url: {
-    type: String,
-  },
-})
-const url = ref(props.url)
+const props = defineProps<{ class?: string; url: string }>()
 </script>
 
 <template>

--- a/packages/client/layouts/iframe.vue
+++ b/packages/client/layouts/iframe.vue
@@ -1,11 +1,5 @@
 <script setup lang="ts">
-import { defineProps, ref } from 'vue'
-const props = defineProps({
-  url: {
-    type: String,
-  },
-})
-const url = ref(props.url)
+defineProps<{ url: string }>()
 </script>
 
 <template>


### PR DESCRIPTION
I found these were using an outdated syntax that imports `defineProps()`.
I had to keep `props` because it's not possible to do `:class="class"` as `class` is a reserved keyword