### PR TITLE
feat!: separate persistent drawing dirs per entry slides

### DIFF
--- a/packages/parser/src/config.ts
+++ b/packages/parser/src/config.ts
@@ -2,7 +2,7 @@ import { toArray, uniq } from '@antfu/utils'
 import type { DrawingsOptions, FontOptions, ResolvedDrawingsOptions, ResolvedFontOptions, SlidevConfig, SlidevThemeMeta } from '@slidev/types'
 import { parseAspectRatio } from './utils'
 
-export function resolveConfig(headmatter: any, themeMeta: SlidevThemeMeta = {}, verify = false) {
+export function resolveConfig(headmatter: any, themeMeta: SlidevThemeMeta = {}, filepath?: string, verify = false) {
   const themeHightlighter = ['prism', 'shiki'].includes(themeMeta.highlighter || '') ? themeMeta.highlighter as 'prism' | 'shiki' : undefined
   const themeColorSchema = ['light', 'dark'].includes(themeMeta.colorSchema || '') ? themeMeta.colorSchema as 'light' | 'dark' : undefined
 
@@ -42,7 +42,7 @@ export function resolveConfig(headmatter: any, themeMeta: SlidevThemeMeta = {}, 
       ...headmatter.config?.fonts,
       ...headmatter?.fonts,
     }),
-    drawings: resolveDrawings(headmatter.drawings),
+    drawings: resolveDrawings(headmatter.drawings, filepath),
   }
 
   if (config.colorSchema !== 'dark' && config.colorSchema !== 'light')
@@ -162,7 +162,7 @@ export function resolveFonts(fonts: FontOptions = {}): ResolvedFontOptions {
   }
 }
 
-function resolveDrawings(options: DrawingsOptions = {}): ResolvedDrawingsOptions {
+function resolveDrawings(options: DrawingsOptions = {}, filepath?: string): ResolvedDrawingsOptions {
   const {
     enabled = true,
     persist = false,
@@ -173,7 +173,7 @@ function resolveDrawings(options: DrawingsOptions = {}): ResolvedDrawingsOptions
   const persistPath = typeof persist === 'string'
     ? persist
     : persist
-      ? '.slidev/drawings'
+      ? `.slidev/drawings${filepath ? `/${filepath.match(/([^\\\/]+?)(\.\w+)?$/)?.[1]}` : ''}`
       : false
 
   return {

--- a/packages/parser/src/core.ts
+++ b/packages/parser/src/core.ts
@@ -154,7 +154,7 @@ export function parse(
 
   const headmatter = slides[0]?.frontmatter || {}
   headmatter.title = headmatter.title || slides[0]?.title
-  const config = resolveConfig(headmatter, themeMeta)
+  const config = resolveConfig(headmatter, themeMeta, filepath)
   const features = detectFeatures(markdown)
 
   return {

--- a/packages/slidev/node/build.ts
+++ b/packages/slidev/node/build.ts
@@ -16,7 +16,7 @@ export async function build(
   viteConfig: InlineConfig = {},
 ) {
   const indexPath = resolve(options.userRoot, 'index.html')
-  const rawConfig = await resolveConfig({}, 'build')
+  const rawConfig = await resolveConfig({}, 'build', options.entry)
   const pluginOptions = rawConfig.slidev || {}
 
   let originalIndexHTML: string | undefined

--- a/packages/slidev/node/drawings.ts
+++ b/packages/slidev/node/drawings.ts
@@ -1,11 +1,15 @@
-import { basename, dirname, join, resolve } from 'path'
+import { basename, dirname, join, resolve, extname } from 'path'
 import fs from 'fs-extra'
 import fg from 'fast-glob'
 import type { ResolvedSlidevOptions } from './options'
 
 function resolveDrawingsDir(options: ResolvedSlidevOptions): string | undefined {
   return options.data.config.drawings.persist
-    ? resolve(dirname(options.entry), options.data.config.drawings.persist)
+    ? resolve(
+      dirname(options.entry),
+      options.data.config.drawings.persist,
+      basename(options.entry, extname(options.entry))
+    )
     : undefined
 }
 

--- a/packages/slidev/node/drawings.ts
+++ b/packages/slidev/node/drawings.ts
@@ -1,4 +1,4 @@
-import { basename, dirname, join, resolve, extname } from 'path'
+import { basename, dirname, join, resolve } from 'path'
 import fs from 'fs-extra'
 import fg from 'fast-glob'
 import type { ResolvedSlidevOptions } from './options'
@@ -8,7 +8,6 @@ function resolveDrawingsDir(options: ResolvedSlidevOptions): string | undefined 
     ? resolve(
       dirname(options.entry),
       options.data.config.drawings.persist,
-      basename(options.entry, extname(options.entry))
     )
     : undefined
 }

--- a/packages/slidev/node/options.ts
+++ b/packages/slidev/node/options.ts
@@ -146,7 +146,7 @@ export async function resolveOptions(
     const themeMeta = await getThemeMeta(theme, join(themeRoots[0], 'package.json'))
     data.themeMeta = themeMeta
     if (themeMeta)
-      data.config = parser.resolveConfig(data.headmatter, themeMeta)
+      data.config = parser.resolveConfig(data.headmatter, themeMeta, options.entry)
   }
 
   debug({

--- a/packages/slidev/node/server.ts
+++ b/packages/slidev/node/server.ts
@@ -10,7 +10,7 @@ export async function createServer(
   viteConfig: InlineConfig = {},
   serverOptions: SlidevServerOptions = {},
 ) {
-  const rawConfig = await resolveConfig({}, 'serve')
+  const rawConfig = await resolveConfig({}, 'serve', options.entry)
   const pluginOptions = rawConfig.slidev || {}
 
   // default open editor to code, #312


### PR DESCRIPTION
Initially, persistent drawings were stored in the same dir for the whole project.
Using multiple different entry slides was leading to overriding drawings.