### PR TITLE
feat: support specify `list-class` for TOC

### DIFF
--- a/packages/client/builtin/Toc.vue
+++ b/packages/client/builtin/Toc.vue
@@ -15,14 +15,14 @@ import { tree } from '../logic/nav'
 const props = withDefaults(
   defineProps<{
     columns?: string | number
-    listClassNames?: string[]
+    listClass?: string | string[]
     maxDepth?: string | number
     minDepth?: string | number
     mode?: 'all' | 'onlyCurrentTree' | 'onlySiblings'
   }>(),
   {
     columns: 1,
-    listClassNames: () => [],
+    listClass: '',
     maxDepth: Infinity,
     minDepth: 1,
     mode: 'all',
@@ -80,6 +80,6 @@ const toc = computed(() => {
 
 <template>
   <div class="slidev-toc" :style="`column-count:${columns}`">
-    <TocList :level="1" :list="toc" :list-class-names="listClassNames" />
+    <TocList :level="1" :list="toc" :list-class="listClass" />
   </div>
 </template>

--- a/packages/client/builtin/Toc.vue
+++ b/packages/client/builtin/Toc.vue
@@ -15,12 +15,14 @@ import { tree } from '../logic/nav'
 const props = withDefaults(
   defineProps<{
     columns?: string | number
+    listStyle?: 'decimal' | 'disc'
     maxDepth?: string | number
     minDepth?: string | number
     mode?: 'all' | 'onlyCurrentTree' | 'onlySiblings'
   }>(),
   {
     columns: 1,
+    listStyle: 'decimal',
     maxDepth: Infinity,
     minDepth: 1,
     mode: 'all',
@@ -78,6 +80,6 @@ const toc = computed(() => {
 
 <template>
   <div class="slidev-toc" :style="`column-count:${columns}`">
-    <TocList :level="1" :list="toc" />
+    <TocList :level="1" :list="toc" :list-style="listStyle" />
   </div>
 </template>

--- a/packages/client/builtin/Toc.vue
+++ b/packages/client/builtin/Toc.vue
@@ -15,14 +15,14 @@ import { tree } from '../logic/nav'
 const props = withDefaults(
   defineProps<{
     columns?: string | number
-    listStyle?: 'decimal' | 'disc'
+    listClassNames?: string[]
     maxDepth?: string | number
     minDepth?: string | number
     mode?: 'all' | 'onlyCurrentTree' | 'onlySiblings'
   }>(),
   {
     columns: 1,
-    listStyle: 'decimal',
+    listClassNames: () => [],
     maxDepth: Infinity,
     minDepth: 1,
     mode: 'all',
@@ -80,6 +80,6 @@ const toc = computed(() => {
 
 <template>
   <div class="slidev-toc" :style="`column-count:${columns}`">
-    <TocList :level="1" :list="toc" :list-style="listStyle" />
+    <TocList :level="1" :list="toc" :list-style="listClassNames" />
   </div>
 </template>

--- a/packages/client/builtin/Toc.vue
+++ b/packages/client/builtin/Toc.vue
@@ -80,6 +80,6 @@ const toc = computed(() => {
 
 <template>
   <div class="slidev-toc" :style="`column-count:${columns}`">
-    <TocList :level="1" :list="toc" :list-style="listClassNames" />
+    <TocList :level="1" :list="toc" :list-class-names="listClassNames" />
   </div>
 </template>

--- a/packages/client/builtin/TocList.vue
+++ b/packages/client/builtin/TocList.vue
@@ -12,15 +12,15 @@ import type { TocItem } from '../logic/nav'
 withDefaults(defineProps<{
   level: number
   list: TocItem[]
-  listStyle: 'decimal' | 'disc'
+  listClassNames: string[]
 }>(), { level: 1 })
 </script>
 
 <template>
-  <ul v-if="list && list.length > 0" :class="[`!list-${listStyle}`, 'slidev-toc-list', `slidev-toc-list-level-${level}`]">
+  <ol v-if="list && list.length > 0" :class="[...listClassNames, 'slidev-toc-list', `slidev-toc-list-level-${level}`]">
     <li v-for="item in list" :key="item.path" :class="['slidev-toc-item', {'slidev-toc-item-active': item.active}, {'slidev-toc-item-parent-active': item.activeParent}]">
       <RouterLink :to="item.path" v-html="item.title" />
-      <TocList :level="level + 1" :list="item.children" :list-style="listStyle" />
+      <TocList :level="level + 1" :list="item.children" :list-style="listClassNames" />
     </li>
-  </ul>
+  </ol>
 </template>

--- a/packages/client/builtin/TocList.vue
+++ b/packages/client/builtin/TocList.vue
@@ -12,14 +12,15 @@ import type { TocItem } from '../logic/nav'
 withDefaults(defineProps<{
   level: number
   list: TocItem[]
+  listStyle: 'decimal' | 'disc'
 }>(), { level: 1 })
 </script>
 
 <template>
-  <ul v-if="list && list.length > 0" :class="['slidev-toc-list', `slidev-toc-list-level-${level}`]">
+  <ul v-if="list && list.length > 0" :class="[`!list-${listStyle}`, 'slidev-toc-list', `slidev-toc-list-level-${level}`]">
     <li v-for="item in list" :key="item.path" :class="['slidev-toc-item', {'slidev-toc-item-active': item.active}, {'slidev-toc-item-parent-active': item.activeParent}]">
       <RouterLink :to="item.path" v-html="item.title" />
-      <TocList :level="level + 1" :list="item.children" />
+      <TocList :level="level + 1" :list="item.children" :list-style="listStyle" />
     </li>
   </ul>
 </template>

--- a/packages/client/builtin/TocList.vue
+++ b/packages/client/builtin/TocList.vue
@@ -7,20 +7,30 @@ Usage:
 <TocList :list="list"/>
 -->
 <script setup lang="ts">
+import { computed } from 'vue'
+import { toArray } from '@antfu/utils'
 import type { TocItem } from '../logic/nav'
 
-withDefaults(defineProps<{
+const props = withDefaults(defineProps<{
   level: number
   list: TocItem[]
-  listClassNames: string[]
+  listClass?: string | string[]
 }>(), { level: 1 })
+
+const classes = computed(() => {
+  return [
+    ...toArray(props.listClass || []),
+    'slidev-toc-list',
+    `slidev-toc-list-level-${props.level}`,
+  ]
+})
 </script>
 
 <template>
-  <ol v-if="list && list.length > 0" :class="[...listClassNames, 'slidev-toc-list', `slidev-toc-list-level-${level}`]">
+  <ol v-if="list && list.length > 0" :class="classes">
     <li v-for="item in list" :key="item.path" :class="['slidev-toc-item', {'slidev-toc-item-active': item.active}, {'slidev-toc-item-parent-active': item.activeParent}]">
       <RouterLink :to="item.path" v-html="item.title" />
-      <TocList :level="level + 1" :list="item.children" :list-class-names="listClassNames" />
+      <TocList :level="level + 1" :list="item.children" :list-class="listClass" />
     </li>
   </ol>
 </template>

--- a/packages/client/builtin/TocList.vue
+++ b/packages/client/builtin/TocList.vue
@@ -20,7 +20,7 @@ withDefaults(defineProps<{
   <ol v-if="list && list.length > 0" :class="[...listClassNames, 'slidev-toc-list', `slidev-toc-list-level-${level}`]">
     <li v-for="item in list" :key="item.path" :class="['slidev-toc-item', {'slidev-toc-item-active': item.active}, {'slidev-toc-item-parent-active': item.activeParent}]">
       <RouterLink :to="item.path" v-html="item.title" />
-      <TocList :level="level + 1" :list="item.children" :list-style="listClassNames" />
+      <TocList :level="level + 1" :list="item.children" :list-class-names="listClassNames" />
     </li>
   </ol>
 </template>


### PR DESCRIPTION
Currently, using `<Toc />` merely offers a disc styled list but table of contents usually want numeric numbering.

With this PR, the `<Toc />` list style becomes configurable using the added prop `listStyle` which allows `decimal`and `disc` and defaults to `decimal`.