### PR TITLE
fix: md export with clicks option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ node_modules
 .idea/
 *.pdf
 *-export
+slides-export.md
 assets/demo
 packages/slidev/README.md
 packages/create-app/template/slides.md

--- a/packages/client/internals/PrintSlideClick.vue
+++ b/packages/client/internals/PrintSlideClick.vue
@@ -35,6 +35,7 @@ if (__SLIDEV_FEATURE_DRAWINGS__ || __SLIDEV_FEATURE_DRAWINGS_PERSIST__)
 
 const clicks = computed(() => props.clicks)
 const navClicks = useNavClicks(clicks, props.nav.currentRoute, props.nav.currentPage)
+const id = computed(() => `${props.route.path.toString().padStart(3, '0')}-${(clicks.value + 1).toString().padStart(2, '0')}`)
 
 provide(injectionSlidevContext, reactive({
   nav: { ...props.nav, ...navClicks },
@@ -44,7 +45,7 @@ provide(injectionSlidevContext, reactive({
 </script>
 
 <template>
-  <div :id="route.path" class="slide-container" :style="style">
+  <div :id="id" class="slide-container" :style="style">
     <GlobalBottom />
 
     <SlideWrapper


### PR DESCRIPTION
Fixes https://github.com/slidevjs/slidev/issues/530
This PR fixes the comments I made here https://github.com/slidevjs/slidev/pull/531
* add compatibility with the `--with-clicks` option
* add exported file in `.gitignore`