### PR TITLE
Allow HTML in TOC

### DIFF
--- a/packages/client/builtin/TocList.vue
+++ b/packages/client/builtin/TocList.vue
@@ -18,8 +18,7 @@ withDefaults(defineProps<{
 <template>
   <ul v-if="list && list.length > 0" :class="['slidev-toc-list', `slidev-toc-list-level-${level}`]">
     <li v-for="item in list" :key="item.path" :class="['slidev-toc-item', {'slidev-toc-item-active': item.active}, {'slidev-toc-item-parent-active': item.activeParent}]">
-      <RouterLink :to="item.path">
-        {{ item.title }}
+      <RouterLink :to="item.path" v-html="item.title">
       </RouterLink>
       <TocList :level="level + 1" :list="item.children" />
     </li>

--- a/packages/parser/src/fs.ts
+++ b/packages/parser/src/fs.ts
@@ -1,8 +1,11 @@
 import { promises as fs } from 'fs'
 import { dirname, resolve } from 'path'
 import type { SlideInfoWithPath, SlidevMarkdown, SlidevThemeMeta } from '@slidev/types'
+import Markdown from 'markdown-it'
 import { detectFeatures, mergeFeatureFlags, parse, parseSlide, stringify, stringifySlide } from './core'
 export * from './core'
+
+const md = Markdown({ html: true }).disable(['code_block', 'fence', 'hardbreak', 'softbreak'])
 
 export async function load(filepath: string, themeMeta?: SlidevThemeMeta, content?: string) {
   const dir = dirname(filepath)
@@ -15,6 +18,9 @@ export async function load(filepath: string, themeMeta?: SlidevThemeMeta, conten
   ])
 
   for (const slide of data.slides) {
+    if (slide.title)
+      slide.title = md.render(slide.title).trim().replace(/^<p>/, '').replace(/<\/p>$/, '')
+
     if (!slide.frontmatter.src)
       continue
 

--- a/packages/parser/src/fs.ts
+++ b/packages/parser/src/fs.ts
@@ -5,7 +5,7 @@ import Markdown from 'markdown-it'
 import { detectFeatures, mergeFeatureFlags, parse, parseSlide, stringify, stringifySlide } from './core'
 export * from './core'
 
-const md = Markdown({ html: true }).disable(['code_block', 'fence', 'hardbreak', 'softbreak'])
+const md = Markdown({ html: true })
 
 export async function load(filepath: string, themeMeta?: SlidevThemeMeta, content?: string) {
   const dir = dirname(filepath)


### PR DESCRIPTION
Typical use-case: having an image in the title.