### PR TITLE
fix: parse markdown in toc

### DIFF
--- a/packages/client/builtin/TocList.vue
+++ b/packages/client/builtin/TocList.vue
@@ -47,3 +47,9 @@ const classes = computed(() => {
     </li>
   </ol>
 </template>
+
+<style>
+.slidev-toc-item p {
+  margin: 0;
+}
+</style>

--- a/packages/slidev/node/plugins/loaders.ts
+++ b/packages/slidev/node/plugins/loaders.ts
@@ -253,7 +253,11 @@ export function createSlidesLoader(
         if (id === '/@slidev/titles.md') {
           return {
             code: data.slides.map(({ title }, i) => {
-              return `<template ${i === 0 ? 'v-if' : 'v-else-if'}="+no === ${i + 1}">${title}</template>`
+              return `<template ${i === 0 ? 'v-if' : 'v-else-if'}="+no === ${i + 1}">
+
+${title}
+
+</template>`
             }).join(''),
             map: { mappings: '' },
           }


### PR DESCRIPTION
This fix is related to https://github.com/slidevjs/slidev/issues/812

Because now markdown is not parsed anymore when wrapped in a component, the toc component does not render the parsed HTML of the original title, but renders the raw markdown (notice the ``What is `Slidev` ?``):
![notparsed](https://user-images.githubusercontent.com/5246045/211537275-50d053fe-6bc3-4b11-a905-9b09dd4ed887.png)

This fix the toc component like this (rendering the markdown of the title):
![parsed](https://user-images.githubusercontent.com/5246045/211537290-0433c996-ef91-484a-9ec8-31b055e52b28.png)

This PR may not be needed if https://github.com/mdit-vue/vite-plugin-vue-markdown/issues/14 is fixed