### PR TITLE
feat: add chrome-executable parameter to export

### DIFF
--- a/packages/slidev/node/cli.ts
+++ b/packages/slidev/node/cli.ts
@@ -322,6 +322,10 @@ cli.command(
       type: 'boolean',
       describe: 'export pages for every clicks',
     })
+    .option('executable-path', {
+      type: 'string',
+      describe: 'executable to override playwright bundled browser',
+    })
     .strict()
     .help(),
   async ({
@@ -333,6 +337,7 @@ cli.command(
     range,
     dark,
     'with-clicks': withClicks,
+    'executable-path': executablePath,
   }) => {
     process.env.NODE_ENV = 'production'
     const { exportSlides } = await import('./export')
@@ -364,6 +369,7 @@ cli.command(
       width,
       height,
       withClicks,
+      executablePath,
     })
     console.log(`${green('  ✓ ')}${dim('exported to ')}./${output}\n`)
     server.close()

--- a/packages/slidev/node/export.ts
+++ b/packages/slidev/node/export.ts
@@ -20,6 +20,7 @@ export interface ExportOptions {
   width?: number
   height?: number
   withClicks?: boolean
+  executablePath?: string
 }
 
 function createSlidevProgress(indeterminate = false) {
@@ -72,6 +73,7 @@ export async function exportSlides({
   width = 1920,
   height = 1080,
   withClicks = false,
+  executablePath = undefined,
 }: ExportOptions) {
   if (!packageExists('playwright-chromium'))
     throw new Error('The exporting for Slidev is powered by Playwright, please installed it via `npm i -D playwright-chromium`')
@@ -79,7 +81,9 @@ export async function exportSlides({
   const pages: number[] = parseRangeString(total, range)
 
   const { chromium } = await import('playwright-chromium')
-  const browser = await chromium.launch()
+  const browser = await chromium.launch({
+    executablePath,
+  })
   const context = await browser.newContext({
     viewport: {
       width,


### PR DESCRIPTION
This adds a `export --chrome-executable` CLI parameter to override the bundled chrome coming with playwright.

I use this to export my slides with the chrome provided by my system, as the playwright chrome build is not binary compatible (I use nix for building, but this would also apply for a musl based system like alpine linux.)