### PR TITLE
feat: relative includes/imports/src:

### DIFF
--- a/packages/parser/src/fs.ts
+++ b/packages/parser/src/fs.ts
@@ -16,10 +16,11 @@ export async function load(filepath: string, themeMeta?: SlidevThemeMeta, conten
 
   const preparserExtensions: SlidevPreparserExtension[] = []
   const data = await parse(markdown, filepath, themeMeta, [], async (headmatter, exts: SlidevPreparserExtension[], filepath: string | undefined) => {
-    return [
+    preparserExtensions.splice(0, preparserExtensions.length,
       ...exts,
       ...preparserExtensionLoader ? await preparserExtensionLoader(headmatter, filepath) : [],
-    ]
+    )
+    return preparserExtensions
   })
 
   const entries = new Set([

--- a/packages/parser/src/fs.ts
+++ b/packages/parser/src/fs.ts
@@ -40,7 +40,14 @@ export async function load(filepath: string, themeMeta?: SlidevThemeMeta, conten
       continue
 
     const srcExpression = baseSlide.frontmatter.src
-    const path = resolve(dir, srcExpression)
+    let path
+    if (srcExpression.startsWith('/'))
+      path = resolve(dir, srcExpression.substring(1))
+    else if (baseSlide.source?.filepath)
+      path = resolve(dirname(baseSlide.source.filepath), srcExpression)
+    else
+      path = resolve(dir, srcExpression)
+
     const raw = await fs.readFile(path, 'utf-8')
     const subSlides = await parse(raw, path, themeMeta, preparserExtensions)
 

--- a/test/__snapshots__/parser.test.ts.snap
+++ b/test/__snapshots__/parser.test.ts.snap
@@ -556,7 +556,7 @@ srcSequence: sub/page1.md
     "frontmatter": {
       "background": "https://sli.dev/demo-cover.png#2",
       "layout": "cover",
-      "srcSequence": "sub/page2.md",
+      "srcSequence": "/sub/page2.md",
       "title": "Page 2",
     },
     "index": 1,
@@ -570,7 +570,7 @@ srcSequence: sub/page1.md
       "level": undefined,
       "note": undefined,
       "raw": "---
-src: sub/page2.md
+src: /sub/page2.md
 background: https://sli.dev/demo-cover.png#2
 ---
 ",
@@ -583,7 +583,7 @@ background: https://sli.dev/demo-cover.png#2
 layout: cover
 title: Page 2
 background: https://sli.dev/demo-cover.png#2
-srcSequence: sub/page2.md
+srcSequence: /sub/page2.md
 ---
 
 # Page 2
@@ -624,7 +624,7 @@ layout: cover
     "end": 2,
     "frontmatter": {
       "background": "https://sli.dev/demo-cover.png#34",
-      "srcSequence": "sub/pages3-4.md",
+      "srcSequence": "./sub/pages3-4.md",
       "title": "Page 3",
     },
     "index": 2,
@@ -638,7 +638,7 @@ layout: cover
       "level": undefined,
       "note": undefined,
       "raw": "---
-src: sub/pages3-4.md
+src: ./sub/pages3-4.md
 background: https://sli.dev/demo-cover.png#34
 ---
 ",
@@ -650,7 +650,7 @@ background: https://sli.dev/demo-cover.png#34
     "raw": "---
 title: Page 3
 background: https://sli.dev/demo-cover.png#34
-srcSequence: sub/pages3-4.md
+srcSequence: ./sub/pages3-4.md
 ---
 
 # Page 3
@@ -683,7 +683,7 @@ srcSequence: sub/pages3-4.md
     "frontmatter": {
       "background": "https://sli.dev/demo-cover.png#34",
       "layout": "cover",
-      "srcSequence": "sub/pages3-4.md",
+      "srcSequence": "./sub/pages3-4.md",
     },
     "index": 3,
     "level": 1,
@@ -691,7 +691,7 @@ srcSequence: sub/pages3-4.md
     "raw": "---
 layout: cover
 background: https://sli.dev/demo-cover.png#34
-srcSequence: sub/pages3-4.md
+srcSequence: ./sub/pages3-4.md
 ---
 
 # Page 4
@@ -731,7 +731,7 @@ layout: cover
     "end": 2,
     "frontmatter": {
       "background": "https://sli.dev/demo-cover.png#14",
-      "srcSequence": "sub/nested1-4.md,sub/page1.md",
+      "srcSequence": "sub/nested1-4.md,/sub/page1.md",
       "title": undefined,
     },
     "index": 4,
@@ -756,7 +756,7 @@ background: https://sli.dev/demo-cover.png#14
     "note": undefined,
     "raw": "---
 background: https://sli.dev/demo-cover.png#14
-srcSequence: sub/nested1-4.md,sub/page1.md
+srcSequence: sub/nested1-4.md,/sub/page1.md
 ---
 
 # Page 1
@@ -789,7 +789,7 @@ srcSequence: sub/nested1-4.md,sub/page1.md
     "frontmatter": {
       "background": "https://sli.dev/demo-cover.png#14",
       "layout": "cover",
-      "srcSequence": "sub/nested1-4.md,sub/page2.md",
+      "srcSequence": "sub/nested1-4.md,page2.md",
       "title": "Page 2",
     },
     "index": 5,
@@ -799,7 +799,7 @@ srcSequence: sub/nested1-4.md,sub/page1.md
 layout: cover
 title: Page 2
 background: https://sli.dev/demo-cover.png#14
-srcSequence: sub/nested1-4.md,sub/page2.md
+srcSequence: sub/nested1-4.md,page2.md
 ---
 
 # Page 2
@@ -840,7 +840,7 @@ layout: cover
     "end": 2,
     "frontmatter": {
       "background": "https://sli.dev/demo-cover.png#14",
-      "srcSequence": "sub/nested1-4.md,sub/pages3-4.md",
+      "srcSequence": "sub/nested1-4.md,../sub/pages3-4.md",
       "title": "Page 3",
     },
     "index": 6,
@@ -849,7 +849,7 @@ layout: cover
     "raw": "---
 title: Page 3
 background: https://sli.dev/demo-cover.png#14
-srcSequence: sub/nested1-4.md,sub/pages3-4.md
+srcSequence: sub/nested1-4.md,../sub/pages3-4.md
 ---
 
 # Page 3
@@ -882,7 +882,7 @@ srcSequence: sub/nested1-4.md,sub/pages3-4.md
     "frontmatter": {
       "background": "https://sli.dev/demo-cover.png#14",
       "layout": "cover",
-      "srcSequence": "sub/nested1-4.md,sub/pages3-4.md",
+      "srcSequence": "sub/nested1-4.md,../sub/pages3-4.md",
     },
     "index": 7,
     "level": 1,
@@ -890,7 +890,7 @@ srcSequence: sub/nested1-4.md,sub/pages3-4.md
     "raw": "---
 layout: cover
 background: https://sli.dev/demo-cover.png#14
-srcSequence: sub/nested1-4.md,sub/pages3-4.md
+srcSequence: sub/nested1-4.md,../sub/pages3-4.md
 ---
 
 # Page 4

--- a/test/fixtures/markdown/multi-entries.md
+++ b/test/fixtures/markdown/multi-entries.md
@@ -3,12 +3,12 @@ src: sub/page1.md
 ---
 
 ---
-src: sub/page2.md
+src: /sub/page2.md
 background: https://sli.dev/demo-cover.png#2
 ---
 
 ---
-src: sub/pages3-4.md
+src: ./sub/pages3-4.md
 background: https://sli.dev/demo-cover.png#34
 ---
 

--- a/test/fixtures/markdown/sub/nested1-4.md
+++ b/test/fixtures/markdown/sub/nested1-4.md
@@ -1,11 +1,11 @@
 ---
-src: sub/page1.md
+src: /sub/page1.md
 ---
 
 ---
-src: sub/page2.md
+src: page2.md
 ---
 
 ---
-src: sub/pages3-4.md
+src: ../sub/pages3-4.md
 ---

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -20,7 +20,7 @@ describe('md parser', () => {
 
       for (const slide of data.slides) {
         if (slide.source?.filepath)
-          // @ts-ingore non-optional
+          // @ts-expect-error non-optional
           delete slide.source.filepath
         // @ts-expect-error extra prop
         if (slide.filepath)


### PR DESCRIPTION

For https://github.com/slidevjs/slidev/issues/753

Make includes relative to their containing file (e.g. when nesting includes inside includes) + allow a leading '/' to refer to the project root.

+ also improves/fixes preparser extensions (that were not applied to included files).
