### PR TITLE
[fix] forgot to handle mermaid scale parameter in ShadowRoot

### DIFF
--- a/packages/client/builtin/Mermaid.vue
+++ b/packages/client/builtin/Mermaid.vue
@@ -59,5 +59,5 @@ watchEffect(() => {
 </script>
 
 <template>
-  <ShadowRoot class="mermaid" :inner-html="html" />
+  <ShadowRoot ref="el" class="mermaid" :inner-html="html" @shadow="el = $event" />
 </template>

--- a/packages/client/internals/ShadowRoot.vue
+++ b/packages/client/internals/ShadowRoot.vue
@@ -5,11 +5,17 @@ const props = defineProps<{
   innerHtml: string
 }>()
 
+const emit = defineEmits<{
+  (event: 'shadow', div: ShadowRoot): void
+}>()
+
 const el = ref<HTMLDivElement>()
 const shadow = computed(() => el.value ? (el.value.shadowRoot || el.value.attachShadow({ mode: 'open' })) : null)
 watchEffect(() => {
-  if (shadow.value)
+  if (shadow.value) {
+    emit('shadow', shadow.value)
     shadow.value.innerHTML = props.innerHtml
+  }
 })
 </script>
 


### PR DESCRIPTION
fixes https://github.com/slidevjs/slidev/issues/625

The scaling code was getting ignored due to a missing ref (the svg used to be ref="el" but was moved inside the shadow root).
