### PR TITLE
fix(cypress): bring basic UpArrow assert back

### DIFF
--- a/cypress/integration/examples/basic.spec.ts
+++ b/cypress/integration/examples/basic.spec.ts
@@ -72,6 +72,7 @@ context('Basic', () => {
     cy.get('body')
       .type('{UpArrow}')
       .url()
+      .should('eq', 'http://localhost:3030/6')
   })
 
   it('named slots', () => {


### PR DESCRIPTION
Ref #591 and https://github.com/slidevjs/slidev/pull/591#discussion_r879042611

Accidentally deleted the basic up cypress test assert, bring it back in this PR.
