### PR TITLE
feat: add Toc component

### DIFF
--- a/packages/client/builtin/Toc.vue
+++ b/packages/client/builtin/Toc.vue
@@ -1,102 +1,117 @@
 <!--
 Table Of content
 
+`mode` can be either 'all', 'onlyCurrentTree' or 'onlySiblings'
+
 Usage:
 
-<Toc columns="2" maxDepth="3" mode="onlySiblings"/>
+<Toc columns='2' maxDepth='3' mode='onlySiblings'/>
 -->
-<script lang="ts">
+<script setup lang='ts'>
+import { computed } from 'vue'
 import type { RouteRecordRaw } from 'vue-router'
-import { defineComponent } from 'vue'
+import { currentRoute, rawRoutes } from '../logic/nav'
 import type { TocItem } from './TocList.vue'
 
-export default defineComponent({
-  props: {
-    columns: {
-      default: 1,
-    },
-    maxDepth: {
-      default: Infinity,
-    },
-    minDepth: {
-      default: 1,
-    },
-    mode: { // 'all' | 'onlyCurrentTree' | 'onlySiblings'
-      type: String,
-      default: 'all',
-    },
-  },
-  computed: {
-    toc() {
-      // console.log(JSON.parse(JSON.stringify(this.$slidev.nav)))
-      let tree = this.makeTree()
-      this.addActiveStatuses(tree)
-      tree = this.filterTree(tree)
-      if (this.mode === 'onlyCurrentTree')
-        tree = this.filterOnlyCurrentTree(tree)
-      else if (this.mode === 'onlySiblings')
-        tree = this.filterOnlySiblings(tree)
-      return tree
-    },
-  },
-  methods: {
-    makeTree(): TocItem[] {
-      return this.$slidev.nav.rawRoutes
-        .filter((route: RouteRecordRaw) => route.meta?.slide?.title)
-        .reduce((acc: TocItem[], route: RouteRecordRaw) => {
-          this.addToTree(acc, route)
-          return acc
-        }, [])
-    },
-    addToTree(tree: TocItem[], route: RouteRecordRaw, level = 1) {
-      const titleLevel = route.meta?.slide?.titleLevel
-      if (titleLevel && titleLevel > level && tree.length > 0) {
-        this.addToTree(tree[tree.length - 1].children, route, level + 1)
-      }
-      else {
-        tree.push({
-          children: [],
-          level,
-          path: route.path,
-          skipInToc: Boolean(route.meta?.skipInToc),
-          title: route.meta?.slide?.title,
-        })
-      }
-    },
-    addActiveStatuses(tree: TocItem[], hasActiveParent = false, parent?: TocItem) {
-      tree.forEach((item: TocItem) => {
-        item.active = item.path === this.$slidev.nav.currentRoute?.path
-        item.hasActiveParent = hasActiveParent
-        if (item.children.length > 0)
-          this.addActiveStatuses(item.children, item.active || item.hasActiveParent, item)
-        if (parent && (item.active || item.activeParent))
-          parent.activeParent = true
-      })
-    },
-    filterTree(tree: TocItem[], level = 1): TocItem[] {
-      if (level > Number(this.maxDepth)) {
-        return []
-      }
-      else if (level < Number(this.minDepth)) {
-        const activeItem = tree.find(item => item.active || item.activeParent)
-        return activeItem ? this.filterTree(activeItem.children, level + 1) : []
-      }
-      return tree
-        .filter((item: TocItem) => !item.skipInToc)
-        .map((item: TocItem) => ({ ...item, children: this.filterTree(item.children, level + 1) }))
-    },
-    filterOnlyCurrentTree(tree: TocItem[]): TocItem[] {
-      return tree
-        .filter((item: TocItem) => item.active || item.activeParent || item.hasActiveParent)
-        .map((item: TocItem) => ({ ...item, children: this.filterOnlyCurrentTree(item.children) }))
-    },
-    filterOnlySiblings(tree: TocItem[]): TocItem[] {
-      const treehasActiveItem = tree.some(item => item.active || item.activeParent || item.hasActiveParent)
-      return tree
-        .filter(() => treehasActiveItem)
-        .map((item: TocItem) => ({ ...item, children: this.filterOnlySiblings(item.children) }))
-    },
-  },
+const props = withDefaults(
+  defineProps<{
+    columns?: string | number
+    maxDepth?: string | number
+    minDepth?: string | number
+    mode?: 'all' | 'onlyCurrentTree' | 'onlySiblings'
+  }>(),
+  { columns: 1, maxDepth: Infinity, minDepth: 1, mode: 'all' },
+)
+
+function makeTree(): TocItem[] {
+  return rawRoutes
+    .filter((route: RouteRecordRaw) => route.meta?.slide?.title)
+    .reduce((acc: TocItem[], route: RouteRecordRaw) => {
+      addToTree(acc, route)
+      return acc
+    }, [])
+}
+
+function addToTree(tree: TocItem[], route: RouteRecordRaw, level = 1) {
+  const titleLevel = route.meta?.slide?.titleLevel
+  if (titleLevel && titleLevel > level && tree.length > 0) {
+    addToTree(tree[tree.length - 1].children, route, level + 1)
+  }
+  else {
+    tree.push({
+      children: [],
+      level,
+      path: route.path,
+      skipInToc: Boolean(route.meta?.skipInToc),
+      title: route.meta?.slide?.title,
+    })
+  }
+}
+
+function addActiveStatuses(
+  tree: TocItem[],
+  hasActiveParent = false,
+  parent?: TocItem,
+) {
+  tree.forEach((item: TocItem) => {
+    item.active = item.path === currentRoute.value?.path
+    item.hasActiveParent = hasActiveParent
+    if (item.children.length > 0)
+      addActiveStatuses(item.children, item.active || item.hasActiveParent, item)
+    if (parent && (item.active || item.activeParent))
+      parent.activeParent = true
+  })
+}
+
+function filterTree(tree: TocItem[], level = 1): TocItem[] {
+  if (level > Number(props.maxDepth)) {
+    return []
+  }
+  else if (level < Number(props.minDepth)) {
+    const activeItem = tree.find((item: TocItem) => item.active || item.activeParent)
+    return activeItem ? filterTree(activeItem.children, level + 1) : []
+  }
+  return tree
+    .filter((item: TocItem) => !item.skipInToc)
+    .map((item: TocItem) => ({
+      ...item,
+      children: filterTree(item.children, level + 1),
+    }))
+}
+
+function filterOnlyCurrentTree(tree: TocItem[]): TocItem[] {
+  return tree
+    .filter(
+      (item: TocItem) =>
+        item.active || item.activeParent || item.hasActiveParent,
+    )
+    .map((item: TocItem) => ({
+      ...item,
+      children: filterOnlyCurrentTree(item.children),
+    }))
+}
+
+function filterOnlySiblings(tree: TocItem[]): TocItem[] {
+  const treehasActiveItem = tree.some(
+    (item: TocItem) => item.active || item.activeParent || item.hasActiveParent,
+  )
+  return tree
+    .filter(() => treehasActiveItem)
+    .map((item: TocItem) => ({
+      ...item,
+      children: filterOnlySiblings(item.children),
+    }))
+}
+
+const toc = computed(() => {
+  let tree = makeTree()
+  addActiveStatuses(tree)
+  tree = filterTree(tree)
+  if (props.mode === 'onlyCurrentTree')
+    tree = filterOnlyCurrentTree(tree)
+  else if (props.mode === 'onlySiblings')
+    tree = filterOnlySiblings(tree)
+  return tree
 })
 </script>
 

--- a/packages/client/builtin/Toc.vue
+++ b/packages/client/builtin/Toc.vue
@@ -9,9 +9,8 @@ Usage:
 -->
 <script setup lang='ts'>
 import { computed } from 'vue'
-import type { RouteRecordRaw } from 'vue-router'
-import { currentRoute, rawRoutes } from '../logic/nav'
-import type { TocItem } from './TocList.vue'
+import type { TocItem } from '../logic/nav'
+import { tree } from '../logic/nav'
 
 const props = withDefaults(
   defineProps<{
@@ -23,59 +22,18 @@ const props = withDefaults(
   { columns: 1, maxDepth: Infinity, minDepth: 1, mode: 'all' },
 )
 
-function makeTree(): TocItem[] {
-  return rawRoutes
-    .filter((route: RouteRecordRaw) => route.meta?.slide?.title)
-    .reduce((acc: TocItem[], route: RouteRecordRaw) => {
-      addToTree(acc, route)
-      return acc
-    }, [])
-}
-
-function addToTree(tree: TocItem[], route: RouteRecordRaw, level = 1) {
-  const titleLevel = route.meta?.slide?.titleLevel
-  if (titleLevel && titleLevel > level && tree.length > 0) {
-    addToTree(tree[tree.length - 1].children, route, level + 1)
-  }
-  else {
-    tree.push({
-      children: [],
-      level,
-      path: route.path,
-      skipInToc: Boolean(route.meta?.skipInToc),
-      title: route.meta?.slide?.title,
-    })
-  }
-}
-
-function addActiveStatuses(
-  tree: TocItem[],
-  hasActiveParent = false,
-  parent?: TocItem,
-) {
-  tree.forEach((item: TocItem) => {
-    item.active = item.path === currentRoute.value?.path
-    item.hasActiveParent = hasActiveParent
-    if (item.children.length > 0)
-      addActiveStatuses(item.children, item.active || item.hasActiveParent, item)
-    if (parent && (item.active || item.activeParent))
-      parent.activeParent = true
-  })
-}
-
-function filterTree(tree: TocItem[], level = 1): TocItem[] {
+function filterTreeDepth(tree: TocItem[], level = 1): TocItem[] {
   if (level > Number(props.maxDepth)) {
     return []
   }
   else if (level < Number(props.minDepth)) {
     const activeItem = tree.find((item: TocItem) => item.active || item.activeParent)
-    return activeItem ? filterTree(activeItem.children, level + 1) : []
+    return activeItem ? filterTreeDepth(activeItem.children, level + 1) : []
   }
   return tree
-    .filter((item: TocItem) => !item.skipInToc)
     .map((item: TocItem) => ({
       ...item,
-      children: filterTree(item.children, level + 1),
+      children: filterTreeDepth(item.children, level + 1),
     }))
 }
 
@@ -104,19 +62,17 @@ function filterOnlySiblings(tree: TocItem[]): TocItem[] {
 }
 
 const toc = computed(() => {
-  let tree = makeTree()
-  addActiveStatuses(tree)
-  tree = filterTree(tree)
+  let tocTree = filterTreeDepth(tree.value)
   if (props.mode === 'onlyCurrentTree')
-    tree = filterOnlyCurrentTree(tree)
+    tocTree = filterOnlyCurrentTree(tocTree)
   else if (props.mode === 'onlySiblings')
-    tree = filterOnlySiblings(tree)
-  return tree
+    tocTree = filterOnlySiblings(tocTree)
+  return tocTree
 })
 </script>
 
 <template>
   <div :style="{ columnCount: columns }">
-    <toc-list :level="1" :list="toc" />
+    <TocList :level="1" :list="toc" />
   </div>
 </template>

--- a/packages/client/builtin/Toc.vue
+++ b/packages/client/builtin/Toc.vue
@@ -19,7 +19,12 @@ const props = withDefaults(
     minDepth?: string | number
     mode?: 'all' | 'onlyCurrentTree' | 'onlySiblings'
   }>(),
-  { columns: 1, maxDepth: Infinity, minDepth: 1, mode: 'all' },
+  {
+    columns: 1,
+    maxDepth: Infinity,
+    minDepth: 1,
+    mode: 'all',
+  },
 )
 
 function filterTreeDepth(tree: TocItem[], level = 1): TocItem[] {
@@ -72,7 +77,7 @@ const toc = computed(() => {
 </script>
 
 <template>
-  <div :style="{ columnCount: columns }">
+  <div :style="`column-count:${columns}`">
     <TocList :level="1" :list="toc" />
   </div>
 </template>

--- a/packages/client/builtin/Toc.vue
+++ b/packages/client/builtin/Toc.vue
@@ -1,0 +1,107 @@
+<!--
+Table Of content
+
+Usage:
+
+<Toc columns="2" maxDepth="3" mode="onlySiblings"/>
+-->
+<script lang="ts">
+import type { RouteRecordRaw } from 'vue-router'
+import { defineComponent } from 'vue'
+import type { TocItem } from './TocList.vue'
+
+export default defineComponent({
+  props: {
+    columns: {
+      default: 1,
+    },
+    maxDepth: {
+      default: Infinity,
+    },
+    minDepth: {
+      default: 1,
+    },
+    mode: { // 'all' | 'onlyCurrentTree' | 'onlySiblings'
+      type: String,
+      default: 'all',
+    },
+  },
+  computed: {
+    toc() {
+      // console.log(JSON.parse(JSON.stringify(this.$slidev.nav)))
+      let tree = this.makeTree()
+      this.addActiveStatuses(tree)
+      tree = this.filterTree(tree)
+      if (this.mode === 'onlyCurrentTree')
+        tree = this.filterOnlyCurrentTree(tree)
+      else if (this.mode === 'onlySiblings')
+        tree = this.filterOnlySiblings(tree)
+      return tree
+    },
+  },
+  methods: {
+    makeTree(): TocItem[] {
+      return this.$slidev.nav.rawRoutes
+        .filter((route: RouteRecordRaw) => route.meta?.slide?.title)
+        .reduce((acc: TocItem[], route: RouteRecordRaw) => {
+          this.addToTree(acc, route)
+          return acc
+        }, [])
+    },
+    addToTree(tree: TocItem[], route: RouteRecordRaw, level = 1) {
+      const titleLevel = route.meta?.slide?.titleLevel
+      if (titleLevel && titleLevel > level && tree.length > 0) {
+        this.addToTree(tree[tree.length - 1].children, route, level + 1)
+      }
+      else {
+        tree.push({
+          children: [],
+          level,
+          path: route.path,
+          skipInToc: Boolean(route.meta?.skipInToc),
+          title: route.meta?.slide?.title,
+        })
+      }
+    },
+    addActiveStatuses(tree: TocItem[], hasActiveParent = false, parent?: TocItem) {
+      tree.forEach((item: TocItem) => {
+        item.active = item.path === this.$slidev.nav.currentRoute?.path
+        item.hasActiveParent = hasActiveParent
+        if (item.children.length > 0)
+          this.addActiveStatuses(item.children, item.active || item.hasActiveParent, item)
+        if (parent && (item.active || item.activeParent))
+          parent.activeParent = true
+      })
+    },
+    filterTree(tree: TocItem[], level = 1): TocItem[] {
+      if (level > Number(this.maxDepth)) {
+        return []
+      }
+      else if (level < Number(this.minDepth)) {
+        const activeItem = tree.find(item => item.active || item.activeParent)
+        return activeItem ? this.filterTree(activeItem.children, level + 1) : []
+      }
+      return tree
+        .filter((item: TocItem) => !item.skipInToc)
+        .map((item: TocItem) => ({ ...item, children: this.filterTree(item.children, level + 1) }))
+    },
+    filterOnlyCurrentTree(tree: TocItem[]): TocItem[] {
+      return tree
+        .filter((item: TocItem) => item.active || item.activeParent || item.hasActiveParent)
+        .map((item: TocItem) => ({ ...item, children: this.filterOnlyCurrentTree(item.children) }))
+    },
+    filterOnlySiblings(tree: TocItem[]): TocItem[] {
+      const treehasActiveItem = tree.some(item => item.active || item.activeParent || item.hasActiveParent)
+      return tree
+        .filter(() => treehasActiveItem)
+        .map((item: TocItem) => ({ ...item, children: this.filterOnlySiblings(item.children) }))
+    },
+  },
+})
+</script>
+
+<template>
+  <div :style="{ columnCount: columns }">
+    <toc-list :level="1" :list="toc" />
+  </div>
+</template>

--- a/packages/client/builtin/TocList.vue
+++ b/packages/client/builtin/TocList.vue
@@ -8,7 +8,6 @@ Usage:
 -->
 <script setup lang="ts">
 import type { TocItem } from '../logic/nav'
-import { go } from '../logic/nav'
 
 withDefaults(defineProps<{
   level: number
@@ -19,7 +18,9 @@ withDefaults(defineProps<{
 <template>
   <ul v-if="list && list.length > 0" :class="['toc', `toc-level-${level}`]">
     <li v-for="item in list" :key="item.path" :class="['toc-item', {'toc-item-active': item.active}, {'toc-item-parent-active': item.activeParent}]">
-      <a @click.prevent="go(item.path)">{{ item.title }}</a>
+      <RouterLink :to="item.path">
+        {{ item.title }}
+      </RouterLink>
       <TocList :level="level + 1" :list="item.children" />
     </li>
   </ul>

--- a/packages/client/builtin/TocList.vue
+++ b/packages/client/builtin/TocList.vue
@@ -1,0 +1,32 @@
+<!--
+TOC list
+(used by Toc component, you don't need to use this component directly)
+-->
+<script setup lang="ts">
+import { go } from '../logic/nav'
+
+export interface TocItem {
+  active?: boolean
+  activeParent?: boolean
+  children: TocItem[]
+  hasActiveParent?: boolean
+  level: number
+  path: string
+  skipInToc?: boolean
+  title?: string
+}
+
+defineProps<{
+  level: number
+  list: TocItem[]
+}>()
+</script>
+
+<template>
+  <ul v-if="list && list.length > 0" :class="['toc', `toc-level-${level}`]">
+    <li v-for="item in list" :key="item.path" :class="['toc-item', {'toc-item-active': item.active}, {'toc-item-parent-active': item.activeParent}]">
+      <a @click.prevent="go(item.path)">{{ item.title }}</a>
+      <toc-list :level="level + 1" :list="item.children" />
+    </li>
+  </ul>
+</template>

--- a/packages/client/builtin/TocList.vue
+++ b/packages/client/builtin/TocList.vue
@@ -1,32 +1,26 @@
 <!--
 TOC list
 (used by Toc component, you don't need to use this component directly)
+
+Usage:
+
+<TocList :list="list"/>
 -->
 <script setup lang="ts">
+import type { TocItem } from '../logic/nav'
 import { go } from '../logic/nav'
 
-export interface TocItem {
-  active?: boolean
-  activeParent?: boolean
-  children: TocItem[]
-  hasActiveParent?: boolean
-  level: number
-  path: string
-  skipInToc?: boolean
-  title?: string
-}
-
-defineProps<{
+withDefaults(defineProps<{
   level: number
   list: TocItem[]
-}>()
+}>(), { level: 1 })
 </script>
 
 <template>
   <ul v-if="list && list.length > 0" :class="['toc', `toc-level-${level}`]">
     <li v-for="item in list" :key="item.path" :class="['toc-item', {'toc-item-active': item.active}, {'toc-item-parent-active': item.activeParent}]">
       <a @click.prevent="go(item.path)">{{ item.title }}</a>
-      <toc-list :level="level + 1" :list="item.children" />
+      <TocList :level="level + 1" :list="item.children" />
     </li>
   </ul>
 </template>

--- a/packages/client/logic/nav.ts
+++ b/packages/client/logic/nav.ts
@@ -14,7 +14,7 @@ export interface TocItem {
   hasActiveParent?: boolean
   level: number
   path: string
-  skipInToc?: boolean
+  hideInToc?: boolean
   title?: string
 }
 
@@ -175,7 +175,7 @@ export async function openInEditor(url?: string) {
 }
 
 export function addToTree(tree: TocItem[], route: RouteRecordRaw, level = 1) {
-  const titleLevel = route.meta?.slide?.titleLevel
+  const titleLevel = route.meta?.slide?.level
   if (titleLevel && titleLevel > level && tree.length > 0) {
     addToTree(tree[tree.length - 1].children, route, level + 1)
   }
@@ -184,7 +184,7 @@ export function addToTree(tree: TocItem[], route: RouteRecordRaw, level = 1) {
       children: [],
       level,
       path: route.path,
-      skipInToc: Boolean(route.meta?.skipInToc),
+      hideInToc: Boolean(route.meta?.hideInToc),
       title: route.meta?.slide?.title,
     })
   }
@@ -211,7 +211,7 @@ export function getTreeWithActiveStatuses(
 
 function filterTree(tree: TocItem[], level = 1): TocItem[] {
   return tree
-    .filter((item: TocItem) => !item.skipInToc)
+    .filter((item: TocItem) => !item.hideInToc)
     .map((item: TocItem) => ({
       ...item,
       children: filterTree(item.children, level + 1),

--- a/packages/client/logic/nav.ts
+++ b/packages/client/logic/nav.ts
@@ -1,10 +1,22 @@
 import type { Ref } from 'vue'
+import type { RouteRecordRaw } from 'vue-router'
 import { computed, ref, nextTick } from 'vue'
 import { isString, SwipeDirection, timestamp, usePointerSwipe } from '@vueuse/core'
 import { rawRoutes, router } from '../routes'
 import { configs } from '../env'
 import { useRouteQuery } from './route'
 import { isDrawing } from './drawings'
+
+export interface TocItem {
+  active?: boolean
+  activeParent?: boolean
+  children: TocItem[]
+  hasActiveParent?: boolean
+  level: number
+  path: string
+  skipInToc?: boolean
+  title?: string
+}
 
 export { rawRoutes, router }
 
@@ -61,6 +73,15 @@ export const clicksTotal = computed(() => +(currentRoute.value?.meta?.clicks ?? 
 
 export const hasNext = computed(() => currentPage.value < rawRoutes.length - 1 || clicks.value < clicksTotal.value)
 export const hasPrev = computed(() => currentPage.value > 1 || clicks.value > 0)
+
+export const rawTree = computed(() => rawRoutes
+  .filter((route: RouteRecordRaw) => route.meta?.slide?.title)
+  .reduce((acc: TocItem[], route: RouteRecordRaw) => {
+    addToTree(acc, route)
+    return acc
+  }, []))
+export const treeWithActiveStatuses = computed(() => getTreeWithActiveStatuses(rawTree.value))
+export const tree = computed(() => filterTree(treeWithActiveStatuses.value))
 
 export function next() {
   if (clicksTotal.value <= clicks.value)
@@ -151,4 +172,48 @@ export async function openInEditor(url?: string) {
   }
   await fetch(`/__open-in-editor?file=${encodeURIComponent(url)}`)
   return true
+}
+
+export function addToTree(tree: TocItem[], route: RouteRecordRaw, level = 1) {
+  const titleLevel = route.meta?.slide?.titleLevel
+  if (titleLevel && titleLevel > level && tree.length > 0) {
+    addToTree(tree[tree.length - 1].children, route, level + 1)
+  }
+  else {
+    tree.push({
+      children: [],
+      level,
+      path: route.path,
+      skipInToc: Boolean(route.meta?.skipInToc),
+      title: route.meta?.slide?.title,
+    })
+  }
+}
+
+export function getTreeWithActiveStatuses(
+  tree: TocItem[],
+  hasActiveParent = false,
+  parent?: TocItem,
+): TocItem[] {
+  return tree.map((item: TocItem) => {
+    const clone = {
+      ...item,
+      active: item.path === currentRoute.value?.path,
+      hasActiveParent,
+    }
+    if (clone.children.length > 0)
+      clone.children = getTreeWithActiveStatuses(clone.children, clone.active || clone.hasActiveParent, clone)
+    if (parent && (clone.active || clone.activeParent))
+      parent.activeParent = true
+    return clone
+  })
+}
+
+function filterTree(tree: TocItem[], level = 1): TocItem[] {
+  return tree
+    .filter((item: TocItem) => !item.skipInToc)
+    .map((item: TocItem) => ({
+      ...item,
+      children: filterTree(item.children, level + 1),
+    }))
 }

--- a/packages/client/routes.ts
+++ b/packages/client/routes.ts
@@ -52,7 +52,7 @@ declare module 'vue-router' {
       no: number
       filepath: string
       title?: string
-      titleLevel?: number
+      level?: number
     }
 
     // private fields

--- a/packages/client/routes.ts
+++ b/packages/client/routes.ts
@@ -51,6 +51,8 @@ declare module 'vue-router' {
       id: number
       no: number
       filepath: string
+      title?: string
+      titleLevel?: number
     }
 
     // private fields

--- a/packages/parser/src/core.ts
+++ b/packages/parser/src/core.ts
@@ -79,11 +79,22 @@ export function parseSlide(raw: string): SlideInfoBase {
     }
   }
 
-  const title = frontmatter.title || frontmatter.name || content.match(/^#+ (.*)$/m)?.[1]?.trim()
+  let title
+  let titleLevel
+  if (frontmatter.title || frontmatter.name) {
+    title = frontmatter.title || frontmatter.name
+    titleLevel = frontmatter.titleLevel || 1
+  }
+  else {
+    const match = content.match(/^(#+) (.*)$/m)
+    title = match?.[2]?.trim()
+    titleLevel = match?.[1]?.length
+  }
 
   return {
     raw,
     title,
+    titleLevel,
     content,
     frontmatter,
     note,

--- a/packages/parser/src/core.ts
+++ b/packages/parser/src/core.ts
@@ -80,21 +80,21 @@ export function parseSlide(raw: string): SlideInfoBase {
   }
 
   let title
-  let titleLevel
+  let level
   if (frontmatter.title || frontmatter.name) {
     title = frontmatter.title || frontmatter.name
-    titleLevel = frontmatter.titleLevel || 1
+    level = frontmatter.level || 1
   }
   else {
     const match = content.match(/^(#+) (.*)$/m)
     title = match?.[2]?.trim()
-    titleLevel = match?.[1]?.length
+    level = match?.[1]?.length
   }
 
   return {
     raw,
     title,
-    titleLevel,
+    level,
     content,
     frontmatter,
     note,

--- a/packages/slidev/node/plugins/loaders.ts
+++ b/packages/slidev/node/plugins/loaders.ts
@@ -414,7 +414,7 @@ export function createSlidesLoader(
               id: idx,
               no,
               title: i.title,
-              titleLevel: i.titleLevel,
+              level: i.level,
             },
             __clicksElements: [],
             __preloaded: false,

--- a/packages/slidev/node/plugins/loaders.ts
+++ b/packages/slidev/node/plugins/loaders.ts
@@ -413,6 +413,8 @@ export function createSlidesLoader(
               filepath: i.source?.filepath || entry,
               id: idx,
               no,
+              title: i.title,
+              titleLevel: i.titleLevel,
             },
             __clicksElements: [],
             __preloaded: false,

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -7,6 +7,7 @@ export interface SlideInfoBase {
   note?: string
   frontmatter: Record<string, any>
   title?: string
+  titleLevel?: number
 }
 
 export interface SlideInfo extends SlideInfoBase {

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -7,7 +7,7 @@ export interface SlideInfoBase {
   note?: string
   frontmatter: Record<string, any>
   title?: string
-  titleLevel?: number
+  level?: number
 }
 
 export interface SlideInfo extends SlideInfoBase {

--- a/test/__snapshots__/parser.test.ts.snap
+++ b/test/__snapshots__/parser.test.ts.snap
@@ -109,6 +109,7 @@ Array [
       "title": "Hi",
     },
     "index": 0,
+    "level": 1,
     "note": undefined,
     "raw": "---
 layout: cover
@@ -138,6 +139,7 @@ title: Hi
       },
     },
     "index": 1,
+    "level": 1,
     "note": "This is note",
     "raw": "---
 meta:
@@ -162,6 +164,7 @@ This is note
     "end": 19,
     "frontmatter": Object {},
     "index": 2,
+    "level": 1,
     "note": undefined,
     "raw": "
 # Morning
@@ -180,6 +183,7 @@ Hey
       "layout": "text",
     },
     "index": 3,
+    "level": undefined,
     "note": "This is note",
     "raw": "---
 layout: text
@@ -207,6 +211,7 @@ this should be treated as code block
     "end": 35,
     "frontmatter": Object {},
     "index": 4,
+    "level": undefined,
     "note": undefined,
     "raw": "
 \`\`\`md
@@ -324,6 +329,7 @@ console.log('Hello World')
       "title": "H1",
     },
     "index": 0,
+    "level": 1,
     "note": undefined,
     "raw": "---
 title: H1
@@ -355,6 +361,7 @@ console.log('Hello World')
     "end": 18,
     "frontmatter": Object {},
     "index": 1,
+    "level": 1,
     "note": undefined,
     "raw": "
 # Hello
@@ -375,6 +382,7 @@ Nice to meet you
     "end": 22,
     "frontmatter": Object {},
     "index": 2,
+    "level": undefined,
     "note": undefined,
     "raw": "
 Nice to meet you
@@ -489,6 +497,7 @@ Array [
         "title": undefined,
       },
       "index": 0,
+      "level": undefined,
       "note": undefined,
       "raw": "---
 src: sub/page1.md
@@ -497,6 +506,7 @@ src: sub/page1.md
       "start": 0,
       "title": undefined,
     },
+    "level": 1,
     "note": undefined,
     "raw": "---
 src: sub/page1.md
@@ -508,6 +518,7 @@ src: sub/page1.md
     "source": Object {
       "content": "# Page 1",
       "frontmatter": Object {},
+      "level": 1,
       "note": undefined,
       "raw": "# Page 1
 ",
@@ -537,6 +548,7 @@ src: sub/page1.md
         "src": "sub/page2.md",
       },
       "index": 1,
+      "level": undefined,
       "note": undefined,
       "raw": "---
 src: sub/page2.md
@@ -546,6 +558,7 @@ background: https://sli.dev/demo-cover.png
       "start": 4,
       "title": undefined,
     },
+    "level": 1,
     "note": undefined,
     "raw": "---
 layout: cover
@@ -565,6 +578,7 @@ background: https://sli.dev/demo-cover.png
       "frontmatter": Object {
         "layout": "cover",
       },
+      "level": 1,
       "note": undefined,
       "raw": "---
 layout: cover
@@ -588,6 +602,7 @@ $x+2$
     "end": 15,
     "frontmatter": Object {},
     "index": 2,
+    "level": 1,
     "note": undefined,
     "raw": "
 # Inline Page


### PR DESCRIPTION
Adding a built-in TOC component.

TOC is really useful when you have long presentations (like for a 3 days training for example). It helps people not to be to much lost.
Lots of presentation library miss this feature, that is mandatory in the usage I have.
I found this library awesome, that's why I am proposing this feature, because It would even more incredible with this feature :smiley: 

This feature automatically gather informations about the title and the title level of each slides to build a tree.
You can also set both information using front matter syntax (if your slide does not contain a title, or if you want to override it).
For example:
```md
---
title: Amazing slide title
title level: 2
---
```

Available props for the Toc component:
* columns (default = 1): TOC in multiple columns
* maxDepth (default = Infinity): Maximum depth of the TOC
* minDepth (default = 1): Minimum depth of the TOC
* mode (default = 'all'):
  * 'all': Displays all items
  * 'onlyCurrentTree': Displays only items that belong to the current active slide (active slide, parents of active slides and children of active slide)
  * 'onlySiblings': Displays only items that belong to the current active slide and their siblings (but it will not show the children of a slide that does not belong to the current tree)

You can also mark a slide to not be displayed in the TOC with the front matter syntax:
```md
---
skipInToc: true
---
```

Examples (Table of content slide is skipped):

=> `columns="3"`
![screencapture-localhost-3031-2-2022-01-12-16_59_50](https://user-images.githubusercontent.com/5246045/149179362-679f42f6-eda5-41b2-a951-3ac77c350b2e.png)

=> `maxDepth="2"`
![screencapture-localhost-3030-12-2022-01-12-17_03_38](https://user-images.githubusercontent.com/5246045/149179576-a5a35b98-9d86-40ea-ba08-8835ef6ec5eb.png)

=> `minDepth="2"`
![screencapture-localhost-3030-21-2022-01-12-17_04_04](https://user-images.githubusercontent.com/5246045/149179625-72767700-a39c-4079-b830-baa416a2afb8.png)

=> `mode="onlyCurrentTree"`
![screencapture-localhost-3031-17-2022-01-12-17_00_36](https://user-images.githubusercontent.com/5246045/149179849-cea41395-614d-42b6-b553-3e3d2a2058f2.png)

=> `mode="onlySiblings"`
![screencapture-localhost-3031-31-2022-01-12-17_01_15](https://user-images.githubusercontent.com/5246045/149179926-f5b8d630-3a98-49dd-9bf6-a827bc2b467a.png)

Possible enhancements:
* add some styles to see active item in the list (classes are already added but I am not sure where I should put the styles or if we should let the user add his own styles)
* the tree for the TOC is a computed value inside the Toc component, but if you put multiple Toc component in your presentation, the tree get calculated for each components. Maybe we can calculate the tree globally and get it inside the component (that will filter it accordingly to the props), but I am not sure how we should do that ().