### PR TITLE
fix(layouts): prevent overflow in `image-left` and `image-right` layouts

### DIFF
--- a/packages/client/layouts/image-left.vue
+++ b/packages/client/layouts/image-left.vue
@@ -15,7 +15,7 @@ const style = computed(() => handleBackground(props.image))
 </script>
 
 <template>
-  <div class="grid grid-cols-2 w-full h-full">
+  <div class="grid grid-cols-2 w-full h-full auto-rows-fr">
     <div class="w-full w-full" :style="style" />
     <div class="slidev-layout default" :class="props.class">
       <slot />

--- a/packages/client/layouts/image-right.vue
+++ b/packages/client/layouts/image-right.vue
@@ -15,7 +15,7 @@ const style = computed(() => handleBackground(props.image))
 </script>
 
 <template>
-  <div class="grid grid-cols-2 w-full h-full">
+  <div class="grid grid-cols-2 w-full h-full auto-rows-fr">
     <div class="slidev-layout default" :class="props.class">
       <slot />
     </div>


### PR DESCRIPTION
Hello, 
I noticed that the size of the full height images in the `image-left` and `image-right` template changes depending on the size of the opposite column. This can be seen in the first image, where the left column is slightly larger than the parent slide. This automatically enlarges the image column as well.
This can look off, when two `image-right` or two `image-left`-slides are used immediately after another with the same default image. The slide that has overflowing content, will show a more zoomed in image (image1) than the one without overflow (image2).
This pr changes the two columns to be only as heigh as the parent slide, e.g. eliminating overflow content.
There are also other options like absolute positioning, if the content should be able to overflow the content without affecting the full size image. If that is not needed this should be the easiest solution

Image 1
![overflow-on](https://user-images.githubusercontent.com/6861911/197363270-68da9185-a34c-4d00-bde3-c713c7d61dd7.jpg)

Image 2
![overflow-off](https://user-images.githubusercontent.com/6861911/197363269-dc5801f5-7fd6-4082-bf8c-d6c4bffb29ac.jpg)

Cheers
