### PR TITLE
feat: add layout of two columns with a header (two-cols-header)

### DIFF
--- a/packages/client/layouts/two-cols-header.vue
+++ b/packages/client/layouts/two-cols-header.vue
@@ -1,0 +1,39 @@
+<!--
+  Usage:
+```md
+---
+layout: two-cols-header
+---
+This spans both
+::left::
+# Left
+This shows on the left
+::right::
+# Right
+This shows on the right
+```
+-->
+
+<script setup lang="ts">
+const props = defineProps({
+  class: {
+    type: String,
+  },
+})
+</script>
+
+<template>
+  <div class="slidev-layout two-columns w-full h-full">
+    <div class="col-span-2">
+      <slot />
+    </div>
+    <div class="grid grid-cols-2">
+      <div class="col-left" :class="props.class">
+        <slot name="left" />
+      </div>
+      <div class="col-right" :class="props.class">
+        <slot name="right" />
+      </div>
+    </div>
+  </div>
+</template>


### PR DESCRIPTION
I was missing this layout, since it's one I use a lot:

<img width="419" alt="image" src="https://user-images.githubusercontent.com/1029947/190376739-ac71c8b1-f0d0-41f4-9e5e-2ff918293d88.png">

In slidev, it looks like this:

<img width="1508" alt="image" src="https://user-images.githubusercontent.com/1029947/190376574-eb51ec4c-69b0-44ee-b9aa-f734d04aabdf.png">
