### PR TITLE
feat: Add brushSize control UI #518

### DIFF
--- a/packages/client/internals/Draggable.vue
+++ b/packages/client/internals/Draggable.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
 import { ref } from 'vue'
+import type { Position } from '@vueuse/core'
 import { useDraggable, useStorage } from '@vueuse/core'
 
 const props = defineProps<{
   storageKey?: string
   initial?: { x: number; y: number }
+  onStart?: (position: Position, event: PointerEvent) => void | false
 }>()
 
 const el = ref<HTMLElement | null>(null)
@@ -12,7 +14,7 @@ const initial = props.initial ?? { x: 0, y: 0 }
 const point = props.storageKey
   ? useStorage(props.storageKey, initial)
   : ref(initial)
-const { style } = useDraggable(el, { initialValue: point })
+const { style } = useDraggable(el, { initialValue: point, onStart: props.onStart })
 </script>
 
 <template>

--- a/packages/client/internals/DrawingControls.vue
+++ b/packages/client/internals/DrawingControls.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
+import { ref, watch } from 'vue'
+import type { Position } from '@vueuse/core'
 import {
   brush, brushColors, canClear,
   canRedo, canUndo, clearDrauu,
-  drauu, drawingEnabled, drawingMode, drawingPinned,
+  drauu, drauuOptions, drawingEnabled, drawingMode, drawingPinned,
 } from '../logic/drawings'
 import VerticalDivider from './VerticalDivider.vue'
 import Draggable from './Draggable.vue'
@@ -21,6 +23,22 @@ function setBrushColor(color: typeof brush.color) {
   brush.color = color
   drawingEnabled.value = true
 }
+
+const brushSize = ref(drauuOptions.brush!.size)
+const excludeDraggableClass = 'drawing-control-fixed'
+
+function onStart(position: Position, event: PointerEvent) {
+  const { target } = event
+  if (!(target instanceof HTMLElement))
+    return
+  if (target.classList.contains(excludeDraggableClass))
+    return false
+}
+
+watch(brushSize, () => {
+  if (drauuOptions.brush?.size)
+    drauuOptions.brush.size = brushSize.value
+})
 </script>
 
 <template>
@@ -31,6 +49,7 @@ function setBrushColor(color: typeof brush.color) {
     storage-key="slidev-drawing-pos"
     :initial-x="10"
     :initial-y="10"
+    :on-start="onStart"
   >
     <button class="icon-btn" :class="{ shallow: drawingMode !== 'stylus' }" @click="setDrawingMode('stylus')">
       <carbon:pen />
@@ -72,6 +91,19 @@ function setBrushColor(color: typeof brush.color) {
 
     <VerticalDivider />
 
+    <div class="flex items-center w-22">
+      <input
+        v-model="brushSize"
+        class="drawing-control-range drawing-control-fixed"
+        type="range"
+        min="1"
+        max="10"
+        step="0.5"
+      >
+    </div>
+
+    <VerticalDivider />
+
     <button class="icon-btn" :class="{ disabled: !canUndo }" @click="undo()">
       <carbon:undo />
     </button>
@@ -98,3 +130,53 @@ function setBrushColor(color: typeof brush.color) {
     </button>
   </Draggable>
 </template>
+
+<style lang="postcss" scoped>
+.drawing-control-range {
+  @apply w-full appearance-none;
+}
+.drawing-control-range:focus {
+  @apply outline-0;
+}
+
+.drawing-control-range::-webkit-slider-thumb {
+  @apply w-5 h-5 border-2 border-cyan-500 rounded-full cursor-pointer bg-white appearance-none;
+  margin-top: -7px;
+}
+.drawing-control-range::-webkit-slider-runnable-track {
+  @apply bg-cyan-500 w-full h-1.5 rounded-md cursor-pointer border-0;
+}
+.drawing-control-range:focus::-webkit-slider-runnable-track {
+  @apply bg-cyan-500;
+}
+
+.drawing-control-range::-moz-range-thumb {
+  @apply w-5 h-5 border-2 border-cyan-500 rounded-full cursor-pointer bg-white;
+}
+.drawing-control-range::-moz-range-track {
+  @apply bg-cyan-500 w-full h-1.5 rounded-md cursor-pointer;
+}
+.drawing-control-range:focus::-moz-range-track {
+  @apply bg-cyan-500;
+}
+
+.drawing-control-range::-ms-thumb {
+  @apply w-5 h-5 border-2 border-cyan-500 rounded-full cursor-pointer bg-white mt-0;
+}
+.drawing-control-range::-ms-track {
+  @apply bg-cyan-500 w-full h-1.5 rounded-md cursor-pointer bg-transparent border-transparent text-transparent;
+  border-width: 20px 0;
+}
+.drawing-control-range::-ms-fill-lower {
+  @apply rounded-md bg-cyan-500;
+}
+.drawing-control-range:focus::-ms-fill-lower {
+  @apply bg-cyan-300;
+}
+.drawing-control-range::-ms-fill-upper {
+  @apply bg-slate-300 rounded-md;
+}
+.drawing-control-range:focus::-ms-fill-upper {
+  @apply bg-slate-200;
+}
+</style>


### PR DESCRIPTION
Related Issue(s)

#518

I choiced solution "add the ui to select the brush size".
https://github.com/slidevjs/slidev/issues/518#issuecomment-1236120941

brushSize input control's type and attribute are based on this drauu site.
https://drauu.netlify.app/

I customized input type="range" style but it many CSS.
If you prefer the default style, I will remove it.