### PR TITLE
fix: use provided range when exporting

### DIFF
--- a/packages/client/internals/PrintContainer.vue
+++ b/packages/client/internals/PrintContainer.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
+import { parseRangeString } from '@slidev/parser/core'
 import { computed, provide } from 'vue'
 import { configs, slideAspect, slideWidth } from '../env'
 import { injectionSlideScale } from '../constants'
-import { rawRoutes } from '../logic/nav'
+import { rawRoutes, route } from '../logic/nav'
 import PrintSlide from './PrintSlide.vue'
 
 const props = defineProps<{
@@ -21,7 +22,11 @@ const scale = computed(() => {
 })
 
 // Remove the "end" slide
-const routes = rawRoutes.slice(0, -1)
+let routes = rawRoutes.slice(0, -1)
+if (route.value.query.range) {
+  const r = parseRangeString(routes.length, route.value.query.range)
+  routes = r.map(i => routes[i - 1])
+}
 
 const className = computed(() => ({
   'select-none': !configs.selectable,

--- a/packages/slidev/node/export.ts
+++ b/packages/slidev/node/export.ts
@@ -182,7 +182,7 @@ export async function exportSlides({
   const progress = createSlidevProgress(true)
 
   async function go(no: number | string, clicks?: string) {
-    const path = `${no}?print${withClicks ? '=clicks' : ''}${clicks ? `&clicks=${clicks}` : ''}`
+    const path = `${no}?print${withClicks ? '=clicks' : ''}${clicks ? `&clicks=${clicks}` : ''}${range ? `&range=${range}` : ''}`
     const url = routerMode === 'hash'
       ? `http://localhost:${port}${base}#${path}`
       : `http://localhost:${port}${base}${path}`


### PR DESCRIPTION

Currently `--range` is ignored in slidev export.
This especially prevents exporting huge presentations as they cannot even be exported by parts.
see https://github.com/slidevjs/slidev/issues/774

 
