### PR TITLE
feat: add ContextRender component

### DIFF
--- a/packages/client/builtin/ContextRender.vue
+++ b/packages/client/builtin/ContextRender.vue
@@ -1,0 +1,28 @@
+<script setup lang="ts">
+import { computed, inject } from 'vue'
+
+import { injectionSlideContext } from '../constants'
+
+type SlideContext = 'main' | 'slidesshow' | 'overview' | 'presenter' | 'presenterNext'
+
+const props = defineProps<{
+  context: SlideContext | SlideContext[]
+}>()
+const { context } = props
+
+const currentContext = inject(injectionSlideContext)
+
+const shouldRender = computed(() => context instanceof Array ? context.some(contextMatch) : contextMatch(context))
+
+function contextMatch(context: SlideContext) {
+  if (context === currentContext)
+    return true
+  if (context === 'main' && (currentContext === 'slidesshow' || currentContext === 'presenter'))
+    return true
+  return false
+}
+</script>
+
+<template>
+  <slot v-if="shouldRender" />
+</template>

--- a/packages/client/constants.ts
+++ b/packages/client/constants.ts
@@ -9,6 +9,7 @@ export const injectionClicksDisabled: InjectionKey<Ref<boolean>> = Symbol('v-cli
 export const injectionSlideScale: InjectionKey<ComputedRef<number>> = Symbol('slidev-slide-scale')
 export const injectionSlidevContext: InjectionKey<SlidevContext> = Symbol('slidev-slidev-context')
 export const injectionRoute: InjectionKey<RouteRecordRaw> = Symbol('slidev-route')
+export const injectionSlideContext: InjectionKey<'slidesshow' | 'overview' | 'presenter' | 'presenterNext'> = Symbol('slidev-slide-context')
 
 export const CLASS_VCLICK_TARGET = 'slidev-vclick-target'
 export const CLASS_VCLICK_HIDDEN = 'slidev-vclick-hidden'

--- a/packages/client/internals/Play.vue
+++ b/packages/client/internals/Play.vue
@@ -49,7 +49,7 @@ if (__SLIDEV_FEATURE_DRAWINGS__)
       @pointerdown="onClick"
     >
       <template #>
-        <SlidesShow />
+        <SlidesShow context="slidesshow" />
       </template>
       <template #controls>
         <div

--- a/packages/client/internals/Presenter.vue
+++ b/packages/client/internals/Presenter.vue
@@ -103,7 +103,7 @@ onMounted(() => {
           class="h-full w-full"
         >
           <template #>
-            <SlidesShow />
+            <SlidesShow context="presenter" />
           </template>
         </SlideContainer>
       </div>
@@ -120,6 +120,7 @@ onMounted(() => {
             :clicks-disabled="false"
             :class="getSlideClass(nextSlide.route)"
             :route="nextSlide.route"
+            context="presenterNext"
           />
         </SlideContainer>
       </div>

--- a/packages/client/internals/SlideWrapper.ts
+++ b/packages/client/internals/SlideWrapper.ts
@@ -1,6 +1,6 @@
 import { useVModel } from '@vueuse/core'
 import { defineComponent, h, provide } from 'vue'
-import { injectionClicks, injectionClicksDisabled, injectionClicksElements, injectionOrderMap, injectionRoute } from '../constants'
+import { injectionClicks, injectionClicksDisabled, injectionClicksElements, injectionOrderMap, injectionRoute, injectionSlideContext } from '../constants'
 
 export default defineComponent({
   props: {
@@ -20,6 +20,10 @@ export default defineComponent({
       type: Boolean,
       default: false,
     },
+    context: {
+      type: String,
+      default: 'main',
+    },
     is: {
       type: Object,
       default: undefined,
@@ -38,6 +42,7 @@ export default defineComponent({
     clicksElements.value.length = 0
 
     provide(injectionRoute, props.route)
+    provide(injectionSlideContext, props.context)
     provide(injectionClicks, clicks)
     provide(injectionClicksDisabled, clicksDisabled)
     provide(injectionClicksElements, clicksElements)

--- a/packages/client/internals/SlidesOverview.vue
+++ b/packages/client/internals/SlidesOverview.vue
@@ -85,6 +85,7 @@ watchEffect(() => {
               :clicks-disabled="true"
               :class="getSlideClass(route)"
               :route="route"
+              context="overview"
             />
             <DrawingPreview :page="+route.path" />
           </SlideContainer>

--- a/packages/client/internals/SlidesShow.vue
+++ b/packages/client/internals/SlidesShow.vue
@@ -9,6 +9,8 @@ import GlobalTop from '/@slidev/global-components/top'
 import GlobalBottom from '/@slidev/global-components/bottom'
 import PresenterMouse from './PresenterMouse.vue'
 
+defineProps<{ context: 'slidesshow' | 'presenter' }>()
+
 // preload next route
 watch(currentRoute, () => {
   if (currentRoute.value?.meta && currentRoute.value.meta.preload !== false)
@@ -37,6 +39,7 @@ if (__SLIDEV_FEATURE_DRAWINGS__ || __SLIDEV_FEATURE_DRAWINGS_PERSIST__)
       :clicks-disabled="false"
       :class="getSlideClass(route)"
       :route="route"
+      :context="context"
     />
   </template>
 


### PR DESCRIPTION
Fixes https://github.com/slidevjs/slidev/issues/396

Add a `<ContextRender>` that will only display its children when the slide is dislpayed in specific context.

It has one props, `context`, that is either one of the following string, either an array of the following strings:
* `'slidesshow'`
* `'overview'`
* `'presenter'`
* `'presenterNext'`
* `'main'`: shortcut for `['slidesshow', 'presenter']`

It allows the use of some components, like the `<Teleport>` component:
```md
<ContextRender context="main">

<Teleport to="body">

**Hello** from teleport !

</Teleport>

</ContextRender>
```
