### PR TITLE
fix: use timeout arg for the goto() function

### DIFF
--- a/packages/slidev/node/cli.ts
+++ b/packages/slidev/node/cli.ts
@@ -303,7 +303,7 @@ cli.command(
       describe: 'output format',
     })
     .option('timeout', {
-      default: 500,
+      default: 30000,
       type: 'number',
       describe: 'timeout for rendering each page',
     })

--- a/packages/slidev/node/export.ts
+++ b/packages/slidev/node/export.ts
@@ -66,7 +66,7 @@ export async function exportSlides({
   output = 'slides',
   slides,
   base = '/',
-  timeout = 500,
+  timeout = 30000,
   dark = false,
   routerMode = 'history',
   width = 1920,
@@ -98,6 +98,7 @@ export async function exportSlides({
       : `http://localhost:${port}${base}${path}`
     await page.goto(url, {
       waitUntil: 'networkidle',
+      timeout,
     })
     await page.waitForLoadState('networkidle')
     await page.emulateMedia({ colorScheme: dark ? 'dark' : 'light', media: 'screen' })
@@ -113,7 +114,6 @@ export async function exportSlides({
     // Wait for frames to load
     const frames = await page.frames()
     await Promise.all(frames.map(frame => frame.waitForLoadState()))
-    await page.waitForTimeout(timeout)
   }
 
   async function genPagePdf() {


### PR DESCRIPTION
Fixes https://github.com/slidevjs/slidev/issues/542

With this PR https://github.com/slidevjs/slidev/pull/513, the `await page.waitForTimeout(timeout)` does not seems to be needed anymore.
The goal of this PR is to reuse the `timeout` arg you can pass to the `slidev export` command to be able to increase the timeout of `page.goto()` and to be able to generate the export in failing scenarios.