### PR TITLE
fix: properly pass headmatter to the extensions

### DIFF
--- a/packages/parser/src/core.ts
+++ b/packages/parser/src/core.ts
@@ -138,16 +138,17 @@ export async function parse(
   }
 
   // identify the headmatter, to be able to load preparser extensions
+  // (strict parsing based on the parsing code)
   {
-    let hStart = 0
-    while (hStart < lines.length && lines[hStart].match(/^(---|\w*)+/))
-      hStart++
-    let hEnd = hStart + 1
-    while (hEnd < lines.length && !lines[hEnd].match(/^---+/))
-      hEnd++
+    let hm = ''
+    if (lines[0].match(/^---([^-].*)?$/) && !lines[1]?.match(/^\s*$/)) {
+      let hEnd = 1
+      while (hEnd < lines.length && !lines[hEnd].trimEnd().match(/^---$/))
+        hEnd++
+      hm = lines.slice(1, hEnd).join('\n')
+    }
     if (onHeadmatter) {
-      /// //// TODO call matter()
-      const o = YAML.load(lines.slice(hStart, hEnd).join('\n')) ?? {}
+      const o = YAML.load(hm) ?? {}
       extensions = await onHeadmatter(o, extensions ?? [], filepath)
     }
   }

--- a/packages/parser/src/fs.ts
+++ b/packages/parser/src/fs.ts
@@ -18,7 +18,7 @@ export async function load(filepath: string, themeMeta?: SlidevThemeMeta, conten
   const data = await parse(markdown, filepath, themeMeta, [], async (headmatter, exts: SlidevPreparserExtension[], filepath: string | undefined) => {
     return [
       ...exts,
-      ...preparserExtensionLoader ? await preparserExtensionLoader(headmatter.addons ?? [], filepath) : [],
+      ...preparserExtensionLoader ? await preparserExtensionLoader(headmatter, filepath) : [],
     ]
   })
 

--- a/packages/slidev/node/cli.ts
+++ b/packages/slidev/node/cli.ts
@@ -31,14 +31,15 @@ const CONFIG_RESTART_FIELDS: (keyof SlidevConfig)[] = [
   'css',
 ]
 
-injectPreparserExtensionLoader(async (addons: string[], filepath?: string) => {
+injectPreparserExtensionLoader(async (headmatter?: Record<string, unknown>, filepath?: string) => {
+  const addons = headmatter?.addons as string[] ?? []
   const roots = /* uniq */([
     getUserRoot({}).userRoot,
     ...getAddonRoots(addons, ''),
     getClientRoot(),
   ])
   const mergeArrays = (a: SlidevPreparserExtension[], b: SlidevPreparserExtension[]) => a.concat(b)
-  return await loadSetups(roots, 'preparser.ts', filepath, [], false, mergeArrays)
+  return await loadSetups(roots, 'preparser.ts', { filepath, headmatter }, [], false, mergeArrays)
 })
 
 const cli = yargs

--- a/packages/slidev/node/plugins/setupNode.ts
+++ b/packages/slidev/node/plugins/setupNode.ts
@@ -16,7 +16,7 @@ function deepMerge(a: any, b: any, rootPath = '') {
   return a
 }
 
-export async function loadSetups<T, R extends object>(roots: string[], name: string, arg: T, initial: R, merge = true, accumulate: (a: R, o: R) => R = undefined): Promise<R> {
+export async function loadSetups<T, R extends object>(roots: string[], name: string, arg: T, initial: R, merge = true, accumulate?: (a: R, o: R) => R): Promise<R> {
   let returns = initial
   for (const root of roots) {
     const path = resolve(root, 'setup', name)

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -61,9 +61,9 @@ export interface SlidevPreparserExtension {
   transformSlide?(content: string, frontmatter: any): Promise<string | undefined>
 }
 
-export type PreparserExtensionLoader = (addons: string[], filepath?: string) => Promise<SlidevPreparserExtension[]>
+export type PreparserExtensionLoader = (headmatter?: Record<string, unknown>, filepath?: string) => Promise<SlidevPreparserExtension[]>
 
 // internal type?
-export type PreparserExtensionFromHeadmatter = (headmatter: any, exts: SlidevPreparserExtension[], filepath: string | undefined) => Promise<SlidevPreparserExtension[]>
+export type PreparserExtensionFromHeadmatter = (headmatter: any, exts: SlidevPreparserExtension[], filepath?: string) => Promise<SlidevPreparserExtension[]>
 
 export type RenderContext = 'slide' | 'overview' | 'presenter' | 'previewNext'

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -121,7 +121,7 @@ b
   it('parse with-extension custom-separator', async () => {
     const data = await parseWithExtension(`---
 ga: bu
-SEPARATOR
+---
 a @@v@@
 
 SEPARATOR


### PR DESCRIPTION
The headmatter was not (always) properly parsed and not passed to the addons.
Now it is passed to the preparser addons (it can be useful to pass them configuration, or to provide a way to enable/disable certain features)