### PR TITLE
feat: update presenter mode styles for mobile

### DIFF
--- a/packages/client/internals/NavControls.vue
+++ b/packages/client/internals/NavControls.vue
@@ -47,7 +47,7 @@ if (__SLIDEV_FEATURE_DRAWINGS__)
 <template>
   <nav ref="root" class="flex flex-col">
     <div
-      class="flex flex-wrap-reverse text-xl p-2 gap-1"
+      class="flex flex-wrap-reverse text-xl gap-0.5 p-1 lg:(gap-1 p-2)"
       :class="barStyle"
       @mouseleave="onMouseLeave"
     >

--- a/packages/client/internals/Presenter.vue
+++ b/packages/client/internals/Presenter.vue
@@ -182,7 +182,7 @@ onMounted(() => {
     "bottom bottom";
 }
 
-@media (orientation: portrait) {
+@media (max-aspect-ratio: 3/5) {
   .grid-container {
     grid-template-columns: 1fr;
     grid-template-rows: min-content 1fr 1fr 1fr min-content;
@@ -195,7 +195,7 @@ onMounted(() => {
   }
 }
 
-@screen md {
+@media (min-aspect-ratio: 1/1) {
   .grid-container {
     grid-template-columns: 1fr 1.1fr 0.9fr;
     grid-template-rows: min-content 1fr 2fr min-content;

--- a/packages/client/internals/Presenter.vue
+++ b/packages/client/internals/Presenter.vue
@@ -84,7 +84,7 @@ onMounted(() => {
   <div class="bg-main h-full slidev-presenter">
     <div class="grid-container">
       <div class="grid-section top flex">
-        <img src="../assets/logo-title-horizontal.png" class="h-14 ml-2 py-2 my-auto">
+        <img src="../assets/logo-title-horizontal.png" class="ml-2 my-auto h-10 py-1 lg:(h-14 py-2)">
         <div class="flex-auto" />
         <div
           class="timer-btn my-auto relative w-22px h-22px cursor-pointer text-lg"
@@ -98,7 +98,7 @@ onMounted(() => {
           {{ timer }}
         </div>
       </div>
-      <div ref="main" class="grid-section main flex flex-col p-4" :style="themeVars">
+      <div ref="main" class="relative grid-section main flex flex-col p-2 lg:(p-4)" :style="themeVars">
         <SlideContainer
           key="main"
           class="h-full w-full"
@@ -107,8 +107,11 @@ onMounted(() => {
             <SlidesShow context="presenter" />
           </template>
         </SlideContainer>
+        <div class="context">
+          current
+        </div>
       </div>
-      <div class="grid-section next flex flex-col p-4">
+      <div class="relative grid-section next flex flex-col p-2 lg:(p-4)">
         <SlideContainer
           v-if="nextSlide"
           key="next"
@@ -124,10 +127,13 @@ onMounted(() => {
             context="previewNext"
           />
         </SlideContainer>
+        <div class="context">
+          next
+        </div>
       </div>
       <div class="grid-section note overflow-auto">
-        <NoteEditor v-if="__DEV__" class="w-full h-full p-4 overflow-auto" />
-        <NoteStatic v-else class="w-full h-full p-4 overflow-auto" />
+        <NoteEditor v-if="__DEV__" class="w-full h-full overflow-auto p-2 lg:(p-4)" />
+        <NoteStatic v-else class="w-full h-full overflow-auto p-2 lg:(p-4)" />
       </div>
       <div class="grid-section bottom">
         <NavControls :persist="true" />
@@ -176,6 +182,19 @@ onMounted(() => {
     "bottom bottom";
 }
 
+@media (orientation: portrait) {
+  .grid-container {
+    grid-template-columns: 1fr;
+    grid-template-rows: min-content 1fr 1fr 1fr min-content;
+    grid-template-areas:
+      "top"
+      "main"
+      "note"
+      "next"
+      "bottom";
+  }
+}
+
 @screen md {
   .grid-container {
     grid-template-columns: 1fr 1.1fr 0.9fr;
@@ -210,5 +229,9 @@ onMounted(() => {
   &.bottom {
     grid-area: bottom;
   }
+}
+
+.context {
+  @apply absolute top-0 left-0 px-1 text-xs bg-gray-400 bg-opacity-50 opacity-75 rounded-br-md;
 }
 </style>

--- a/packages/client/internals/VerticalDivider.vue
+++ b/packages/client/internals/VerticalDivider.vue
@@ -1,3 +1,3 @@
 <template>
-  <div class="w-1px m-2 opacity-10 bg-current" />
+  <div class="w-1px opacity-10 bg-current m-1 lg:(m-2)" />
 </template>

--- a/packages/client/styles/index.css
+++ b/packages/client/styles/index.css
@@ -16,8 +16,14 @@ html {
 
 .icon-btn {
   @apply inline-block cursor-pointer select-none !outline-none;
-  @apply opacity-75 transition duration-200 ease-in-out align-middle rounded p-2;
+  @apply opacity-75 transition duration-200 ease-in-out align-middle rounded p-1;
   @apply hover:(opacity-100 bg-gray-400 bg-opacity-10);
+}
+
+@screen md {
+  .icon-btn {
+    @apply p-2;
+  }
 }
 
 .icon-btn.shallow {


### PR DESCRIPTION
Fixes https://github.com/slidevjs/slidev/issues/615

Propsals:

Mobile landscape:
![mobile-landscape](https://user-images.githubusercontent.com/5246045/171608471-7b5a936a-33a7-4114-8480-b1a1e5c42089.png)

Mobile portrait:
![mobile-portrait](https://user-images.githubusercontent.com/5246045/171609841-311e1d69-5369-4792-a703-f90b3cd58787.png)

Tablet landcape:
![tablet-landcape](https://user-images.githubusercontent.com/5246045/171608536-870f8caa-7172-4224-b498-a08d9dccfd40.png)

Tablet portrait:
![tablet-portrait](https://user-images.githubusercontent.com/5246045/171608561-de2cce6e-f1d2-44ba-8e72-6bc2d1dc29f5.png)

Desktop:
![desktop](https://user-images.githubusercontent.com/5246045/171608583-b6e42489-fc9c-40eb-8f31-7001df3878b0.png)

* add one column display when width << height
* use previous mobile display (2 cols) when width < height
* use classique display (3 cols) when width > height
* add context information ("current" and "next")
* try to fit the bottom bar in one line for small width