### PR TITLE
feat(export): add basic metatada to exported PDF

### DIFF
--- a/packages/slidev/node/export.ts
+++ b/packages/slidev/node/export.ts
@@ -6,6 +6,7 @@ import { parseRangeString } from '@slidev/parser/core'
 import type { SlideInfo } from '@slidev/types'
 import { outlinePdfFactory } from '@lillallol/outline-pdf'
 import * as pdfLib from 'pdf-lib'
+import { PDFDocument } from 'pdf-lib'
 import { packageExists } from './utils'
 
 export interface ExportOptions {
@@ -223,9 +224,18 @@ export async function exportSlides({
       preferCSSPageSize: true,
     })
 
+    // Edit generated PDF: add metadata and (optionally) TOC
+    let pdfData = fs.readFileSync(output)
+    let pdf = await PDFDocument.load(pdfData)
+
+    const titleSlide = slides[0]
+    if (titleSlide?.title)
+      pdf.setTitle(titleSlide.title)
+    if (titleSlide?.frontmatter?.info)
+      pdf.setSubject(titleSlide.frontmatter.info)
+
     if (withTOC) {
       const outlinePdf = outlinePdfFactory(pdfLib)
-      const pdf = fs.readFileSync(output, { encoding: 'base64' })
 
       const tocTree = slides.filter(slide => slide.title)
         .reduce((acc: TocItem[], slide) => {
@@ -235,10 +245,11 @@ export async function exportSlides({
 
       const outline = makeOutline(tocTree)
 
-      const outlinedPdfDocument = await outlinePdf({ outline, pdf })
-      const outlinedPdf = await outlinedPdfDocument.save()
-      fs.writeFileSync(output, outlinedPdf)
+      pdf = await outlinePdf({ outline, pdf })
     }
+
+    pdfData = Buffer.from(await pdf.save())
+    fs.writeFileSync(output, pdfData)
   }
 
   async function genPagePng() {

--- a/packages/slidev/node/export.ts
+++ b/packages/slidev/node/export.ts
@@ -225,7 +225,7 @@ export async function exportSlides({
     })
 
     // Edit generated PDF: add metadata and (optionally) TOC
-    let pdfData = fs.readFileSync(output)
+    let pdfData = await fs.readFile(output)
     let pdf = await PDFDocument.load(pdfData)
 
     const titleSlide = slides[0]
@@ -249,7 +249,7 @@ export async function exportSlides({
     }
 
     pdfData = Buffer.from(await pdf.save())
-    fs.writeFileSync(output, pdfData)
+    await fs.writeFile(output, pdfData)
   }
 
   async function genPagePng() {


### PR DESCRIPTION
In https://github.com/slidevjs/slidev/pull/669 `pdf-lib` dependency was added and an option to process exported PDF to add some info to it.

Why not go further and enhance exported PDF a little bit more, adding basic metadata to it?

<details>
<summary>Before:</summary>

![Screenshot from 2022-11-10 21-36-14](https://user-images.githubusercontent.com/264400/201093426-77db22e9-50cc-4017-a27a-e4b209b00cf2.png)
</details>


<details>
<summary>After (look at window title):</summary>

![Screenshot from 2022-11-10 21-34-16](https://user-images.githubusercontent.com/264400/201093655-8d4f12fd-d1a5-447f-9253-8748e1059af7.png)
</details>
