### PR TITLE
feat: auto scroll code highlight, close #378

### DIFF
--- a/packages/client/builtin/CodeBlockWrapper.vue
+++ b/packages/client/builtin/CodeBlockWrapper.vue
@@ -103,7 +103,7 @@ function copyCode() {
     ref="el" class="slidev-code-wrapper relative group"
     :style="{
       'max-height': props.maxHeight,
-      'overflow-y': props.maxHeight ? 'scroll' : 'hidden',
+      'overflow-y': props.maxHeight ? 'scroll' : undefined,
     }"
   >
     <slot />

--- a/packages/client/builtin/CodeBlockWrapper.vue
+++ b/packages/client/builtin/CodeBlockWrapper.vue
@@ -27,6 +27,10 @@ const props = defineProps({
     type: Number,
     default: undefined,
   },
+  maxHeight: {
+    type: String,
+    default: undefined,
+  },
 })
 
 const clicks = inject(injectionClicks)
@@ -76,6 +80,11 @@ onMounted(() => {
         line.classList.toggle('highlighted', highlighted)
         line.classList.toggle('dishonored', !highlighted)
       })
+      if (props.maxHeight) {
+        const firstHighlightedEl = target.querySelector('.line.highlighted')
+        if (firstHighlightedEl)
+          firstHighlightedEl.scrollIntoView({ behavior: 'smooth', block: 'center' })
+      }
     }
   })
 })
@@ -90,7 +99,13 @@ function copyCode() {
 </script>
 
 <template>
-  <div ref="el" class="slidev-code-wrapper relative group">
+  <div
+    ref="el" class="slidev-code-wrapper relative group"
+    :style="{
+      'max-height': props.maxHeight,
+      'overflow-y': props.maxHeight ? 'scroll' : 'hidden',
+    }"
+  >
     <slot />
     <button
       v-if="configs.codeCopy"

--- a/packages/client/styles/code.css
+++ b/packages/client/styles/code.css
@@ -6,8 +6,15 @@ html:not(.dark) .shiki-dark {
   display: none;
 }
 
+::-webkit-scrollbar {
+  width: 0px;
+}
+
 .slidev-code-wrapper {
   margin: var(--slidev-code-margin) !important;
+  &:-webkit-scrollbar {
+    width: 0px;
+  }
 }
 
 .slidev-code {


### PR DESCRIPTION

**Related Issue(s)**

https://github.com/slidevjs/slidev/issues/378

**Why**
It enables automatically scrolling to the current highlighted code, by setting maxHeight option on code block.

**Example:**
```
```ts {all|2|1-6|9|all} {height:'200px'}
interface User {
  id: number
  firstName: string
  lastName: string
  role: string
}

interface User2 {
  id: number
  firstName: string
  lastName: string
  role: string
}

interface User3 {
  id: number
  firstName: string
  lastName: string
  role: string
}

interface User4 {
  id: number
  firstName: string
  lastName: string
  role: string
}
```

Video:

https://user-images.githubusercontent.com/46906474/177882902-a6bbcd4e-4029-4ff4-afb7-822e9ca3c15c.mp4


