### PR TITLE
chore: bump vite-plugin-vue-markdown

### DIFF
--- a/packages/slidev/package.json
+++ b/packages/slidev/package.json
@@ -89,7 +89,7 @@
     "unplugin-vue-components": "^0.22.4",
     "vite": "^3.0.9",
     "vite-plugin-remote-assets": "^0.3.0",
-    "vite-plugin-vue-markdown": "~0.20.1",
+    "vite-plugin-vue-markdown": "~0.21.1",
     "vite-plugin-vue-server-ref": "^0.3.0",
     "vite-plugin-windicss": "^1.8.7",
     "vue": "^3.2.38",

--- a/packages/slidev/package.json
+++ b/packages/slidev/package.json
@@ -89,7 +89,7 @@
     "unplugin-vue-components": "^0.22.4",
     "vite": "^3.0.9",
     "vite-plugin-remote-assets": "^0.3.0",
-    "vite-plugin-vue-markdown": "~0.21.1",
+    "vite-plugin-vue-markdown": "0.21.0",
     "vite-plugin-vue-server-ref": "^0.3.0",
     "vite-plugin-windicss": "^1.8.7",
     "vue": "^3.2.38",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -282,7 +282,7 @@ importers:
       unplugin-vue-components: ^0.22.4
       vite: ^3.0.9
       vite-plugin-remote-assets: ^0.3.0
-      vite-plugin-vue-markdown: ~0.21.1
+      vite-plugin-vue-markdown: 0.21.0
       vite-plugin-vue-server-ref: ^0.3.0
       vite-plugin-windicss: ^1.8.7
       vue: ^3.2.38
@@ -330,7 +330,7 @@ importers:
       unplugin-vue-components: 0.22.4_vite@3.0.9+vue@3.2.38
       vite: 3.0.9
       vite-plugin-remote-assets: 0.3.0_vite@3.0.9
-      vite-plugin-vue-markdown: 0.21.1_vite@3.0.9
+      vite-plugin-vue-markdown: 0.21.0_vite@3.0.9
       vite-plugin-vue-server-ref: 0.3.0_vite@3.0.9+vue@3.2.38
       vite-plugin-windicss: 1.8.7_vite@3.0.9
       vue: 3.2.38
@@ -6766,8 +6766,8 @@ packages:
       - supports-color
     dev: false
 
-  /vite-plugin-vue-markdown/0.21.1_vite@3.0.9:
-    resolution: {integrity: sha512-tvHtARDdNK45nSJhyCVaRhSxBAEVmgA6aD+xV1J4xXynNNxRaYXcpHS3l3S7l09j/lR3beRjTfbS+Ro6ipSHmA==}
+  /vite-plugin-vue-markdown/0.21.0_vite@3.0.9:
+    resolution: {integrity: sha512-7qFs3mQu1nV9HiiQ0EZD0aG++qsUW4K8TOuIWHa5uVaOxq8WLgr+AkFK0UJDJ+kLG6fL8MWoBYUfsrJOPcLGoA==}
     peerDependencies:
       vite: ^2.0.0 || ^3.0.0-0
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -282,7 +282,7 @@ importers:
       unplugin-vue-components: ^0.22.4
       vite: ^3.0.9
       vite-plugin-remote-assets: ^0.3.0
-      vite-plugin-vue-markdown: ~0.20.1
+      vite-plugin-vue-markdown: ~0.21.1
       vite-plugin-vue-server-ref: ^0.3.0
       vite-plugin-windicss: ^1.8.7
       vue: ^3.2.38
@@ -330,7 +330,7 @@ importers:
       unplugin-vue-components: 0.22.4_vite@3.0.9+vue@3.2.38
       vite: 3.0.9
       vite-plugin-remote-assets: 0.3.0_vite@3.0.9
-      vite-plugin-vue-markdown: 0.20.1_vite@3.0.9
+      vite-plugin-vue-markdown: 0.21.1_vite@3.0.9
       vite-plugin-vue-server-ref: 0.3.0_vite@3.0.9+vue@3.2.38
       vite-plugin-windicss: 1.8.7_vite@3.0.9
       vue: 3.2.38
@@ -725,11 +725,24 @@ packages:
       type-detect: 4.0.8
     dev: true
 
-  /@mdit-vue/plugin-component/0.1.1:
-    resolution: {integrity: sha512-DC4OEZO737FbvwZxVToO2d9jprbQEs4lor7bylEBrPDYDds8pjRBUIx2BNc54X0effIopsZhq+b4gxkOHJOPNQ==}
+  /@mdit-vue/plugin-component/0.8.1:
+    resolution: {integrity: sha512-lBkVDc4/uq93CDKBUbKZ25lpBwZ4fghHaBMV956Eb/Qp7isHzqn31qpdJT6S7nPNltt9clkWTVZeZRL7hmRKUw==}
     dependencies:
       '@types/markdown-it': 12.2.3
       markdown-it: 13.0.1
+    dev: false
+
+  /@mdit-vue/plugin-frontmatter/0.8.0:
+    resolution: {integrity: sha512-STjTlQ+gxLBprcdyu2dH8kezgBwqS/jlPKLsy18BMSHoElGJeDJM458lwDa3MGL+Mm+g5NK0KoWTnQHj/9Uwow==}
+    dependencies:
+      '@mdit-vue/types': 0.8.0
+      '@types/markdown-it': 12.2.3
+      gray-matter: 4.0.3
+      markdown-it: 13.0.1
+    dev: false
+
+  /@mdit-vue/types/0.8.0:
+    resolution: {integrity: sha512-g6Tc8JwwJjTnx8sb66ZFCHvJ5TJpvoRnAkGT8Aq0K6UcvAOslODaU4tQ87WZ1ETTeXE9PTYPLGxngRudcyMHoQ==}
     dev: false
 
   /@nodelib/fs.scandir/2.1.5:
@@ -6753,16 +6766,17 @@ packages:
       - supports-color
     dev: false
 
-  /vite-plugin-vue-markdown/0.20.1_vite@3.0.9:
-    resolution: {integrity: sha512-OKWb7dtfb8SU2CLUQHWFz54eYN8Y3d3P8FpQCb7yzzh/GetTJVdY57A/orvzNJxAJqjZXx2Af1Q9ncj2wsGkiw==}
+  /vite-plugin-vue-markdown/0.21.1_vite@3.0.9:
+    resolution: {integrity: sha512-tvHtARDdNK45nSJhyCVaRhSxBAEVmgA6aD+xV1J4xXynNNxRaYXcpHS3l3S7l09j/lR3beRjTfbS+Ro6ipSHmA==}
     peerDependencies:
       vite: ^2.0.0 || ^3.0.0-0
     dependencies:
       '@antfu/utils': 0.5.2
-      '@mdit-vue/plugin-component': 0.1.1
+      '@mdit-vue/plugin-component': 0.8.1
+      '@mdit-vue/plugin-frontmatter': 0.8.0
+      '@mdit-vue/types': 0.8.0
       '@rollup/pluginutils': 4.2.1
       '@types/markdown-it': 12.2.3
-      gray-matter: 4.0.3
       markdown-it: 13.0.1
       vite: 3.0.9
     dev: false


### PR DESCRIPTION
Resolves #658 

Pinned it to `0.21.0` due to https://github.com/mdit-vue/vite-plugin-vue-markdown/issues/9