### PR TITLE
fix: extend 1h recording limit to 24h

### DIFF
--- a/packages/client/logic/recording.ts
+++ b/packages/client/logic/recording.ts
@@ -58,6 +58,8 @@ export function useRecording() {
   const config: RecorderOptions = {
     type: 'video',
     bitsPerSecond: 4 * 256 * 8 * 1024,
+    // Extending recording limit as default is only 1h (see https://github.com/muaz-khan/RecordRTC/issues/144)
+    timeSlice: 24 * 60 * 60 * 1000,
   }
 
   async function toggleAvatar() {


### PR DESCRIPTION
Currently, when recording the presentation, the video is not recorded anymore after 1h delay. When the recording is stopped, the resulting video will never exceed 1h long.

[This issue](https://github.com/muaz-khan/RecordRTC/issues/144) explains why.

This PR increases the value to 24h, which should be enough for most use-cases.