### PR TITLE
feat: multiple slides and recursive include for multi-entries

### DIFF
--- a/packages/parser/src/core.ts
+++ b/packages/parser/src/core.ts
@@ -6,6 +6,7 @@ import { resolveConfig } from './config'
 export function stringify(data: SlidevMarkdown) {
   return `${
     data.slides
+      .filter(slide => slide.source === undefined || slide.inline !== undefined)
       .map((slide, idx) => stringifySlide(slide.inline || slide, idx))
       .join('\n')
       .trim()

--- a/packages/parser/src/fs.ts
+++ b/packages/parser/src/fs.ts
@@ -39,7 +39,7 @@ export async function load(filepath: string, themeMeta?: SlidevThemeMeta, conten
         ...subSlide,
       }
 
-      if (offset === 0 && !baseSlide.frontmatter.srcseq) {
+      if (offset === 0 && !baseSlide.frontmatter.srcSequence) {
         slide.inline = { ...baseSlide }
         delete slide.inline.frontmatter.src
         Object.assign(slide, slide.source, { raw: null })
@@ -54,7 +54,7 @@ export async function load(filepath: string, themeMeta?: SlidevThemeMeta, conten
       slide.frontmatter = {
         ...subSlide.frontmatter,
         ...baseSlideFrontMatterWithoutSrc,
-        srcseq: `${baseSlide.frontmatter.srcseq ? `${baseSlide.frontmatter.srcseq},` : ''}${srcExpression}`,
+        srcSequence: `${baseSlide.frontmatter.srcSequence ? `${baseSlide.frontmatter.srcSequence},` : ''}${srcExpression}`,
       }
 
       data.features = mergeFeatureFlags(data.features, detectFeatures(raw))

--- a/test/__snapshots__/parser.test.ts.snap
+++ b/test/__snapshots__/parser.test.ts.snap
@@ -483,9 +483,9 @@ exports[`md parser > multi-entries.md > slides 1`] = `
     "content": "
 # Page 1
 ",
-    "end": 4,
+    "end": 2,
     "frontmatter": {
-      "src": "sub/page1.md",
+      "srcseq": "sub/page1.md",
       "title": undefined,
     },
     "index": 0,
@@ -493,7 +493,6 @@ exports[`md parser > multi-entries.md > slides 1`] = `
       "content": "",
       "end": 4,
       "frontmatter": {
-        "src": "sub/page1.md",
         "title": undefined,
       },
       "index": 0,
@@ -509,7 +508,7 @@ src: sub/page1.md
     "level": 1,
     "note": undefined,
     "raw": "---
-src: sub/page1.md
+srcseq: sub/page1.md
 ---
 
 # Page 1
@@ -517,11 +516,16 @@ src: sub/page1.md
 ",
     "source": {
       "content": "# Page 1",
-      "frontmatter": {},
+      "end": 2,
+      "frontmatter": {
+        "title": "Page 1",
+      },
+      "index": 0,
       "level": 1,
       "note": undefined,
       "raw": "# Page 1
 ",
+      "start": 0,
       "title": "Page 1",
     },
     "start": 0,
@@ -533,26 +537,26 @@ src: sub/page1.md
 
 <Tweet />
 ",
-    "end": 9,
+    "end": 8,
     "frontmatter": {
-      "background": "https://sli.dev/demo-cover.png",
+      "background": "https://sli.dev/demo-cover.png#2",
       "layout": "cover",
-      "src": "sub/page2.md",
+      "srcseq": "sub/page2.md",
+      "title": "Page 2",
     },
     "index": 1,
     "inline": {
       "content": "",
       "end": 9,
       "frontmatter": {
-        "background": "https://sli.dev/demo-cover.png",
-        "src": "sub/page2.md",
+        "background": "https://sli.dev/demo-cover.png#2",
       },
       "index": 1,
       "level": undefined,
       "note": undefined,
       "raw": "---
 src: sub/page2.md
-background: https://sli.dev/demo-cover.png
+background: https://sli.dev/demo-cover.png#2
 ---
 ",
       "start": 4,
@@ -562,8 +566,9 @@ background: https://sli.dev/demo-cover.png
     "note": undefined,
     "raw": "---
 layout: cover
-src: sub/page2.md
-background: https://sli.dev/demo-cover.png
+title: Page 2
+background: https://sli.dev/demo-cover.png#2
+srcseq: sub/page2.md
 ---
 
 # Page 2
@@ -575,9 +580,12 @@ background: https://sli.dev/demo-cover.png
       "content": "# Page 2
 
 <Tweet />",
+      "end": 8,
       "frontmatter": {
         "layout": "cover",
+        "title": "Page 2",
       },
+      "index": 0,
       "level": 1,
       "note": undefined,
       "raw": "---
@@ -588,10 +596,317 @@ layout: cover
 
 <Tweet />
 ",
+      "start": 0,
       "title": "Page 2",
     },
-    "start": 4,
+    "start": 0,
     "title": "Page 2",
+  },
+  {
+    "content": "
+# Page 3
+",
+    "end": 2,
+    "frontmatter": {
+      "background": "https://sli.dev/demo-cover.png#34",
+      "srcseq": "sub/pages3-4.md",
+      "title": "Page 3",
+    },
+    "index": 2,
+    "inline": {
+      "content": "",
+      "end": 14,
+      "frontmatter": {
+        "background": "https://sli.dev/demo-cover.png#34",
+      },
+      "index": 2,
+      "level": undefined,
+      "note": undefined,
+      "raw": "---
+src: sub/pages3-4.md
+background: https://sli.dev/demo-cover.png#34
+---
+",
+      "start": 9,
+      "title": undefined,
+    },
+    "level": 1,
+    "note": undefined,
+    "raw": "---
+title: Page 3
+background: https://sli.dev/demo-cover.png#34
+srcseq: sub/pages3-4.md
+---
+
+# Page 3
+
+",
+    "source": {
+      "content": "# Page 3",
+      "end": 2,
+      "frontmatter": {
+        "title": "Page 3",
+      },
+      "index": 0,
+      "level": 1,
+      "note": undefined,
+      "raw": "# Page 3
+",
+      "start": 0,
+      "title": "Page 3",
+    },
+    "start": 0,
+    "title": "Page 3",
+  },
+  {
+    "content": "
+# Page 4
+
+<Tweet />
+",
+    "end": 10,
+    "frontmatter": {
+      "background": "https://sli.dev/demo-cover.png#34",
+      "layout": "cover",
+      "srcseq": "sub/pages3-4.md",
+    },
+    "index": 3,
+    "level": 1,
+    "note": undefined,
+    "raw": "---
+layout: cover
+background: https://sli.dev/demo-cover.png#34
+srcseq: sub/pages3-4.md
+---
+
+# Page 4
+
+<Tweet />
+
+",
+    "source": {
+      "content": "# Page 4
+
+<Tweet />",
+      "end": 10,
+      "frontmatter": {
+        "layout": "cover",
+      },
+      "index": 1,
+      "level": 1,
+      "note": undefined,
+      "raw": "---
+layout: cover
+---
+
+# Page 4
+
+<Tweet />
+",
+      "start": 2,
+      "title": "Page 4",
+    },
+    "start": 2,
+    "title": "Page 4",
+  },
+  {
+    "content": "
+# Page 1
+",
+    "end": 2,
+    "frontmatter": {
+      "background": "https://sli.dev/demo-cover.png#14",
+      "srcseq": "sub/nested1-4.md,sub/page1.md",
+      "title": undefined,
+    },
+    "index": 4,
+    "inline": {
+      "content": "",
+      "end": 19,
+      "frontmatter": {
+        "background": "https://sli.dev/demo-cover.png#14",
+      },
+      "index": 3,
+      "level": undefined,
+      "note": undefined,
+      "raw": "---
+src: sub/nested1-4.md
+background: https://sli.dev/demo-cover.png#14
+---
+",
+      "start": 14,
+      "title": undefined,
+    },
+    "level": 1,
+    "note": undefined,
+    "raw": "---
+background: https://sli.dev/demo-cover.png#14
+srcseq: sub/nested1-4.md,sub/page1.md
+---
+
+# Page 1
+
+",
+    "source": {
+      "content": "# Page 1",
+      "end": 2,
+      "frontmatter": {
+        "title": "Page 1",
+      },
+      "index": 0,
+      "level": 1,
+      "note": undefined,
+      "raw": "# Page 1
+",
+      "start": 0,
+      "title": "Page 1",
+    },
+    "start": 0,
+    "title": "Page 1",
+  },
+  {
+    "content": "
+# Page 2
+
+<Tweet />
+",
+    "end": 8,
+    "frontmatter": {
+      "background": "https://sli.dev/demo-cover.png#14",
+      "layout": "cover",
+      "srcseq": "sub/nested1-4.md,sub/page2.md",
+      "title": "Page 2",
+    },
+    "index": 5,
+    "level": 1,
+    "note": undefined,
+    "raw": "---
+layout: cover
+title: Page 2
+background: https://sli.dev/demo-cover.png#14
+srcseq: sub/nested1-4.md,sub/page2.md
+---
+
+# Page 2
+
+<Tweet />
+
+",
+    "source": {
+      "content": "# Page 2
+
+<Tweet />",
+      "end": 8,
+      "frontmatter": {
+        "layout": "cover",
+        "title": "Page 2",
+      },
+      "index": 0,
+      "level": 1,
+      "note": undefined,
+      "raw": "---
+layout: cover
+---
+
+# Page 2
+
+<Tweet />
+",
+      "start": 0,
+      "title": "Page 2",
+    },
+    "start": 0,
+    "title": "Page 2",
+  },
+  {
+    "content": "
+# Page 3
+",
+    "end": 2,
+    "frontmatter": {
+      "background": "https://sli.dev/demo-cover.png#14",
+      "srcseq": "sub/nested1-4.md,sub/pages3-4.md",
+      "title": "Page 3",
+    },
+    "index": 6,
+    "level": 1,
+    "note": undefined,
+    "raw": "---
+title: Page 3
+background: https://sli.dev/demo-cover.png#14
+srcseq: sub/nested1-4.md,sub/pages3-4.md
+---
+
+# Page 3
+
+",
+    "source": {
+      "content": "# Page 3",
+      "end": 2,
+      "frontmatter": {
+        "title": "Page 3",
+      },
+      "index": 0,
+      "level": 1,
+      "note": undefined,
+      "raw": "# Page 3
+",
+      "start": 0,
+      "title": "Page 3",
+    },
+    "start": 0,
+    "title": "Page 3",
+  },
+  {
+    "content": "
+# Page 4
+
+<Tweet />
+",
+    "end": 10,
+    "frontmatter": {
+      "background": "https://sli.dev/demo-cover.png#14",
+      "layout": "cover",
+      "srcseq": "sub/nested1-4.md,sub/pages3-4.md",
+    },
+    "index": 7,
+    "level": 1,
+    "note": undefined,
+    "raw": "---
+layout: cover
+background: https://sli.dev/demo-cover.png#14
+srcseq: sub/nested1-4.md,sub/pages3-4.md
+---
+
+# Page 4
+
+<Tweet />
+
+",
+    "source": {
+      "content": "# Page 4
+
+<Tweet />",
+      "end": 10,
+      "frontmatter": {
+        "layout": "cover",
+      },
+      "index": 1,
+      "level": 1,
+      "note": undefined,
+      "raw": "---
+layout: cover
+---
+
+# Page 4
+
+<Tweet />
+",
+      "start": 2,
+      "title": "Page 4",
+    },
+    "start": 2,
+    "title": "Page 4",
   },
   {
     "content": "
@@ -599,9 +914,9 @@ layout: cover
 
 $x+2$
 ",
-    "end": 15,
+    "end": 25,
     "frontmatter": {},
-    "index": 2,
+    "index": 8,
     "level": 1,
     "note": undefined,
     "raw": "
@@ -610,7 +925,7 @@ $x+2$
 $x+2$
 
 ",
-    "start": 10,
+    "start": 20,
     "title": "Inline Page",
   },
 ]

--- a/test/__snapshots__/parser.test.ts.snap
+++ b/test/__snapshots__/parser.test.ts.snap
@@ -485,7 +485,7 @@ exports[`md parser > multi-entries.md > slides 1`] = `
 ",
     "end": 2,
     "frontmatter": {
-      "srcseq": "sub/page1.md",
+      "srcSequence": "sub/page1.md",
       "title": undefined,
     },
     "index": 0,
@@ -508,7 +508,7 @@ src: sub/page1.md
     "level": 1,
     "note": undefined,
     "raw": "---
-srcseq: sub/page1.md
+srcSequence: sub/page1.md
 ---
 
 # Page 1
@@ -541,7 +541,7 @@ srcseq: sub/page1.md
     "frontmatter": {
       "background": "https://sli.dev/demo-cover.png#2",
       "layout": "cover",
-      "srcseq": "sub/page2.md",
+      "srcSequence": "sub/page2.md",
       "title": "Page 2",
     },
     "index": 1,
@@ -568,7 +568,7 @@ background: https://sli.dev/demo-cover.png#2
 layout: cover
 title: Page 2
 background: https://sli.dev/demo-cover.png#2
-srcseq: sub/page2.md
+srcSequence: sub/page2.md
 ---
 
 # Page 2
@@ -609,7 +609,7 @@ layout: cover
     "end": 2,
     "frontmatter": {
       "background": "https://sli.dev/demo-cover.png#34",
-      "srcseq": "sub/pages3-4.md",
+      "srcSequence": "sub/pages3-4.md",
       "title": "Page 3",
     },
     "index": 2,
@@ -635,7 +635,7 @@ background: https://sli.dev/demo-cover.png#34
     "raw": "---
 title: Page 3
 background: https://sli.dev/demo-cover.png#34
-srcseq: sub/pages3-4.md
+srcSequence: sub/pages3-4.md
 ---
 
 # Page 3
@@ -668,7 +668,7 @@ srcseq: sub/pages3-4.md
     "frontmatter": {
       "background": "https://sli.dev/demo-cover.png#34",
       "layout": "cover",
-      "srcseq": "sub/pages3-4.md",
+      "srcSequence": "sub/pages3-4.md",
     },
     "index": 3,
     "level": 1,
@@ -676,7 +676,7 @@ srcseq: sub/pages3-4.md
     "raw": "---
 layout: cover
 background: https://sli.dev/demo-cover.png#34
-srcseq: sub/pages3-4.md
+srcSequence: sub/pages3-4.md
 ---
 
 # Page 4
@@ -716,7 +716,7 @@ layout: cover
     "end": 2,
     "frontmatter": {
       "background": "https://sli.dev/demo-cover.png#14",
-      "srcseq": "sub/nested1-4.md,sub/page1.md",
+      "srcSequence": "sub/nested1-4.md,sub/page1.md",
       "title": undefined,
     },
     "index": 4,
@@ -741,7 +741,7 @@ background: https://sli.dev/demo-cover.png#14
     "note": undefined,
     "raw": "---
 background: https://sli.dev/demo-cover.png#14
-srcseq: sub/nested1-4.md,sub/page1.md
+srcSequence: sub/nested1-4.md,sub/page1.md
 ---
 
 # Page 1
@@ -774,7 +774,7 @@ srcseq: sub/nested1-4.md,sub/page1.md
     "frontmatter": {
       "background": "https://sli.dev/demo-cover.png#14",
       "layout": "cover",
-      "srcseq": "sub/nested1-4.md,sub/page2.md",
+      "srcSequence": "sub/nested1-4.md,sub/page2.md",
       "title": "Page 2",
     },
     "index": 5,
@@ -784,7 +784,7 @@ srcseq: sub/nested1-4.md,sub/page1.md
 layout: cover
 title: Page 2
 background: https://sli.dev/demo-cover.png#14
-srcseq: sub/nested1-4.md,sub/page2.md
+srcSequence: sub/nested1-4.md,sub/page2.md
 ---
 
 # Page 2
@@ -825,7 +825,7 @@ layout: cover
     "end": 2,
     "frontmatter": {
       "background": "https://sli.dev/demo-cover.png#14",
-      "srcseq": "sub/nested1-4.md,sub/pages3-4.md",
+      "srcSequence": "sub/nested1-4.md,sub/pages3-4.md",
       "title": "Page 3",
     },
     "index": 6,
@@ -834,7 +834,7 @@ layout: cover
     "raw": "---
 title: Page 3
 background: https://sli.dev/demo-cover.png#14
-srcseq: sub/nested1-4.md,sub/pages3-4.md
+srcSequence: sub/nested1-4.md,sub/pages3-4.md
 ---
 
 # Page 3
@@ -867,7 +867,7 @@ srcseq: sub/nested1-4.md,sub/pages3-4.md
     "frontmatter": {
       "background": "https://sli.dev/demo-cover.png#14",
       "layout": "cover",
-      "srcseq": "sub/nested1-4.md,sub/pages3-4.md",
+      "srcSequence": "sub/nested1-4.md,sub/pages3-4.md",
     },
     "index": 7,
     "level": 1,
@@ -875,7 +875,7 @@ srcseq: sub/nested1-4.md,sub/pages3-4.md
     "raw": "---
 layout: cover
 background: https://sli.dev/demo-cover.png#14
-srcseq: sub/nested1-4.md,sub/pages3-4.md
+srcSequence: sub/nested1-4.md,sub/pages3-4.md
 ---
 
 # Page 4

--- a/test/fixtures/markdown/multi-entries.md
+++ b/test/fixtures/markdown/multi-entries.md
@@ -4,7 +4,17 @@ src: sub/page1.md
 
 ---
 src: sub/page2.md
-background: https://sli.dev/demo-cover.png
+background: https://sli.dev/demo-cover.png#2
+---
+
+---
+src: sub/pages3-4.md
+background: https://sli.dev/demo-cover.png#34
+---
+
+---
+src: sub/nested1-4.md
+background: https://sli.dev/demo-cover.png#14
 ---
 
 ---

--- a/test/fixtures/markdown/sub/nested1-4.md
+++ b/test/fixtures/markdown/sub/nested1-4.md
@@ -1,0 +1,11 @@
+---
+src: sub/page1.md
+---
+
+---
+src: sub/page2.md
+---
+
+---
+src: sub/pages3-4.md
+---

--- a/test/fixtures/markdown/sub/pages3-4.md
+++ b/test/fixtures/markdown/sub/pages3-4.md
@@ -1,0 +1,9 @@
+# Page 3
+
+---
+layout: cover
+---
+
+# Page 4
+
+<Tweet />


### PR DESCRIPTION
This PR allows an md file included with `src: ....` to contain several slides and also to itself include another md file recursively (with no limit on the depth). I've added some tests, limited to two levels: a src that contains a src (that itself contains several slides).

Given that the slides are now parsed, a few things change in the result (notes are parsed, `title:` frontmatter get added, ...).

A possible ugliness in the proposed implementation is that the frontmatter (that originally contains `src`) is rewritten as `srcseq` to keep track of the nested includes, as in https://github.com/slidevjs/slidev/compare/main...twitwi:allow-multiple-slides-in-src?expand=1#diff-71214303b78b0f2ebd638a82b7608f2dc802d4e43f81895ca44bbcf66f3f5088R719

----

fixes: https://github.com/slidevjs/slidev/issues/506
fixes: https://github.com/slidevjs/slidev/issues/449 (I guess)
fixes: https://github.com/slidevjs/slidev/issues/327 (as sub md are now parsed)
fixes: https://github.com/slidevjs/slidev/issues/291

see also: https://github.com/slidevjs/slidev/issues/53