### PR TITLE
fix: currentLayout will no longer be empty

### DIFF
--- a/packages/client/composables/useNav.ts
+++ b/packages/client/composables/useNav.ts
@@ -13,7 +13,7 @@ export function useNav(route: ComputedRef<RouteLocationNormalizedLoaded>) {
   const currentPath = computed(() => getPath(currentPage.value))
   const currentRoute = computed(() => rawRoutes.find(i => i.path === `${currentPage.value}`))
   const currentSlideId = computed(() => currentRoute.value?.meta?.slide?.id)
-  const currentLayout = computed(() => currentRoute.value?.meta?.layout)
+  const currentLayout = computed(() => currentRoute.value?.meta?.layout || (currentPage.value === 1 ? 'cover' : 'default'))
 
   const nextRoute = computed(() => rawRoutes.find(i => i.path === `${Math.min(rawRoutes.length, currentPage.value + 1)}`))
 

--- a/packages/client/logic/nav.ts
+++ b/packages/client/logic/nav.ts
@@ -47,7 +47,7 @@ export const currentPage = computed(() => parseInt(path.value.split(/\//g).slice
 export const currentPath = computed(() => getPath(currentPage.value))
 export const currentRoute = computed(() => rawRoutes.find(i => i.path === `${currentPage.value}`))
 export const currentSlideId = computed(() => currentRoute.value?.meta?.slide?.id)
-export const currentLayout = computed(() => currentRoute.value?.meta?.layout)
+export const currentLayout = computed(() => currentRoute.value?.meta?.layout || (currentPage.value === 1 ? 'cover' : 'default'))
 
 export const nextRoute = computed(() => rawRoutes.find(i => i.path === `${Math.min(rawRoutes.length, currentPage.value + 1)}`))
 


### PR DESCRIPTION
When no layout is explicitly configured, the currentLayout value is empty. There are actually two possibilities, `cover` and `default`.