### PR TITLE
fix: add 'slidev' class prefix

### DIFF
--- a/packages/client/builtin/Toc.vue
+++ b/packages/client/builtin/Toc.vue
@@ -77,7 +77,7 @@ const toc = computed(() => {
 </script>
 
 <template>
-  <div :style="`column-count:${columns}`">
+  <div class="slidev-toc" :style="`column-count:${columns}`">
     <TocList :level="1" :list="toc" />
   </div>
 </template>

--- a/packages/client/builtin/TocList.vue
+++ b/packages/client/builtin/TocList.vue
@@ -16,7 +16,7 @@ withDefaults(defineProps<{
 </script>
 
 <template>
-  <ul v-if="list && list.length > 0" :class="['slidev-toc', `slidev-toc-level-${level}`]">
+  <ul v-if="list && list.length > 0" :class="['slidev-toc-list', `slidev-toc-list-level-${level}`]">
     <li v-for="item in list" :key="item.path" :class="['slidev-toc-item', {'slidev-toc-item-active': item.active}, {'slidev-toc-item-parent-active': item.activeParent}]">
       <RouterLink :to="item.path">
         {{ item.title }}

--- a/packages/client/builtin/TocList.vue
+++ b/packages/client/builtin/TocList.vue
@@ -16,8 +16,8 @@ withDefaults(defineProps<{
 </script>
 
 <template>
-  <ul v-if="list && list.length > 0" :class="['toc', `toc-level-${level}`]">
-    <li v-for="item in list" :key="item.path" :class="['toc-item', {'toc-item-active': item.active}, {'toc-item-parent-active': item.activeParent}]">
+  <ul v-if="list && list.length > 0" :class="['slidev-toc', `slidev-toc-level-${level}`]">
+    <li v-for="item in list" :key="item.path" :class="['slidev-toc-item', {'slidev-toc-item-active': item.active}, {'slidev-toc-item-parent-active': item.activeParent}]">
       <RouterLink :to="item.path">
         {{ item.title }}
       </RouterLink>


### PR DESCRIPTION
It is not urgent, but I just realized I forgot to add the `slidev` prefix to HTML classes.