### PR TITLE
fix: video having no duration (with recordrtc dependency from GitHub)

### DIFF
--- a/packages/client/logic/recording.ts
+++ b/packages/client/logic/recording.ts
@@ -1,3 +1,4 @@
+import { getSeekableBlob } from 'recordrtc'
 import type { Ref } from 'vue'
 import { nextTick, ref, shallowRef, watch } from 'vue'
 import { useDevicesList, useEventListener } from '@vueuse/core'
@@ -5,6 +6,8 @@ import { isTruthy } from '@antfu/utils'
 import type RecorderType from 'recordrtc'
 import type { Options as RecorderOptions } from 'recordrtc'
 import { currentCamera, currentMic } from '../state'
+
+import 'recordrtc-github/libs/EBML'
 
 export const recordingName = ref('')
 export const recordCamera = ref(true)
@@ -155,22 +158,24 @@ export function useRecording() {
     recording.value = false
     recorderCamera.value?.stopRecording(() => {
       if (recordCamera.value) {
-        const blob = recorderCamera.value!.getBlob()
-        const url = URL.createObjectURL(blob)
-        download(getFilename('camera'), url)
-        window.URL.revokeObjectURL(url)
+        getSeekableBlob(recorderCamera.value!.getBlob(), (seekableBLob) => {
+          const url = URL.createObjectURL(seekableBLob)
+          download(getFilename('camera'), url)
+          window.URL.revokeObjectURL(url)
+        })
       }
       recorderCamera.value = undefined
       if (!showAvatar.value)
         closeStream(streamCamera)
     })
     recorderSlides.value?.stopRecording(() => {
-      const blob = recorderSlides.value!.getBlob()
-      const url = URL.createObjectURL(blob)
-      download(getFilename('screen'), url)
-      window.URL.revokeObjectURL(url)
-      closeStream(streamSlides)
-      recorderSlides.value = undefined
+      getSeekableBlob(recorderSlides.value!.getBlob(), (seekableBLob) => {
+        const url = URL.createObjectURL(seekableBLob)
+        download(getFilename('screen'), url)
+        window.URL.revokeObjectURL(url)
+        closeStream(streamSlides)
+        recorderSlides.value = undefined
+      })
     })
   }
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -29,6 +29,7 @@
     "nanoid": "^3.2.0",
     "prettier": "^2.5.1",
     "recordrtc": "^5.6.2",
+    "recordrtc-github": "muaz-khan/RecordRTC#5.6.2",
     "resolve": "^1.22.0",
     "vite-plugin-windicss": "^1.7.0",
     "vue": "^3.2.30",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,6 +159,7 @@ importers:
       nanoid: ^3.2.0
       prettier: ^2.5.1
       recordrtc: ^5.6.2
+      recordrtc-github: muaz-khan/RecordRTC#5.6.2
       resolve: ^1.22.0
       vite-plugin-windicss: ^1.7.0
       vue: ^3.2.30
@@ -182,6 +183,7 @@ importers:
       nanoid: 3.2.0
       prettier: 2.5.1
       recordrtc: 5.6.2
+      recordrtc-github: github.com/muaz-khan/RecordRTC/ebae1da10f50a521000cbcced5c5adfb96f32411
       resolve: 1.22.0
       vite-plugin-windicss: 1.7.0_vite@2.7.13
       vue: 3.2.30
@@ -1705,6 +1707,7 @@ packages:
   /colors/1.4.0:
     resolution: {integrity: sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==}
     engines: {node: '>=0.1.90'}
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -6561,3 +6564,9 @@ packages:
       ps-tree: 1.2.0
       which: 2.0.2
     dev: true
+
+  github.com/muaz-khan/RecordRTC/ebae1da10f50a521000cbcced5c5adfb96f32411:
+    resolution: {tarball: https://codeload.github.com/muaz-khan/RecordRTC/tar.gz/ebae1da10f50a521000cbcced5c5adfb96f32411}
+    name: recordrtc
+    version: 5.6.2
+    dev: false


### PR DESCRIPTION
When recording the presentation, the resulting video is *corrupted* as the duration is not/incorrectly detected by video players.

[This issue](https://github.com/muaz-khan/RecordRTC/issues/147) explains the problem and gives a solution: we have to wrap the blob in `getSeekableBlob` function.

An important thing to note is that `getSeekableBlob` function **requires `EBML` as dependency**.

I have developed several PR solving the problem and using different ways to import `EBML` as each of them have pros and cons.

This PR imports `recordrtc` dependency twice (second time from GitHub URL instead of from npm registry) in order to have the required `EBML.js` file (which is not packed in the npm registry version of `recordrtc`)
Cons: we declare the same dependency twice and we use GitHub dependency (not a good practice?).

See other PRs:
- https://github.com/slidevjs/slidev/pull/489
- https://github.com/slidevjs/slidev/pull/491