### PR TITLE
fix(vercel): fix build outputs configuration

### DIFF
--- a/packages/create-app/template/vercel.json
+++ b/packages/create-app/template/vercel.json
@@ -1,5 +1,7 @@
 {
   "rewrites": [
     { "source": "/(.*)", "destination": "/index.html" }
-  ]
+  ],
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist"
 }


### PR DESCRIPTION
Changes the default `vercel.json` file from

```json
{
  "rewrites": [
    { "source": "/(.*)", "destination": "/index.html" }
  ],
}
```

to

```json
{
  "rewrites": [
    { "source": "/(.*)", "destination": "/index.html" }
  ],
  "buildCommand": "npm run build",
  "outputDirectory": "dist"
}
```

Closes https://github.com/slidevjs/slidev/issues/722.