### PR TITLE
fix: add missing use of addonRoots, e.g. for setup/katex.ts in addons

### DIFF
--- a/packages/slidev/node/common.ts
+++ b/packages/slidev/node/common.ts
@@ -6,7 +6,7 @@ import type { ConfigEnv, InlineConfig } from 'vite'
 import type { ResolvedSlidevOptions } from './options'
 import { generateGoogleFontsUrl, toAtFS } from './utils'
 
-export async function getIndexHtml({ clientRoot, themeRoots, data, userRoot }: ResolvedSlidevOptions): Promise<string> {
+export async function getIndexHtml({ clientRoot, themeRoots, addonRoots, data, userRoot }: ResolvedSlidevOptions): Promise<string> {
   let main = await fs.readFile(join(clientRoot, 'index.html'), 'utf-8')
   let head = ''
   let body = ''
@@ -15,6 +15,7 @@ export async function getIndexHtml({ clientRoot, themeRoots, data, userRoot }: R
 
   const roots = uniq([
     ...themeRoots,
+    ...addonRoots,
     userRoot,
   ])
 

--- a/packages/slidev/node/options.ts
+++ b/packages/slidev/node/options.ts
@@ -146,7 +146,7 @@ export async function resolveOptions(
   const themeRoots = getThemeRoots(theme, entry)
   const addons = await getAddons(userRoot, data.config)
   const addonRoots = getAddonRoots(addons, entry)
-  const roots = uniq([clientRoot, ...themeRoots, userRoot])
+  const roots = uniq([clientRoot, ...themeRoots, ...addonRoots, userRoot])
 
   if (themeRoots.length) {
     const themeMeta = await getThemeMeta(theme, join(themeRoots[0], 'package.json'))


### PR DESCRIPTION

Depending on the extension point (setup/*), the addons were considered or not.
With this PR, now addons are considered in all places where themes are considered.