### PR TITLE
feat: optionally hide subpages

### DIFF
--- a/demo/starter/pages/hidden.md
+++ b/demo/starter/pages/hidden.md
@@ -1,3 +1,0 @@
-# Hidden Page
-
-You're not supposed to see this page.

--- a/demo/starter/pages/hidden.md
+++ b/demo/starter/pages/hidden.md
@@ -1,0 +1,3 @@
+# Hidden Page
+
+You're not supposed to see this page.

--- a/demo/starter/pages/multiple-entries.md
+++ b/demo/starter/pages/multiple-entries.md
@@ -1,0 +1,27 @@
+# Multiple Entries
+
+You can split your slides.md into multiple files and organize them as you want.
+
+#### `slides.md`
+
+```markdown
+# Page 1
+
+This is a normal page
+
+---
+src: ./subpage2.md
+hide: false # optionally set `hide` to true to avoid showing `./subpage2.md`
+---
+
+<!-- this page will be loaded from './subpage2.md' -->
+Inline content will be ignored
+```
+
+#### `subpage2.md`
+
+```markdown
+# Page 2
+
+This page is from another file
+```

--- a/demo/starter/pages/multiple-entries.md
+++ b/demo/starter/pages/multiple-entries.md
@@ -1,27 +1,27 @@
 # Multiple Entries
 
-You can split your slides.md into multiple files and organize them as you want.
+You can split your slides.md into multiple files and organize them as you want using the `src` attribute.
 
 #### `slides.md`
 
 ```markdown
 # Page 1
 
-This is a normal page
+Page 2 from main entry.
 
 ---
-src: ./subpage2.md
-hide: false # optionally set `hide` to true to avoid showing `./subpage2.md`
+src: ./subpage.md
 ---
-
-<!-- this page will be loaded from './subpage2.md' -->
-Inline content will be ignored
 ```
 
-#### `subpage2.md`
+<br>
+
+#### `subpage.md`
 
 ```markdown
 # Page 2
 
-This page is from another file
+Page 2 from another file.
 ```
+
+[Learn more](https://sli.dev/guide/syntax.html#multiple-entries)

--- a/demo/starter/slides.md
+++ b/demo/starter/slides.md
@@ -374,6 +374,10 @@ database "MySql" {
 
 [Learn More](https://sli.dev/guide/syntax.html#diagrams)
 
+---
+src: ./pages/multiple-entries.md
+hide: false # set to true to hide this page
+---
 
 ---
 layout: center

--- a/demo/starter/slides.md
+++ b/demo/starter/slides.md
@@ -376,7 +376,7 @@ database "MySql" {
 
 ---
 src: ./pages/multiple-entries.md
-hide: false # set to true to hide this page
+hide: false
 ---
 
 ---

--- a/packages/parser/src/fs.ts
+++ b/packages/parser/src/fs.ts
@@ -23,6 +23,9 @@ export async function load(filepath: string, themeMeta?: SlidevThemeMeta, conten
 
     data.slides.splice(iSlide, 1)
 
+    if (baseSlide.frontmatter.hide)
+      continue
+
     const srcExpression = baseSlide.frontmatter.src
     const path = resolve(dir, srcExpression)
     const raw = await fs.readFile(path, 'utf-8')


### PR DESCRIPTION
Optionally hide subpages via `hide: true`. The `starter` demo slides now reflect this new functionality.

Example:

```markdown
---
src: ./subpage2.md
hide: true
---
```

In this example, `./subpage2.md` is skipped. This:
- doesn't generate any extra slide
- doesn't forget about any other slide in the deck
- keeps `$slidev.nav.currentPage` and `$slidev.nav.total` consistent, as if the markdown block above was never defined in the first place.

Closes https://github.com/slidevjs/slidev/issues/720.

TODO:
- [ ] Highlight the new functionality in [slidevjs/docs](https://github.com/slidevjs/docs) and [slidevjs/docs-cn](https://github.com/slidevjs/docs-cn)