### PR TITLE
feat: allow serving several presentations using several servers

### DIFF
--- a/packages/slidev/node/cli.ts
+++ b/packages/slidev/node/cli.ts
@@ -71,7 +71,7 @@ cli.command(
     })
     .strict()
     .help(),
-  async({ entry, theme, port: userPort, open, log, remote, force, secondary }) => {
+  async({ entry: mainEntry, theme, port: userPort, open, log, remote, force, secondary }) => {
     async function startServerFor(entry: string, targetPort: number, isPrimary: boolean) {
       if (!fs.existsSync(entry) && !entry.endsWith('.md'))
         entry = `${entry}.md`
@@ -180,13 +180,12 @@ cli.command(
     }
     const primaryPort = userPort || await findFreePort(3030)
     if (secondary) {
-      const secondaries = secondary.split(',')
-      for (let i = 0; i < secondaries.length; i++) {
+      for (let i = 0; i < secondary.length; i++) {
         const secondaryPort = await findFreePort(primaryPort + 1 + i)
-        await startServerFor(secondaries[i], secondaryPort, false)
+        await startServerFor(secondary[i] as string, secondaryPort, false)
       }
     }
-    await startServerFor(entry, primaryPort, true)
+    await startServerFor(mainEntry, primaryPort, true)
   },
 )
 
@@ -398,7 +397,7 @@ function commonOptions(args: Argv<{}>) {
       describe: 'override theme',
     })
     .option('secondary', {
-      type: 'string',
+      type: 'array',
       describe: 'more md files to host',
     })
 }

--- a/packages/slidev/node/cli.ts
+++ b/packages/slidev/node/cli.ts
@@ -125,7 +125,7 @@ cli.command(
         printInfo(options, port, remote, isPrimary)
       }
 
-      initServer()
+      await initServer()
       if (isPrimary) {
         const SHORTCUTS = [
           {


### PR DESCRIPTION
Current status:
can run `slidev --secondary slides2.md slides3.md` to serve:
- `slides.md` as usual
- `slides2.md` on port n+1
- `slides3.md` on port n+2

NB:
- might need to reconsider the cli api (just allow several file names? ... but it seems difficult with yargs + typescript)
- nothing about export is implemented yet

Will eventually fix:
- https://github.com/slidevjs/slidev/issues/317
- https://github.com/slidevjs/slidev/issues/479
- https://github.com/slidevjs/slidev/issues/505 