### PR TITLE
Feat/standalone presenter mode

### DIFF
--- a/packages/client/env.ts
+++ b/packages/client/env.ts
@@ -3,12 +3,8 @@ import { computed } from 'vue'
 import { objectMap } from '@antfu/utils'
 // @ts-expect-error missing types
 import _configs from '/@slidev/configs'
-import _serverDrawingState from 'server-reactive:drawings?diff'
-import type { ServerReactive } from 'vite-plugin-vue-server-ref'
 
-export const serverDrawingState = _serverDrawingState as ServerReactive<Record<number, string | undefined>>
 export const configs = _configs as SlidevConfig
-
 export const slideAspect = configs.aspectRatio ?? (16 / 9)
 export const slideWidth = configs.canvasWidth ?? 980
 export const slideHeight = Math.round(slideWidth / slideAspect)

--- a/packages/client/env.ts
+++ b/packages/client/env.ts
@@ -3,20 +3,9 @@ import { computed } from 'vue'
 import { objectMap } from '@antfu/utils'
 // @ts-expect-error missing types
 import _configs from '/@slidev/configs'
-import _serverState from 'server-reactive:nav'
 import _serverDrawingState from 'server-reactive:drawings?diff'
 import type { ServerReactive } from 'vite-plugin-vue-server-ref'
 
-export interface ServerState {
-  page: number
-  clicks: number
-  cursor?: {
-    x: number
-    y: number
-  }
-}
-
-export const serverState = _serverState as ServerReactive<ServerState>
 export const serverDrawingState = _serverDrawingState as ServerReactive<Record<number, string | undefined>>
 export const configs = _configs as SlidevConfig
 

--- a/packages/client/internals/NavControls.vue
+++ b/packages/client/internals/NavControls.vue
@@ -108,7 +108,7 @@ if (__SLIDEV_FEATURE_DRAWINGS__)
         <VerticalDivider />
       </template>
 
-      <template v-if="__DEV__ && !isEmbedded">
+      <template v-if="!isEmbedded">
         <RouterLink v-if="isPresenter" :to="nonPresenterLink" class="icon-btn" title="Play Mode">
           <carbon:presentation-file />
         </RouterLink>
@@ -116,7 +116,7 @@ if (__SLIDEV_FEATURE_DRAWINGS__)
           <carbon:user-speaker />
         </RouterLink>
 
-        <button v-if="!isPresenter" class="icon-btn <md:hidden" @click="showEditor = !showEditor">
+        <button v-if="__DEV__ && !isPresenter" class="icon-btn <md:hidden" @click="showEditor = !showEditor">
           <carbon:text-annotation-toggle />
         </button>
       </template>

--- a/packages/client/internals/Presenter.vue
+++ b/packages/client/internals/Presenter.vue
@@ -4,7 +4,8 @@ import { computed, onMounted, reactive, ref, watch } from 'vue'
 import { useMouse, useWindowFocus } from '@vueuse/core'
 import { clicks, clicksTotal, currentPage, currentRoute, hasNext, nextRoute, total, useSwipeControls } from '../logic/nav'
 import { showOverview, showPresenterCursor } from '../state'
-import { configs, serverState, themeVars } from '../env'
+import { configs, themeVars } from '../env'
+import { sharedState } from '../state/shared'
 import { registerShortcuts } from '../logic/shortcuts'
 import { getSlideClass } from '../utils'
 import { useTimer } from '../logic/utils'
@@ -72,7 +73,7 @@ onMounted(() => {
       return { x, y }
     },
     (pos) => {
-      serverState.cursor = pos
+      sharedState.cursor = pos
     },
   )
 })

--- a/packages/client/internals/PresenterMouse.vue
+++ b/packages/client/internals/PresenterMouse.vue
@@ -1,15 +1,15 @@
 <script setup lang="ts">
-import { serverState } from '../env'
+import { sharedState } from '../state/shared'
 </script>
 
 <template>
   <div
-    v-if="serverState.cursor"
+    v-if="sharedState.cursor"
     class="absolute top-0 left-0 right-0 bottom-0 pointer-events-none text-xl"
   >
     <ph:cursor-fill
       class="absolute"
-      :style="{ left: `${serverState.cursor.x}%`, top: `${serverState.cursor.y}%` }"
+      :style="{ left: `${sharedState.cursor.x}%`, top: `${sharedState.cursor.y}%` }"
     />
   </div>
 </template>

--- a/packages/client/logic/note.ts
+++ b/packages/client/logic/note.ts
@@ -35,10 +35,12 @@ export function useSlideInfo(id: number | undefined): UseSlideInfo {
     ).then(r => r.json())
   }
 
-  import.meta.hot?.on('slidev-update', (payload) => {
-    if (payload.id === id)
-      info.value = payload.data
-  })
+  if (__DEV__) {
+    import.meta.hot?.on('slidev-update', (payload) => {
+      if (payload.id === id)
+        info.value = payload.data
+    })
+  }
 
   return {
     info,

--- a/packages/client/routes.ts
+++ b/packages/client/routes.ts
@@ -19,21 +19,16 @@ export const routes: RouteRecordRaw[] = [
   { name: 'print', path: '/print', component: Print },
   { path: '', redirect: { path: '/1' } },
   { path: '/:pathMatch(.*)', redirect: { path: '/1' } },
+  {
+    name: 'presenter',
+    path: '/presenter/:no',
+    component: () => import('./internals/Presenter.vue'),
+  },
+  {
+    path: '/presenter',
+    redirect: { path: '/presenter/1' },
+  },
 ]
-
-if (import.meta.env.DEV) {
-  routes.push(
-    {
-      name: 'presenter',
-      path: '/presenter/:no',
-      component: () => import('./internals/Presenter.vue'),
-    },
-    {
-      path: '/presenter',
-      redirect: { path: '/presenter/1' },
-    },
-  )
-}
 
 export const router = createRouter({
   history: __SLIDEV_HASH_ROUTE__ ? createWebHashHistory(import.meta.env.BASE_URL) : createWebHistory(import.meta.env.BASE_URL),

--- a/packages/client/setup/root.ts
+++ b/packages/client/setup/root.ts
@@ -1,8 +1,11 @@
 /* __imports__ */
+import { watch } from 'vue'
 import { useHead } from '@vueuse/head'
 import { configs } from '../env'
-import { initSharedState } from '../state/shared'
-import { initDrawingsState } from '../state/drawings'
+import { initSharedState, onPatch, patch } from '../state/shared'
+import { initDrawingState } from '../state/drawings'
+import { clicks, currentPage, getPath, isPresenter } from '../logic/nav'
+import { router } from '../routes'
 
 export default function setupRoot() {
   // @ts-expect-error injected in runtime
@@ -13,6 +16,28 @@ export default function setupRoot() {
 
   const title = configs.titleTemplate.replace('%s', configs.title || 'Slidev')
   useHead({ title })
-  initSharedState(title)
-  initDrawingsState(title)
+  initSharedState(`${title} - shared`)
+  initDrawingState(`${title} - drawing`)
+
+  // update shared state
+  function updateSharedState() {
+    if (isPresenter.value) {
+      patch('page', +currentPage.value)
+      patch('clicks', clicks.value)
+    }
+  }
+  router.afterEach(updateSharedState)
+  watch(clicks, updateSharedState)
+
+  onPatch((state) => {
+    if (+state.page !== +currentPage.value || clicks.value !== state.clicks) {
+      router.replace({
+        path: getPath(state.page),
+        query: {
+          ...router.currentRoute.value.query,
+          clicks: state.clicks || 0,
+        },
+      })
+    }
+  })
 }

--- a/packages/client/setup/root.ts
+++ b/packages/client/setup/root.ts
@@ -2,6 +2,7 @@
 import { useHead } from '@vueuse/head'
 import { configs } from '../env'
 import { initSharedState } from '../state/shared'
+import { initDrawingsState } from '../state/drawings'
 
 export default function setupRoot() {
   // @ts-expect-error injected in runtime
@@ -13,4 +14,5 @@ export default function setupRoot() {
   const title = configs.titleTemplate.replace('%s', configs.title || 'Slidev')
   useHead({ title })
   initSharedState(title)
+  initDrawingsState(title)
 }

--- a/packages/client/setup/root.ts
+++ b/packages/client/setup/root.ts
@@ -1,9 +1,7 @@
 /* __imports__ */
 import { useHead } from '@vueuse/head'
-import { watch } from 'vue'
-import { clicks, currentPage, getPath, isPresenter } from '../logic/nav'
-import { router } from '../routes'
-import { configs, serverState } from '../env'
+import { configs } from '../env'
+import { initSharedState } from '../state/shared'
 
 export default function setupRoot() {
   // @ts-expect-error injected in runtime
@@ -12,36 +10,7 @@ export default function setupRoot() {
 
   /* __injections__ */
 
-  useHead({
-    title: configs.titleTemplate.replace('%s', configs.title || 'Slidev'),
-  })
-
-  function onServerStateChanged() {
-    if (isPresenter.value)
-      return
-    if (+serverState.page !== +currentPage.value || clicks.value !== serverState.clicks) {
-      router.replace({
-        path: getPath(serverState.page),
-        query: {
-          ...router.currentRoute.value.query,
-          clicks: serverState.clicks || 0,
-        },
-      })
-    }
-  }
-  function updateServerState() {
-    if (isPresenter.value) {
-      serverState.page = +currentPage.value
-      serverState.clicks = clicks.value
-    }
-  }
-
-  // upload state to server
-  router.afterEach(updateServerState)
-  watch(clicks, updateServerState)
-
-  // sync with server state
-  router.isReady().then(() => {
-    watch(serverState, onServerStateChanged, { deep: true })
-  })
+  const title = configs.titleTemplate.replace('%s', configs.title || 'Slidev')
+  useHead({ title })
+  initSharedState(title)
 }

--- a/packages/client/state/drawings.ts
+++ b/packages/client/state/drawings.ts
@@ -1,0 +1,50 @@
+import { reactive, toRaw, watch } from 'vue'
+import serverDrawingState from 'server-reactive:drawings?diff'
+
+export type DrawingsState = Record<number, string | undefined>
+export type OnDrawingPatch = (state: DrawingsState) => void
+
+const onPatchCallbacks: OnDrawingPatch[] = []
+let patching = false
+let updating = false
+let patchingTimeout: NodeJS.Timeout
+let updatingTimeout: NodeJS.Timeout
+
+export const drawingState = __DEV__
+  ? serverDrawingState
+  : reactive<DrawingsState>({})
+
+export function onPatch(fn: OnDrawingPatch) {
+  onPatchCallbacks.push(fn)
+}
+
+export function patch(key: number, dump: string | undefined) {
+  clearTimeout(patchingTimeout)
+  patching = true
+  drawingState[key] = dump
+  patchingTimeout = setTimeout(() => patching = false, 0)
+}
+
+export function initDrawingsState(title: string) {
+  let stateChannel: BroadcastChannel
+  if (!__DEV__) {
+    stateChannel = new BroadcastChannel(`${title} - state`)
+    stateChannel.addEventListener('message', (event: MessageEvent<DrawingsState>) => {
+      if (!patching) {
+        clearTimeout(updatingTimeout)
+        updating = true
+        Object.entries(event.data).forEach(([key, value]) => drawingState[+key] = value)
+        updatingTimeout = setTimeout(() => updating = false, 0)
+      }
+    })
+  }
+
+  function onDrawingStateChanged() {
+    if (stateChannel && !updating)
+      stateChannel.postMessage(toRaw(drawingState))
+    if (!patching)
+      onPatchCallbacks.forEach(fn => fn(drawingState))
+  }
+
+  watch(drawingState, onDrawingStateChanged, { deep: true })
+}

--- a/packages/client/state/drawings.ts
+++ b/packages/client/state/drawings.ts
@@ -1,50 +1,7 @@
-import { reactive, toRaw, watch } from 'vue'
 import serverDrawingState from 'server-reactive:drawings?diff'
+import { createSyncState } from './syncState'
 
 export type DrawingsState = Record<number, string | undefined>
-export type OnDrawingPatch = (state: DrawingsState) => void
 
-const onPatchCallbacks: OnDrawingPatch[] = []
-let patching = false
-let updating = false
-let patchingTimeout: NodeJS.Timeout
-let updatingTimeout: NodeJS.Timeout
-
-export const drawingState = __DEV__
-  ? serverDrawingState
-  : reactive<DrawingsState>({})
-
-export function onPatch(fn: OnDrawingPatch) {
-  onPatchCallbacks.push(fn)
-}
-
-export function patch(key: number, dump: string | undefined) {
-  clearTimeout(patchingTimeout)
-  patching = true
-  drawingState[key] = dump
-  patchingTimeout = setTimeout(() => patching = false, 0)
-}
-
-export function initDrawingsState(title: string) {
-  let stateChannel: BroadcastChannel
-  if (!__DEV__) {
-    stateChannel = new BroadcastChannel(`${title} - state`)
-    stateChannel.addEventListener('message', (event: MessageEvent<DrawingsState>) => {
-      if (!patching) {
-        clearTimeout(updatingTimeout)
-        updating = true
-        Object.entries(event.data).forEach(([key, value]) => drawingState[+key] = value)
-        updatingTimeout = setTimeout(() => updating = false, 0)
-      }
-    })
-  }
-
-  function onDrawingStateChanged() {
-    if (stateChannel && !updating)
-      stateChannel.postMessage(toRaw(drawingState))
-    if (!patching)
-      onPatchCallbacks.forEach(fn => fn(drawingState))
-  }
-
-  watch(drawingState, onDrawingStateChanged, { deep: true })
-}
+const { init, onPatch, patch, state } = createSyncState<DrawingsState>(serverDrawingState, {})
+export { init as initDrawingState, onPatch, patch, state as drawingState }

--- a/packages/client/state/shared.ts
+++ b/packages/client/state/shared.ts
@@ -1,0 +1,63 @@
+import { reactive, toRaw, watch } from 'vue'
+import serverState from 'server-reactive:nav'
+
+import { clicks, currentPage, getPath, isPresenter } from '../logic/nav'
+import { router } from '../routes'
+
+export interface SharedState {
+  page: number
+  clicks: number
+  cursor?: {
+    x: number
+    y: number
+  }
+}
+
+export const sharedState = __DEV__
+  ? serverState
+  : reactive<SharedState>({
+    page: 1,
+    clicks: 0,
+  })
+
+export function initSharedState(title: string) {
+  let stateChannel: BroadcastChannel
+  if (!__DEV__) {
+    stateChannel = new BroadcastChannel(`${title} - state`)
+    stateChannel.addEventListener('message', (event: MessageEvent<SharedState>) => {
+      if (!isPresenter.value)
+        Object.entries(event.data).forEach(([key, value]) => sharedState[key as keyof SharedState] = value)
+    })
+  }
+
+  function onSharedStateChanged() {
+    if (isPresenter.value && stateChannel)
+      stateChannel.postMessage(toRaw(sharedState))
+    if (+sharedState.page !== +currentPage.value || clicks.value !== sharedState.clicks) {
+      router.replace({
+        path: getPath(sharedState.page),
+        query: {
+          ...router.currentRoute.value.query,
+          clicks: sharedState.clicks || 0,
+        },
+      })
+    }
+  }
+
+  function updateSharedState() {
+    if (isPresenter.value) {
+      sharedState.page = +currentPage.value
+      sharedState.clicks = clicks.value
+    }
+  }
+
+  // upload state to server
+  router.afterEach(updateSharedState)
+  watch(clicks, updateSharedState)
+
+  // sync with server state
+  router.isReady().then(() => {
+    watch(sharedState, onSharedStateChanged, { deep: true })
+    updateSharedState()
+  })
+}

--- a/packages/client/state/shared.ts
+++ b/packages/client/state/shared.ts
@@ -1,8 +1,5 @@
-import { reactive, toRaw, watch } from 'vue'
 import serverState from 'server-reactive:nav'
-
-import { clicks, currentPage, getPath, isPresenter } from '../logic/nav'
-import { router } from '../routes'
+import { createSyncState } from './syncState'
 
 export interface SharedState {
   page: number
@@ -13,51 +10,8 @@ export interface SharedState {
   }
 }
 
-export const sharedState = __DEV__
-  ? serverState
-  : reactive<SharedState>({
-    page: 1,
-    clicks: 0,
-  })
-
-export function initSharedState(title: string) {
-  let stateChannel: BroadcastChannel
-  if (!__DEV__) {
-    stateChannel = new BroadcastChannel(`${title} - state`)
-    stateChannel.addEventListener('message', (event: MessageEvent<SharedState>) => {
-      if (!isPresenter.value)
-        Object.entries(event.data).forEach(([key, value]) => sharedState[key as keyof SharedState] = value)
-    })
-  }
-
-  function onSharedStateChanged() {
-    if (isPresenter.value && stateChannel)
-      stateChannel.postMessage(toRaw(sharedState))
-    if (+sharedState.page !== +currentPage.value || clicks.value !== sharedState.clicks) {
-      router.replace({
-        path: getPath(sharedState.page),
-        query: {
-          ...router.currentRoute.value.query,
-          clicks: sharedState.clicks || 0,
-        },
-      })
-    }
-  }
-
-  function updateSharedState() {
-    if (isPresenter.value) {
-      sharedState.page = +currentPage.value
-      sharedState.clicks = clicks.value
-    }
-  }
-
-  // upload state to server
-  router.afterEach(updateSharedState)
-  watch(clicks, updateSharedState)
-
-  // sync with server state
-  router.isReady().then(() => {
-    watch(sharedState, onSharedStateChanged, { deep: true })
-    updateSharedState()
-  })
-}
+const { init, onPatch, patch, state } = createSyncState<SharedState>(serverState, {
+  page: 1,
+  clicks: 0,
+})
+export { init as initSharedState, onPatch, patch, state as sharedState }

--- a/packages/client/state/syncState.ts
+++ b/packages/client/state/syncState.ts
@@ -1,54 +1,66 @@
-import type { UnwrapNestedRefs } from 'vue'
 import { reactive, toRaw, watch } from 'vue'
 
 export function createSyncState<State extends object>(serverState: State, defaultState: State) {
-  const onPatchCallbacks: ((state: UnwrapNestedRefs<State>) => void)[] = []
+  const onPatchCallbacks: ((state: State) => void)[] = []
   let patching = false
   let updating = false
   let patchingTimeout: NodeJS.Timeout
   let updatingTimeout: NodeJS.Timeout
 
   const state = __DEV__
-    ? reactive<State>(serverState) // serverState
-    : reactive<State>(defaultState)
+    ? reactive<State>(serverState) as State
+    : reactive<State>(defaultState) as State
 
-  function onPatch(fn: (state: UnwrapNestedRefs<State>) => void) {
+  function onPatch(fn: (state: State) => void) {
     onPatchCallbacks.push(fn)
   }
 
-  function patch<K extends keyof State, V = State[K]>(key: K, value: V) {
+  function patch<K extends keyof State>(key: K, value: State[K]) {
     clearTimeout(patchingTimeout)
     patching = true
-    // @ts-expect-error fixme
     state[key] = value
     patchingTimeout = setTimeout(() => patching = false, 0)
   }
 
+  function onUpdate(patch: Partial<State>) {
+    if (!patching) {
+      clearTimeout(updatingTimeout)
+      updating = true
+      Object.entries(patch).forEach(([key, value]) => {
+        state[key as keyof State] = value as State[keyof State]
+      })
+      updatingTimeout = setTimeout(() => updating = false, 0)
+    }
+  }
+
   function init(channelKey: string) {
     let stateChannel: BroadcastChannel
-    if (!__DEV__) {
+    if (!__DEV__ && !__SLIDEV_FEATURE_DRAWINGS_PERSIST__) {
       stateChannel = new BroadcastChannel(channelKey)
-      stateChannel.addEventListener('message', (event: MessageEvent<State>) => {
-        if (!patching) {
-          clearTimeout(updatingTimeout)
-          updating = true
-          Object.entries(event.data).forEach(([key, value]) => {
-            // @ts-expect-error fixme
-            state[key as keyof State] = value
-          })
-          updatingTimeout = setTimeout(() => updating = false, 0)
-        }
+      stateChannel.addEventListener('message', (event: MessageEvent<Partial<State>>) => onUpdate(event.data))
+    }
+    else if (!__DEV__ && __SLIDEV_FEATURE_DRAWINGS_PERSIST__) {
+      window.addEventListener('storage', (event) => {
+        if (event && event.key === channelKey && event.newValue)
+          onUpdate(JSON.parse(event.newValue) as Partial<State>)
       })
     }
 
     function onDrawingStateChanged() {
-      if (stateChannel && !updating)
+      if (!__SLIDEV_FEATURE_DRAWINGS_PERSIST__ && stateChannel && !updating)
         stateChannel.postMessage(toRaw(state))
+      else if (__SLIDEV_FEATURE_DRAWINGS_PERSIST__ && !updating)
+        window.localStorage.setItem(channelKey, JSON.stringify(state))
       if (!patching)
-        onPatchCallbacks.forEach((fn: (state: UnwrapNestedRefs<State>) => void) => fn(state))
+        onPatchCallbacks.forEach((fn: (state: State) => void) => fn(state))
     }
 
     watch(state, onDrawingStateChanged, { deep: true })
+    if (!__DEV__ && __SLIDEV_FEATURE_DRAWINGS_PERSIST__) {
+      const serialzedState = window.localStorage.getItem(channelKey)
+      if (serialzedState)
+        onUpdate(JSON.parse(serialzedState) as Partial<State>)
+    }
   }
 
   return { init, onPatch, patch, state }

--- a/packages/client/state/syncState.ts
+++ b/packages/client/state/syncState.ts
@@ -1,0 +1,55 @@
+import type { UnwrapNestedRefs } from 'vue'
+import { reactive, toRaw, watch } from 'vue'
+
+export function createSyncState<State extends object>(serverState: State, defaultState: State) {
+  const onPatchCallbacks: ((state: UnwrapNestedRefs<State>) => void)[] = []
+  let patching = false
+  let updating = false
+  let patchingTimeout: NodeJS.Timeout
+  let updatingTimeout: NodeJS.Timeout
+
+  const state = __DEV__
+    ? reactive<State>(serverState) // serverState
+    : reactive<State>(defaultState)
+
+  function onPatch(fn: (state: UnwrapNestedRefs<State>) => void) {
+    onPatchCallbacks.push(fn)
+  }
+
+  function patch<K extends keyof State, V = State[K]>(key: K, value: V) {
+    clearTimeout(patchingTimeout)
+    patching = true
+    // @ts-expect-error fixme
+    state[key] = value
+    patchingTimeout = setTimeout(() => patching = false, 0)
+  }
+
+  function init(channelKey: string) {
+    let stateChannel: BroadcastChannel
+    if (!__DEV__) {
+      stateChannel = new BroadcastChannel(channelKey)
+      stateChannel.addEventListener('message', (event: MessageEvent<State>) => {
+        if (!patching) {
+          clearTimeout(updatingTimeout)
+          updating = true
+          Object.entries(event.data).forEach(([key, value]) => {
+            // @ts-expect-error fixme
+            state[key as keyof State] = value
+          })
+          updatingTimeout = setTimeout(() => updating = false, 0)
+        }
+      })
+    }
+
+    function onDrawingStateChanged() {
+      if (stateChannel && !updating)
+        stateChannel.postMessage(toRaw(state))
+      if (!patching)
+        onPatchCallbacks.forEach((fn: (state: UnwrapNestedRefs<State>) => void) => fn(state))
+    }
+
+    watch(state, onDrawingStateChanged, { deep: true })
+  }
+
+  return { init, onPatch, patch, state }
+}


### PR DESCRIPTION
Fixes https://github.com/slidevjs/slidev/issues/24

The idea is to use different technologies depending on the cases:
* dev mode: continue to use server state with`vite-plugin-vue-server-ref` to keep the possibility to remotely control the slides using the `--remote` option
* build mode with persist drawing option enabled: use `localStorage` to synchronize the state between multiple tabs
* build mode with persist drawing option disabled: use `BroadcastChannel` to synchronize the state between multiple tabs

For both `localStorage` and `BroadcastChannel`, I use a key based on the slides main title instead of using a `slidev-` prefixed key.
This prevent to have different slidev presentation opened that interact which each others.