### PR TITLE
fix: toc links keep keyboard focus in firefox

### DIFF
--- a/packages/client/builtin/TocList.vue
+++ b/packages/client/builtin/TocList.vue
@@ -18,7 +18,7 @@ withDefaults(defineProps<{
 <template>
   <ul v-if="list && list.length > 0" :class="['slidev-toc-list', `slidev-toc-list-level-${level}`]">
     <li v-for="item in list" :key="item.path" :class="['slidev-toc-item', {'slidev-toc-item-active': item.active}, {'slidev-toc-item-parent-active': item.activeParent}]">
-      <RouterLink :to="item.path" v-html="item.title" />
+      <RouterLink :to="item.path" @click="$event.target.blur()" v-html="item.title" />
       <TocList :level="level + 1" :list="item.children" />
     </li>
   </ul>


### PR DESCRIPTION
fixes https://github.com/slidevjs/slidev/issues/499

Here is a PR if it is ok to fix it this way (explicit inline $event.target.blur()).

Maybe something more general would be needed, e.g., I can imagine focusing the slide div when navigation occurs.