### PR TITLE
feat: add toc compact mode

### DIFF
--- a/packages/client/builtin/Toc.vue
+++ b/packages/client/builtin/Toc.vue
@@ -17,7 +17,7 @@ const props = withDefaults(
     columns?: string | number
     maxDepth?: string | number
     minDepth?: string | number
-    mode?: 'all' | 'onlyCurrentTree' | 'onlySiblings'
+    mode?: 'all' | 'onlyCurrentTree' | 'onlySiblings' | 'allDots'
   }>(),
   {
     columns: 1,
@@ -78,6 +78,6 @@ const toc = computed(() => {
 
 <template>
   <div class="slidev-toc" :style="`column-count:${columns}`">
-    <TocList :level="1" :list="toc" />
+    <TocList :level="1" :list="toc" :mode="mode === 'allDots' ? 'span' : 'ul'" />
   </div>
 </template>

--- a/packages/client/builtin/TocList.vue
+++ b/packages/client/builtin/TocList.vue
@@ -21,7 +21,7 @@ withDefaults(defineProps<{
 <template>
   <ul v-if="mode === 'ul' && list && list.length > 0" :class="['slidev-toc-list', `slidev-toc-list-level-${level}`]">
     <li v-for="item in list" :key="item.path" :class="['slidev-toc-item', {'slidev-toc-item-active': item.active}, {'slidev-toc-item-parent-active': item.activeParent}]">
-      <RouterLink :to="item.path" v-html="item.title" />
+      <a :class="{active: item.active}" @click="router.push({ path: item.path })" v-html="item.title" />
       <TocList :level="level + 1" :list="item.children" />
     </li>
   </ul>

--- a/packages/client/builtin/TocList.vue
+++ b/packages/client/builtin/TocList.vue
@@ -27,7 +27,10 @@ withDefaults(defineProps<{
   </ul>
   <template v-if="mode === 'span' && list && list.length > 0">
     <template v-for="item in list" :key="item.path">
-      <a :class="{dot: true, active: item.active}" @click="router.push({ path: item.path })">
+      <a
+        :class="['slidev-toc-dot', item.active ? 'slidev-toc-dot-active' : '', `slidev-toc-dot-level-${level}`]"
+        @click="router.push({ path: item.path })"
+      >
         {{ dots[Math.min(level, dots.length) - 1] }}
       </a>
       <TocList :level="level + 1" :list="item.children" :mode="mode" :dots="dots" />
@@ -36,11 +39,11 @@ withDefaults(defineProps<{
 </template>
 
 <style>
-    .dark .dot { filter: invert();}
+    .dark .slidev-toc-dot { filter: invert();}
 </style>
 <style scoped>
     a { cursor: pointer; border-bottom-width: 0 !important;}
-    .dot:hover { color: red !important; }
-    .dot { font-size: 0.65em; color: #444; text-shadow: white 0 0 2px; margin: 0 .05em; }
-    .dot.active ~ .dot { color: #bbb; }
+    .slidev-toc-dot:hover { color: red !important; }
+    .slidev-toc-dot { font-size: 0.65em; color: #444; text-shadow: white 0 0 2px; margin: 0 .05em; }
+    .slidev-toc-dot-active ~ .slidev-toc-dot { color: #bbb; }
 </style>

--- a/packages/client/builtin/TocList.vue
+++ b/packages/client/builtin/TocList.vue
@@ -8,18 +8,29 @@ Usage:
 -->
 <script setup lang="ts">
 import type { TocItem } from '../logic/nav'
+import { router } from '../routes'
 
 withDefaults(defineProps<{
   level: number
   list: TocItem[]
-}>(), { level: 1 })
+  mode?: 'ul' | 'span'
+  dots?: string
+}>(), { level: 1, mode: 'ul', dots: '●○◌◡.' })
 </script>
 
 <template>
-  <ul v-if="list && list.length > 0" :class="['slidev-toc-list', `slidev-toc-list-level-${level}`]">
+  <ul v-if="mode === 'ul' && list && list.length > 0" :class="['slidev-toc-list', `slidev-toc-list-level-${level}`]">
     <li v-for="item in list" :key="item.path" :class="['slidev-toc-item', {'slidev-toc-item-active': item.active}, {'slidev-toc-item-parent-active': item.activeParent}]">
       <RouterLink :to="item.path" v-html="item.title" />
       <TocList :level="level + 1" :list="item.children" />
     </li>
   </ul>
+  <template v-if="mode === 'span' && list && list.length > 0">
+    <template v-for="item in list" :key="item.path">
+      <a :class="{dot: true, active: item.active}" @click="router.push({ path: item.path })">
+        {{ dots[Math.min(level, dots.length) - 1] }}
+      </a>
+      <TocList :level="level + 1" :list="item.children" :mode="mode" :dots="dots" />
+    </template>
+  </template>
 </template>

--- a/packages/client/builtin/TocList.vue
+++ b/packages/client/builtin/TocList.vue
@@ -34,3 +34,13 @@ withDefaults(defineProps<{
     </template>
   </template>
 </template>
+
+<style>
+    .dark .dot { filter: invert();}
+</style>
+<style scoped>
+    a { cursor: pointer; border-bottom-width: 0 !important;}
+    .dot:hover { color: red !important; }
+    .dot { font-size: 0.65em; color: #444; text-shadow: white 0 0 2px; margin: 0 .05em; }
+    .dot.active ~ .dot { color: #bbb; }
+</style>


### PR DESCRIPTION
This PR adds a mode for toc `<Toc mode="allDots"/>` to show a concise TOC (e.g., to be put as a footer) that allows quick navigation and shows progress (inspired by beamer).

Possible design problems:
- there is some default style, maybe it should be in the theme?
- currently, the allDots is a mode so it is exclusive with other modes (that do not display all points)

This PR is adding some new links so it also fixes the focus problem #499, instead of adding more focus problem.
