### PR TITLE
fix: $slidev injection, close #679

### DIFF
--- a/packages/slidev/node/plugins/extendConfig.ts
+++ b/packages/slidev/node/plugins/extendConfig.ts
@@ -12,6 +12,9 @@ import { searchForWorkspaceRoot } from '../vite/searchRoot'
 const EXCLUDE = [
   '@slidev/shared',
   '@slidev/types',
+  '@slidev/client',
+  '@slidev/client/constants',
+  '@slidev/client/logic/dark',
   '@vueuse/core',
   '@vueuse/shared',
   '@unocss/reset',

--- a/packages/slidev/node/plugins/loaders.ts
+++ b/packages/slidev/node/plugins/loaders.ts
@@ -296,12 +296,6 @@ export function createSlidesLoader(
         const pageNo = parseInt(no) - 1
         return transformMarkdown(code, pageNo, data)
       },
-      // #679 fix
-      config: () => ({
-        optimizeDeps: {
-          exclude: ['@slidev/client/constants'],
-        },
-      }),
     },
     {
       name: 'slidev:context-transform:pre',
@@ -311,12 +305,6 @@ export function createSlidesLoader(
           return
         return transformVue(code)
       },
-      // #679 fix
-      config: () => ({
-        optimizeDeps: {
-          exclude: ['@slidev/client/constants'],
-        },
-      }),
     },
     {
       name: 'slidev:title-transform:pre',

--- a/packages/slidev/node/plugins/loaders.ts
+++ b/packages/slidev/node/plugins/loaders.ts
@@ -191,7 +191,7 @@ export function createSlidesLoader(
                   read() { return md },
                 })
               }
-              catch {}
+              catch { }
             }),
           )
         ).flatMap(i => i || [])
@@ -296,6 +296,12 @@ export function createSlidesLoader(
         const pageNo = parseInt(no) - 1
         return transformMarkdown(code, pageNo, data)
       },
+      // #679 fix
+      config: () => ({
+        optimizeDeps: {
+          exclude: ['@slidev/client/constants'],
+        },
+      }),
     },
     {
       name: 'slidev:context-transform:pre',
@@ -305,6 +311,12 @@ export function createSlidesLoader(
           return
         return transformVue(code)
       },
+      // #679 fix
+      config: () => ({
+        optimizeDeps: {
+          exclude: ['@slidev/client/constants'],
+        },
+      }),
     },
     {
       name: 'slidev:title-transform:pre',


### PR DESCRIPTION
修复 #679 
问题原因：
`Symbol` 惹的祸
 全局属性 `$slidev` 的注入名声明在 `packages/client/constants.ts`，为 `Symbol`，其提供于文件 `packages/client/modules/context.ts`，注入于插件 `slidev:layout-transform:pre` `slidev:context-transform:pre` 。
开发环境下，上述两插件中的依赖项会预编译到 `node_modules/.vite/deps`，即，`constants.ts` 暂存位置。提供处仍引用的是 `packages/client/constants.ts`。
此时出现了两份 `constants.ts`，而 Symbol('slidev-slidev-context') !== Symbol('slidev-slidev-context')，故而报错。

解决办法：
分别配置两插件，在预构建中强制排除依赖项 `@slidev/client/constants`。
