### PR TITLE
feat: expose go() for dynamic slide navigation

### DIFF
--- a/packages/client/setup/shortcuts.ts
+++ b/packages/client/setup/shortcuts.ts
@@ -1,7 +1,7 @@
 /* __imports__ */
 
 import type { NavOperations, ShortcutOptions } from '@slidev/types'
-import { downloadPDF, next, nextSlide, prev, prevSlide, go } from '../logic/nav'
+import { downloadPDF, go, next, nextSlide, prev, prevSlide } from '../logic/nav'
 import { toggleDark } from '../logic/dark'
 import { showGotoDialog, showOverview, toggleOverview } from '../state'
 import { drawingEnabled } from '../logic/drawings'
@@ -20,7 +20,7 @@ export default function setupShortcuts() {
     toggleOverview,
     toggleDrawing: () => drawingEnabled.value = !drawingEnabled.value,
     escapeOverview: () => showOverview.value = false,
-    showGotoDialog: () => showGotoDialog.value = !showGotoDialog.value
+    showGotoDialog: () => showGotoDialog.value = !showGotoDialog.value,
   }
 
   // eslint-disable-next-line prefer-const

--- a/packages/client/setup/shortcuts.ts
+++ b/packages/client/setup/shortcuts.ts
@@ -1,7 +1,7 @@
 /* __imports__ */
 
 import type { NavOperations, ShortcutOptions } from '@slidev/types'
-import { downloadPDF, next, nextSlide, prev, prevSlide } from '../logic/nav'
+import { downloadPDF, next, nextSlide, prev, prevSlide, go } from '../logic/nav'
 import { toggleDark } from '../logic/dark'
 import { showGotoDialog, showOverview, toggleOverview } from '../state'
 import { drawingEnabled } from '../logic/drawings'
@@ -14,12 +14,13 @@ export default function setupShortcuts() {
     prev,
     nextSlide,
     prevSlide,
+    go,
     downloadPDF,
     toggleDark,
     toggleOverview,
     toggleDrawing: () => drawingEnabled.value = !drawingEnabled.value,
     escapeOverview: () => showOverview.value = false,
-    showGotoDialog: () => showGotoDialog.value = !showGotoDialog.value,
+    showGotoDialog: () => showGotoDialog.value = !showGotoDialog.value
   }
 
   // eslint-disable-next-line prefer-const

--- a/packages/types/src/setups.ts
+++ b/packages/types/src/setups.ts
@@ -40,6 +40,7 @@ export interface NavOperations {
   prev: () => Promise<void>
   nextSlide: () => void
   prevSlide: () => Promise<void>
+  go: (index: number) => Promise<void>
   downloadPDF: () => Promise<void>
   toggleDark: () => void
   toggleOverview: () => void

--- a/packages/types/src/setups.ts
+++ b/packages/types/src/setups.ts
@@ -40,7 +40,7 @@ export interface NavOperations {
   prev: () => Promise<void>
   nextSlide: () => void
   prevSlide: () => Promise<void>
-  go: (index: number) => Promise<void>
+  go: (index: number) => void
   downloadPDF: () => Promise<void>
   toggleDark: () => void
   toggleOverview: () => void


### PR DESCRIPTION
When users want to extend the existing shortcuts (which are very minimal) with the customized setup then they still should be able to easily access some core navigation elements.

This PR exposes the `go()` navigation control.