### PR TITLE
feat: allow routeAlias frontmatter to be able to link to slides by name

### DIFF
--- a/packages/client/internals/Goto.vue
+++ b/packages/client/internals/Goto.vue
@@ -1,16 +1,29 @@
 <script setup lang="ts">
 import { computed, nextTick, ref, watch } from 'vue'
-import { go, total } from '../logic/nav'
+import { go, rawRoutes, total } from '../logic/nav'
 import { showGotoDialog } from '../state'
 
 const input = ref<HTMLInputElement>()
 const text = ref('')
-const num = computed(() => +text.value)
-const valid = computed(() => !isNaN(num.value) && num.value > 0 && num.value <= total.value)
+
+const valid = computed(() => {
+  if (text.value.startsWith('/')) {
+    return !!rawRoutes.find(r => r.path === text.value.substring(1))
+  }
+  else {
+    const num = +text.value
+    return !isNaN(num) && num > 0 && num <= total.value
+  }
+})
 
 function goTo() {
-  if (valid.value)
-    go(num.value)
+  if (valid.value) {
+    if (text.value.startsWith('/'))
+      go(text.value.substring(1))
+
+    else
+      go(+text.value)
+  }
   close()
 }
 
@@ -31,8 +44,8 @@ watch(showGotoDialog, async(show) => {
 
 // remove the g character coming from the key that triggered showGotoDialog (e.g. in Firefox)
 watch(text, (t) => {
-  if (t.match(/^[^0-9]/))
-    text.value = text.value.substr(1)
+  if (t.match(/^[^0-9/]/))
+    text.value = text.value.substring(1)
 })
 </script>
 

--- a/packages/client/logic/nav.ts
+++ b/packages/client/logic/nav.ts
@@ -113,7 +113,7 @@ export async function prevSlide(lastClicks = true) {
     router.replace({ query: { ...route.value.query, clicks: clicksTotal.value } })
 }
 
-export function go(page: number, clicks?: number) {
+export function go(page: number | string, clicks?: number) {
   return router.push({ path: getPath(page), query: { ...route.value.query, clicks } })
 }
 

--- a/packages/slidev/node/plugins/loaders.ts
+++ b/packages/slidev/node/plugins/loaders.ts
@@ -529,9 +529,11 @@ defineProps<{ no: number | string }>()`)
           }
           const meta = Object.assign({}, i.frontmatter, additions)
           const route = `{ path: '${no}', name: 'page-${no}', component: n${no}, meta: ${JSON.stringify(meta)} }`
+          const redirect = i.frontmatter?.routeAlias ? `{ path: '${i.frontmatter?.routeAlias}', redirect: { path: '${no}' } }` : null
           no += 1
-          return route
+          return [route, redirect]
         })
+        .flat()
         .filter(notNullish),
       `{ path: "${no}", component: __layout__end, meta: { layout: "end" } }`,
     ]


### PR DESCRIPTION
Currently working with with internal links only, i.e. in a `<Link to="..." />` but not as a bookmark (visiting directly the page), no idea why...