### PR TITLE
fix: blur router links to give back the focus to the slides

### DIFF
--- a/packages/client/builtin/Link.vue
+++ b/packages/client/builtin/Link.vue
@@ -17,8 +17,8 @@ defineProps<{
 </script>
 
 <template>
-  <RouterLink v-if="!isPrintMode && title" :to="to" v-html="title" />
-  <RouterLink v-else-if="!isPrintMode && !title" :to="to">
+  <RouterLink v-if="!isPrintMode && title" :to="to" @click="$event.target.blur()" v-html="title" />
+  <RouterLink v-else-if="!isPrintMode && !title" :to="to" @click="$event.target.blur()">
     <slot />
   </RouterLink>
   <a v-else-if="isPrintMode && title" :href="'#' + to" v-html="title" />

--- a/packages/client/builtin/TocList.vue
+++ b/packages/client/builtin/TocList.vue
@@ -34,7 +34,7 @@ const classes = computed(() => {
       <Link :to="item.path">
         <Titles :no="item.path" />
       </Link>
-      <TocList :level="level + 1" :list="item.children" :list-class="listClass" />
+      <TocList v-if="item.children.length > 0" :level="level + 1" :list="item.children" :list-class="listClass" />
     </li>
   </ol>
 </template>


### PR DESCRIPTION
fixes https://github.com/slidevjs/slidev/issues/499

Also cleans up some empty TocList elements (I found it while working on the fix but I can do a second PR if needed)
More visually, the second commit removes the TocList-s between the Link-s

![image](https://user-images.githubusercontent.com/244649/163262989-0c27d6fe-7810-4e1b-a96c-dcdf064063ae.png) -> ![image](https://user-images.githubusercontent.com/244649/163263087-c86d338c-aec4-4d96-809a-9fbf11e3d70d.png)

