### PR TITLE
feat: expose ServerRef state

### DIFF
--- a/packages/slidev/node/options.ts
+++ b/packages/slidev/node/options.ts
@@ -5,6 +5,7 @@ import type Components from 'unplugin-vue-components/vite'
 import type Markdown from 'vite-plugin-md'
 import type WindiCSS from 'vite-plugin-windicss'
 import type RemoteAssets from 'vite-plugin-remote-assets'
+import type ServerRef from 'vite-plugin-vue-server-ref'
 import type { ArgumentsType } from '@antfu/utils'
 import { uniq } from '@antfu/utils'
 import type { SlidevMarkdown } from '@slidev/types'
@@ -55,6 +56,7 @@ export interface SlidevPluginOptions extends SlidevEntryOptions {
   windicss?: ArgumentsType<typeof WindiCSS>[0]
   icons?: ArgumentsType<typeof Icons>[0]
   remoteAssets?: ArgumentsType<typeof RemoteAssets>[0]
+  serverRef?: ArgumentsType<typeof ServerRef>[0]
 }
 
 export interface SlidevServerOptions {

--- a/packages/slidev/node/plugins/preset.ts
+++ b/packages/slidev/node/plugins/preset.ts
@@ -58,6 +58,7 @@ export async function ViteSlidevPlugin(
     components: componentsOptions = {},
     icons: iconsOptions = {},
     remoteAssets: remoteAssetsOptions = {},
+    serverRef: serverRefOptions = {},
   } = pluginOptions
 
   const {
@@ -146,8 +147,10 @@ export async function ViteSlidevPlugin(
           clicks: 0,
         },
         drawings: drawingData,
+        ...serverRefOptions.state,
       },
-      onChanged(key, data, patch) {
+      onChanged(key, data, patch, timestamp) {
+        serverRefOptions.onChanged && serverRefOptions.onChanged(key, data, patch, timestamp)
         if (!options.data.config.drawings.persist)
           return
         if (key === 'drawings')


### PR DESCRIPTION
In some cases, I want to customize the state of server, such as drawing and sharing some data with other clients.