### PR TITLE
feat(themes): allow arbitary theme package names

### DIFF
--- a/packages/slidev/node/themes.ts
+++ b/packages/slidev/node/themes.ts
@@ -46,6 +46,8 @@ export function resolveThemeName(name: string) {
     return `@slidev/theme-${name}`
   if (packageExists(`slidev-theme-${name}`))
     return `slidev-theme-${name}`
+  if (packageExists(name))
+    return name
 
   // fallback to prompt install
   if (officialThemes[name] != null)


### PR DESCRIPTION
This allows scoped package names like `@organization/slidev-theme-school` as well as any package name. The prompt still defaults to `slidev-theme-${name}`, so the feature of offering the user to install the package is still in place.