### PR TITLE
refactor: use trimEnd instead of trimRight

### DIFF
--- a/packages/parser/src/core.ts
+++ b/packages/parser/src/core.ts
@@ -114,7 +114,7 @@ export function parse(
   }
 
   for (let i = 0; i < lines.length; i++) {
-    const line = lines[i].trimRight()
+    const line = lines[i].trimEnd()
     if (line.match(/^---+/)) {
       slice(i)
 
@@ -123,7 +123,7 @@ export function parse(
       if (line.match(/^---([^-].*)?$/) && !next?.match(/^\s*$/)) {
         start = i
         for (i += 1; i < lines.length; i++) {
-          if (lines[i].trimRight().match(/^---$/))
+          if (lines[i].trimEnd().match(/^---$/))
             break
         }
       }

--- a/packages/slidev/node/plugins/markdown.ts
+++ b/packages/slidev/node/plugins/markdown.ts
@@ -121,7 +121,7 @@ export function transformSlotSugar(md: string) {
     if (isLineInsideCodeblocks(idx))
       return
 
-    const match = line.trimRight().match(/^::\s*(\w+)\s*::$/)
+    const match = line.trimEnd().match(/^::\s*(\w+)\s*::$/)
     if (match) {
       lines[idx] = `${prevSlot ? '\n\n</template>\n' : '\n'}<template v-slot:${match[1]}="slotProps">\n`
       prevSlot = true


### PR DESCRIPTION
`trimRight` has been deprecated, we can use `trimEnd` instead of `trimRight`.

![9C6E4A1D-11B3-4B61-8422-15BD8F8A6F2A](https://user-images.githubusercontent.com/25154432/146189240-c7f5ba55-85a4-4eb8-8f10-904748ba3da5.png)
