### PR TITLE
feat: support custom preparser

### DIFF
--- a/packages/parser/src/fs.ts
+++ b/packages/parser/src/fs.ts
@@ -1,14 +1,26 @@
 import { promises as fs } from 'fs'
 import { dirname, resolve } from 'path'
-import type { SlideInfo, SlideInfoWithPath, SlidevMarkdown, SlidevThemeMeta } from '@slidev/types'
+import type { PreparserExtensionLoader, SlideInfo, SlideInfoWithPath, SlidevMarkdown, SlidevPreparserExtension, SlidevThemeMeta } from '@slidev/types'
 import { detectFeatures, mergeFeatureFlags, parse, stringify, stringifySlide } from './core'
 export * from './core'
+
+let preparserExtensionLoader: PreparserExtensionLoader | null = null
+
+export function injectPreparserExtensionLoader(fn: PreparserExtensionLoader) {
+  preparserExtensionLoader = fn
+}
 
 export async function load(filepath: string, themeMeta?: SlidevThemeMeta, content?: string) {
   const dir = dirname(filepath)
   const markdown = content ?? await fs.readFile(filepath, 'utf-8')
 
-  const data = parse(markdown, filepath, themeMeta)
+  const preparserExtensions: SlidevPreparserExtension[] = []
+  const data = await parse(markdown, filepath, themeMeta, [], async (headmatter, exts: SlidevPreparserExtension[], filepath: string | undefined) => {
+    return [
+      ...exts,
+      ...preparserExtensionLoader ? await preparserExtensionLoader(headmatter.addons ?? [], filepath) : [],
+    ]
+  })
 
   const entries = new Set([
     filepath,
@@ -26,7 +38,7 @@ export async function load(filepath: string, themeMeta?: SlidevThemeMeta, conten
     const srcExpression = baseSlide.frontmatter.src
     const path = resolve(dir, srcExpression)
     const raw = await fs.readFile(path, 'utf-8')
-    const subSlides = parse(raw, path, themeMeta)
+    const subSlides = await parse(raw, path, themeMeta, preparserExtensions)
 
     for (const [offset, subSlide] of subSlides.slides.entries()) {
       const slide: SlideInfo = { ...baseSlide }

--- a/packages/slidev/node/plugins/setupNode.ts
+++ b/packages/slidev/node/plugins/setupNode.ts
@@ -1,5 +1,5 @@
 import { resolve } from 'path'
-import { existsSync } from 'fs-extra'
+import { pathExists } from 'fs-extra'
 import { isObject } from '@antfu/utils'
 import jiti from 'jiti'
 
@@ -20,7 +20,7 @@ export async function loadSetups<T, R extends object>(roots: string[], name: str
   let returns = initial
   for (const root of roots) {
     const path = resolve(root, 'setup', name)
-    if (existsSync(path)) {
+    if (await pathExists(path)) {
       const { default: setup } = jiti(__filename)(path)
       const result = await setup(arg)
       if (result !== null) {

--- a/packages/slidev/node/plugins/setupNode.ts
+++ b/packages/slidev/node/plugins/setupNode.ts
@@ -16,7 +16,7 @@ function deepMerge(a: any, b: any, rootPath = '') {
   return a
 }
 
-export async function loadSetups<T, R extends object>(roots: string[], name: string, arg: T, initial: R, merge = true): Promise<R> {
+export async function loadSetups<T, R extends object>(roots: string[], name: string, arg: T, initial: R, merge = true, accumulate: (a: R, o: R) => R = undefined): Promise<R> {
   let returns = initial
   for (const root of roots) {
     const path = resolve(root, 'setup', name)
@@ -26,7 +26,9 @@ export async function loadSetups<T, R extends object>(roots: string[], name: str
       if (result !== null) {
         returns = merge
           ? deepMerge(returns, result)
-          : result
+          : accumulate
+            ? accumulate(returns, result)
+            : result
       }
     }
   }

--- a/packages/types/src/setups.ts
+++ b/packages/types/src/setups.ts
@@ -9,6 +9,7 @@ import type mermaid from 'mermaid'
 import type { KatexOptions } from 'katex'
 import type { WindiCssOptions } from 'vite-plugin-windicss'
 import type { VitePluginConfig as UnoCssConfig } from 'unocss/vite'
+import type { SlidevPreparserExtension } from './types'
 
 export interface AppContext {
   app: App
@@ -63,6 +64,7 @@ export type ShikiSetup = (shiki: typeof Shiki) => Awaitable<ShikiOptions | undef
 export type KatexSetup = () => Awaitable<Partial<KatexOptions> | undefined>
 export type WindiSetup = () => Awaitable<Partial<WindiCssOptions> | undefined>
 export type UnoSetup = () => Awaitable<Partial<UnoCssConfig> | undefined>
+export type PreparserSetup = (filepath: string) => SlidevPreparserExtension
 
 // client side
 export type MonacoSetup = (m: typeof monaco) => Awaitable<MonacoSetupReturn>
@@ -99,5 +101,9 @@ export function defineKatexSetup(fn: KatexSetup) {
 }
 
 export function defineShortcutsSetup(fn: ShortcutsSetup) {
+  return fn
+}
+
+export function definePreparserSetup(fn: PreparserSetup) {
   return fn
 }

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -55,4 +55,15 @@ export interface SlidevMarkdown {
   themeMeta?: SlidevThemeMeta
 }
 
+export interface SlidevPreparserExtension {
+  name: string
+  transformRawLines?(lines: string[]): Promise<void>
+  transformSlide?(content: string, frontmatter: any): Promise<string | undefined>
+}
+
+export type PreparserExtensionLoader = (addons: string[], filepath?: string) => Promise<SlidevPreparserExtension[]>
+
+// internal type?
+export type PreparserExtensionFromHeadmatter = (headmatter: any, exts: SlidevPreparserExtension[], filepath: string | undefined) => Promise<SlidevPreparserExtension[]>
+
 export type RenderContext = 'slide' | 'overview' | 'presenter' | 'previewNext'

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -2,6 +2,7 @@ import { basename, resolve } from 'path'
 import fg from 'fast-glob'
 import { describe, expect, it } from 'vitest'
 import { load, parse, prettify, stringify } from '../packages/parser/src/fs'
+import type { SlidevPreparserExtension } from '../slidev/types/src/types'
 
 describe('md parser', () => {
   const files = fg.sync('*.md', {
@@ -32,8 +33,8 @@ describe('md parser', () => {
     })
   }
 
-  it('parse', () => {
-    const data = parse(`
+  it('parse', async () => {
+    const data = await parse(`
 a
 
 ---
@@ -58,10 +59,12 @@ f
       .toEqual(Array.from('abcdef'))
     expect(data.slides[2].frontmatter)
       .toEqual({ layout: 'z' })
+    expect(data.slides[3].frontmatter)
+      .toEqual({ })
   })
 
-  it('parse section matter', () => {
-    const data = parse(`
+  it('parse section matter', async () => {
+    const data = await parse(`
 a
 
 ---
@@ -86,5 +89,156 @@ f
       .toEqual(Array.from('abcdef'))
     expect(data.slides[2].frontmatter)
       .toEqual({ layout: 'z' })
+    expect(data.slides[3].frontmatter)
+      .toEqual({ })
   })
+
+  async function parseWithExtension(src, handle, more = {}, moreExts: SlidevPreparserExtension = []) {
+    return await parse(src, undefined, undefined, undefined, async () => [{ handle, ...more }, ...moreExts])
+  }
+
+  it('parse with-extension replace', async () => {
+    const data = await parseWithExtension(`---
+ga: bu
+---
+a @@v@@
+
+---
+
+b
+@@v@@
+
+@@v@@ = @@v@@
+`, (s) => {
+      s.lines[s.i] = s.lines[s.i].replace(/@@v@@/g, 'thing')
+      return false
+    })
+
+    expect(data.slides.map(i => i.content.trim().replace(/\n/g, '%')).join('/'))
+      .toEqual('a thing/b%thing%%thing = thing')
+  })
+
+  it('parse with-extension disabled', async () => {
+    const data = await parseWithExtension(`
+a @@v@@
+
+---
+
+b
+@@v@@
+
+@@v@@ = @@v@@
+`, (s) => {
+      s.lines[s.i] = s.lines[s.i].replace(/@@v@@/g, 'thing')
+      return false
+    }, { disabled: true })
+
+    expect(data.slides.map(i => i.content.trim().replace(/\n/g, '%')).join('/'))
+      .toEqual('a @@v@@/b%@@v@@%%@@v@@ = @@v@@')
+  })
+
+  it('parse with-extension pingpong', async () => {
+    const data = await parseWithExtension(`
+.
+a.
+.
+`, () => false, {}, [{
+      handle(s) {
+        const l = s.lines[s.i]
+        if (l.startsWith('......'))
+          return false
+        if (l.startsWith('.')) {
+          s.lines[s.i] = `.${s.lines[s.i]}`
+          return true
+        }
+        return false
+      },
+    },
+    {
+      handle(s) {
+        const l = s.lines[s.i]
+        if (l[0] !== '.' || l.length > 9)
+          return false
+        s.lines[s.i] = `.A${s.lines[s.i]}`
+        return true
+      },
+    },
+    ])
+    expect(data.slides.map(i => i.content.trim().replace(/\n/g, '%')).join('/'))
+      .toEqual('......A......%a.%......A......')
+  })
+
+  // Generate cartesian product of given iterables:
+  function* cartesian(...all) {
+    const [head, ...tail] = all
+    const remainder = tail.length ? cartesian(...tail) : [[]]
+    for (const r of remainder) for (const h of head) yield [h, ...r]
+  }
+  const B = [0, 1]
+  const Bs = [B, B, B, B, B, B, B]
+  const bNames = '_swScCfF'
+
+  for (const desc of cartesian(...Bs)) {
+    const [withSlideBefore, withFrontmatter, withSlideAfter, prependContent, appendContent, prependFrontmatter, appendFrontmatter] = desc
+    it(`parse with-extension wrap ${desc.map((b, i) => bNames[b * (i + 1)]).join('')}`, async () => {
+      const data = await parseWithExtension(`${
+withSlideBefore
+? `
+.
+
+---
+`
+: ''}${!withSlideBefore && withFrontmatter ? '---\n' : ''}${withFrontmatter
+? `m: M
+n: N
+---`
+: ''}
+
+ccc
+@a
+@b
+ddd
+${
+withSlideAfter
+? `
+---
+
+..
+`
+: ''}`, (s) => {
+        const l = s.lines[s.i]
+        if (l.startsWith('@')) {
+          const t = l.substr(1)
+          if (prependContent)
+            s.contentPrepend.push(`<${t}>`)
+          if (appendContent)
+            s.contentAppend.unshift(`</${t}>`)
+          if (prependFrontmatter)
+            s.frontmatterPrepend.push(`start${t}: start`)
+          if (appendFrontmatter)
+            s.frontmatterAppend.unshift(`end${t}: end`)
+          s.lines.splice(s.i, 1)
+          return true
+        }
+      })
+      function project(s) {
+        // like the trim in other tests, the goal is not to test newlines here
+        return s.replace(/%%%*/g, '%')
+      }
+      const fm = withFrontmatter || prependFrontmatter || appendFrontmatter
+      expect(project(data.slides.map(i => i.raw.replace(/\n/g, '%')).join('/')))
+        .toEqual(project([
+          ...withSlideBefore ? ['%.%/'] : [],
+          ...fm ? ['---%'] : [],
+          ...prependFrontmatter ? ['starta: start%startb: start%'] : [],
+          ...withFrontmatter ? ['m: M%n: N%'] : [],
+          ...appendFrontmatter ? ['endb: end%enda: end%'] : [],
+          ...fm ? ['---%'] : [],
+          ...prependContent ? ['<a>%<b>%'] : [],
+          '%ccc%ddd%',
+          ...appendContent ? ['</b>%</a>'] : [],
+          ...withSlideAfter ? ['/%..%'] : [],
+        ].join('')))
+    })
+  }
 })


### PR DESCRIPTION
Targeting https://github.com/slidevjs/slidev/issues/700

- [x] ~~rewrite parser to a single while loop and an explicit state (including the current mode, i.e. what it is currently parsing)~~
- [x] make it extensible by addons
- [x] add addon pseudo-callbacks in useful places ~~(e.g. onSlice)~~ (toplevel all lines (as splitting is already done, and per slide)
- [x] allow easy "wrap" use case (to prepend and append lines to the content)
- [x] integrate tests in the testing infrastructure
- [x] make an initial documentation (a few typical use cases) https://github.com/slidevjs/docs/pull/91/files
- [ ] update the doc with the latest API

I think the core of the PR is fully ok (all parser tests still passing, more tests added for the extensibility).

The question of **clean integration in the project** is to be checked as I'm not fully familiar with its architecture.