### PR TITLE
chore: ensure name field is at the top of package.json

### DIFF
--- a/packages/create-app/template/package.json
+++ b/packages/create-app/template/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "untitled",
   "private": true,
   "scripts": {
     "build": "slidev build",


### PR DESCRIPTION
add a placeholder, because that `name` is at the top of `package.json` in general, it will be rewritten by CLI.

https://github.com/slidevjs/slidev/blob/122053fef27cf2a4ceae8c8713fa3e96d7ecdda9/packages/create-app/index.js#L88-L90