### PR TITLE
fix: video having no duration (with CDN)

### DIFF
--- a/packages/client/index.html
+++ b/packages/client/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <script src="https://www.webrtc-experiment.com/EBML.js"></script>
   <!-- head -->
 </head>
 <body>

--- a/packages/client/logic/recording.ts
+++ b/packages/client/logic/recording.ts
@@ -1,3 +1,4 @@
+import { getSeekableBlob } from 'recordrtc'
 import type { Ref } from 'vue'
 import { nextTick, ref, shallowRef, watch } from 'vue'
 import { useDevicesList, useEventListener } from '@vueuse/core'
@@ -155,22 +156,24 @@ export function useRecording() {
     recording.value = false
     recorderCamera.value?.stopRecording(() => {
       if (recordCamera.value) {
-        const blob = recorderCamera.value!.getBlob()
-        const url = URL.createObjectURL(blob)
-        download(getFilename('camera'), url)
-        window.URL.revokeObjectURL(url)
+        getSeekableBlob(recorderCamera.value!.getBlob(), (seekableBLob) => {
+          const url = URL.createObjectURL(seekableBLob)
+          download(getFilename('camera'), url)
+          window.URL.revokeObjectURL(url)
+        })
       }
       recorderCamera.value = undefined
       if (!showAvatar.value)
         closeStream(streamCamera)
     })
     recorderSlides.value?.stopRecording(() => {
-      const blob = recorderSlides.value!.getBlob()
-      const url = URL.createObjectURL(blob)
-      download(getFilename('screen'), url)
-      window.URL.revokeObjectURL(url)
-      closeStream(streamSlides)
-      recorderSlides.value = undefined
+      getSeekableBlob(recorderSlides.value!.getBlob(), (seekableBLob) => {
+        const url = URL.createObjectURL(seekableBLob)
+        download(getFilename('screen'), url)
+        window.URL.revokeObjectURL(url)
+        closeStream(streamSlides)
+        recorderSlides.value = undefined
+      })
     })
   }
 


### PR DESCRIPTION
When recording the presentation, the resulting video is *corrupted* as the duration is not/incorrectly detected by video players.

[This issue](https://github.com/muaz-khan/RecordRTC/issues/147) explains the problem and gives a solution: we have to wrap the blob in `getSeekableBlob` function.

An important thing to note is that `getSeekableBlob` function **requires `EBML` as dependency**.

I have developed several PR solving the problem and using different ways to import `EBML` as each of them have pros and cons.

This PR imports a JS file from a CDN in `index.html`.
Cons: we depend on internet connection and CDN availability.

See other PRs:
- https://github.com/slidevjs/slidev/pull/490
- https://github.com/slidevjs/slidev/pull/491