### PR TITLE
fix: create app template error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ slides-export.md
 assets/demo
 packages/slidev/README.md
 packages/create-app/template/slides.md
+packages/create-app/template/pages
 composable-vue-cn
 components.d.ts
 .slidev

--- a/packages/create-app/build.mjs
+++ b/packages/create-app/build.mjs
@@ -1,0 +1,31 @@
+import { copyFileSync, existsSync, mkdirSync, rmSync } from 'node:fs'
+import * as url from 'node:url'
+import { resolve } from 'node:path'
+
+const __dirname = url.fileURLToPath(new URL('.', import.meta.url))
+const __templateDir = resolve(__dirname, 'template')
+const __pagesDir = resolve(__templateDir, 'pages')
+
+const shouldCreatePagesDict = () => existsSync(__pagesDir)
+
+const needCopyFiles = {
+  'slides.md': '../../../demo/starter/slides.md',
+  'pages/multiple-entries.md': '../../../demo/starter/pages/multiple-entries.md',
+}
+
+function main() {
+  if (!shouldCreatePagesDict())
+    mkdirSync(__pagesDir)
+  Object.keys(needCopyFiles).forEach((relativeTargetPath) => {
+    const sourcePath = resolve(__templateDir, needCopyFiles[relativeTargetPath])
+    const targetPath = resolve(__templateDir, relativeTargetPath)
+    const exist = existsSync(targetPath)
+    if (exist)
+      rmSync(targetPath)
+    copyFileSync(sourcePath, targetPath)
+  })
+  // eslint-disable-next-line no-console
+  console.log('done...')
+}
+
+main()

--- a/packages/create-app/build.mjs
+++ b/packages/create-app/build.mjs
@@ -8,6 +8,8 @@ const __pagesDir = resolve(__templateDir, 'pages')
 
 const shouldCreatePagesDict = () => !existsSync(__pagesDir)
 
+// key: copy to (relative ./)
+// value: origin (relative ./template)
 const needCopyFiles = {
   'slides.md': '../../../demo/starter/slides.md',
   'pages/multiple-entries.md': '../../../demo/starter/pages/multiple-entries.md',

--- a/packages/create-app/build.mjs
+++ b/packages/create-app/build.mjs
@@ -6,7 +6,7 @@ const __dirname = url.fileURLToPath(new URL('.', import.meta.url))
 const __templateDir = resolve(__dirname, 'template')
 const __pagesDir = resolve(__templateDir, 'pages')
 
-const shouldCreatePagesDict = () => existsSync(__pagesDir)
+const shouldCreatePagesDict = () => !existsSync(__pagesDir)
 
 const needCopyFiles = {
   'slides.md': '../../../demo/starter/slides.md',
@@ -14,7 +14,7 @@ const needCopyFiles = {
 }
 
 function main() {
-  if (!shouldCreatePagesDict())
+  if (shouldCreatePagesDict())
     mkdirSync(__pagesDir)
   Object.keys(needCopyFiles).forEach((relativeTargetPath) => {
     const sourcePath = resolve(__templateDir, needCopyFiles[relativeTargetPath])

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -19,7 +19,7 @@
     "node": ">=14.0.0"
   },
   "scripts": {
-    "build": "cp ../../demo/starter/slides.md template/slides.md",
+    "build": "node build.mjs",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {


### PR DESCRIPTION
Here is the thing:
- package `create-app` invoke build
- build command copy files

but ../../demo/starter/slides.md includes ../../demo/starter/pages/multiple-entries.md:

<img width="705" alt="image" src="https://user-images.githubusercontent.com/49969959/194849050-3a1e0363-4727-4600-ab5b-34cbc65e7310.png">

So we must copy `multiple-entries.md` when build.

I create a script to do this work.

Hope will fix this issue :)
