### PR TITLE
fix(export): add timeout arg for export-notes command

### DIFF
--- a/packages/slidev/node/cli.ts
+++ b/packages/slidev/node/cli.ts
@@ -420,11 +420,17 @@ cli.command(
       type: 'string',
       describe: 'path to the output',
     })
+    .option('timeout', {
+      default: 30000,
+      type: 'number',
+      describe: 'timeout for rendering the print page',
+    })
     .strict()
     .help(),
   async ({
     entry,
     output,
+    timeout,
   }) => {
     process.env.NODE_ENV = 'production'
     const { exportNotes } = await import('./export')
@@ -450,6 +456,7 @@ cli.command(
     output = await exportNotes({
       port,
       output,
+      timeout,
     })
     console.log(`${green('  ✓ ')}${dim('exported to ')}./${output}\n`)
 

--- a/packages/slidev/node/export.ts
+++ b/packages/slidev/node/export.ts
@@ -64,6 +64,7 @@ export interface ExportNotesOptions {
   port?: number
   base?: string
   output?: string
+  timeout?: number
 }
 
 function createSlidevProgress(indeterminate = false) {
@@ -106,6 +107,7 @@ export async function exportNotes({
   port = 18724,
   base = '/',
   output = 'notes',
+  timeout = 30000,
 }: ExportNotesOptions): Promise<string> {
   if (!packageExists('playwright-chromium'))
     throw new Error('The exporting for Slidev is powered by Playwright, please installed it via `npm i -D playwright-chromium`')
@@ -122,7 +124,7 @@ export async function exportNotes({
   if (!output.endsWith('.pdf'))
     output = `${output}.pdf`
 
-  await page.goto(`http://localhost:${port}${base}presenter/print`, { waitUntil: 'networkidle' })
+  await page.goto(`http://localhost:${port}${base}presenter/print`, { waitUntil: 'networkidle', timeout })
   await page.waitForLoadState('networkidle')
   await page.emulateMedia({ media: 'screen' })
 


### PR DESCRIPTION
Fixes #795 
Added timeout arg to `export-note` command as in #542.