### PR TITLE
feat!: injection chains to allow merging custom and addons/themes keyboard shortcuts

### DIFF
--- a/packages/client/logic/shortcuts.ts
+++ b/packages/client/logic/shortcuts.ts
@@ -42,10 +42,10 @@ export function strokeShortcut(key: KeyFilter, fn: Fn) {
 }
 
 export function registerShortcuts() {
-  const { customShortcuts, defaultShortcuts } = setupShortcuts()
+  const allShortcuts = setupShortcuts()
 
   const shortcuts = new Map<string | Ref<Boolean>, ShortcutOptions>(
-    [...defaultShortcuts, ...customShortcuts].map((options: ShortcutOptions) => [options.key, options]),
+    allShortcuts.map((options: ShortcutOptions) => [options.key, options]),
   )
 
   shortcuts.forEach((options) => {

--- a/packages/client/setup/shortcuts.ts
+++ b/packages/client/setup/shortcuts.ts
@@ -28,7 +28,8 @@ export default function setupShortcuts() {
     showGotoDialog: () => showGotoDialog.value = !showGotoDialog.value,
   }
 
-  const injection_arg_2: ShortcutOptions[] = [
+  // eslint-disable-next-line prefer-const
+  let injection_return: ShortcutOptions[] = [
     { name: 'next_space', key: and(space, not(shift)), fn: next, autoRepeat: true },
     { name: 'prev_space', key: and(space, shift), fn: prev, autoRepeat: true },
     { name: 'next_right', key: and(right, not(shift), not(showOverview)), fn: next, autoRepeat: true },
@@ -50,10 +51,7 @@ export default function setupShortcuts() {
     { name: 'goto_from_overview', key: and(enter, showOverview), fn: () => { go(currentOverviewPage.value); showOverview.value = false } },
   ]
 
-  // eslint-disable-next-line prefer-const
-  let injection_return: Array<ShortcutOptions> = []
-
   /* __chained_injections__ */
 
-  return { customShortcuts: injection_return, defaultShortcuts: injection_arg_2 }
+  return injection_return
 }

--- a/packages/client/setup/shortcuts.ts
+++ b/packages/client/setup/shortcuts.ts
@@ -51,7 +51,23 @@ export default function setupShortcuts() {
     { name: 'goto_from_overview', key: and(enter, showOverview), fn: () => { go(currentOverviewPage.value); showOverview.value = false } },
   ]
 
+  const baseShortcutNames = new Set(injection_return.map(s => s.name))
+
   /* __chained_injections__ */
+
+  const remainingBaseShortcutNames = injection_return.filter(s => s.name && baseShortcutNames.has(s.name))
+  if (remainingBaseShortcutNames.length === 0) {
+    const message = [
+      '========== WARNING ==========',
+      'defineShortcutsSetup did not return any of the base shortcuts.',
+      'See https://sli.dev/custom/config-shortcuts.html for migration.',
+      'If it is intentional, return at least one shortcut with one of the base names (e.g. name:"goto").',
+    ].join('\n\n')
+    // eslint-disable-next-line no-alert
+    alert(message)
+
+    console.warn(message)
+  }
 
   return injection_return
 }

--- a/packages/client/setup/shortcuts.ts
+++ b/packages/client/setup/shortcuts.ts
@@ -53,7 +53,7 @@ export default function setupShortcuts() {
   // eslint-disable-next-line prefer-const
   let injection_return: Array<ShortcutOptions> = []
 
-  /* __injections__ */
+  /* __chained_injections__ */
 
   return { customShortcuts: injection_return, defaultShortcuts: injection_arg_2 }
 }


### PR DESCRIPTION
Fixes https://github.com/slidevjs/slidev/issues/629

IMPORTANT, There are 4 commits
- the 1st one is the core feature, probably without big issues,
- the 2nd one is an (optional but that I find nice) refactoring,
- the 3rd one is **to be discussed** (or just dropped) as it is a **breaking change** and would necessarily require a documentation update (that would be highly recommended anyways even with the first commits).
- following the discussion commit 4 adds a user message to help migration

Basically, the third commit breaks every situation that used setup/shortcuts (the default shortcuts are then removed).
The doc update would suggest something like:
```ts
export default defineShortcutsSetup((nav: NavOperations, baseShortcuts: any) => {
  return [
    ...baseShortcuts,
    {
```


Related to https://github.com/slidevjs/slidev/pull/659 (authored by @manniL )
- I kept the multi-args logic even if (with the 3rd commit) it is not used anymore, because it can become useful
- to remove some shortcuts, the principle would be to remove from baseShortcuts before the return with ...baseShortcuts (i.e. there is no "global" object that we mutate, only the return value is used)
