### PR TITLE
fix: export drawings in export (if persist is true)

### DIFF
--- a/packages/client/state/syncState.ts
+++ b/packages/client/state/syncState.ts
@@ -7,7 +7,7 @@ export function createSyncState<State extends object>(serverState: State, defaul
   let patchingTimeout: NodeJS.Timeout
   let updatingTimeout: NodeJS.Timeout
 
-  const state = __DEV__
+  const state = __USE_SERVER__
     ? reactive<State>(serverState) as State
     : reactive<State>(defaultState) as State
 
@@ -35,11 +35,11 @@ export function createSyncState<State extends object>(serverState: State, defaul
 
   function init(channelKey: string) {
     let stateChannel: BroadcastChannel
-    if (!__DEV__ && !persist) {
+    if (!__USE_SERVER__ && !persist) {
       stateChannel = new BroadcastChannel(channelKey)
       stateChannel.addEventListener('message', (event: MessageEvent<Partial<State>>) => onUpdate(event.data))
     }
-    else if (!__DEV__ && persist) {
+    else if (!__USE_SERVER__ && persist) {
       window.addEventListener('storage', (event) => {
         if (event && event.key === channelKey && event.newValue)
           onUpdate(JSON.parse(event.newValue) as Partial<State>)
@@ -56,7 +56,7 @@ export function createSyncState<State extends object>(serverState: State, defaul
     }
 
     watch(state, onDrawingStateChanged, { deep: true })
-    if (!__DEV__ && persist) {
+    if (!__USE_SERVER__ && persist) {
       const serialzedState = window.localStorage.getItem(channelKey)
       if (serialzedState)
         onUpdate(JSON.parse(serialzedState) as Partial<State>)

--- a/packages/slidev/node/cli.ts
+++ b/packages/slidev/node/cli.ts
@@ -371,7 +371,7 @@ cli.command(
     process.env.NODE_ENV = 'production'
     const { exportSlides } = await import('./export')
     const port = await findFreePort(12445)
-    const options = await resolveOptions({ entry, theme }, 'build')
+    const options = await resolveOptions({ entry, theme }, 'export')
     output = output || options.data.config.exportFilename || `${path.basename(entry, '.md')}-export`
     const server = await createServer(
       options,
@@ -436,7 +436,7 @@ cli.command(
     const { exportNotes } = await import('./export')
 
     const port = await findFreePort(12445)
-    const options = await resolveOptions({ entry }, 'build')
+    const options = await resolveOptions({ entry }, 'export')
 
     if (!output)
       output = options.data.config.exportFilename ? `${options.data.config.exportFilename}-notes` : `${path.basename(entry, '.md')}-export-notes`

--- a/packages/slidev/node/drawings.ts
+++ b/packages/slidev/node/drawings.ts
@@ -25,7 +25,7 @@ export async function loadDrawings(options: ResolvedSlidevOptions) {
   })
 
   const obj: Record<string, string> = {}
-  Promise.all(files.map(async (path) => {
+  await Promise.all(files.map(async (path) => {
     const num = +basename(path, '.svg')
     if (Number.isNaN(num))
       return

--- a/packages/slidev/node/options.ts
+++ b/packages/slidev/node/options.ts
@@ -59,7 +59,7 @@ export interface ResolvedSlidevOptions {
   themeRoots: string[]
   addonRoots: string[]
   roots: string[]
-  mode: 'dev' | 'build'
+  mode: 'dev' | 'build' | 'export'
   remote?: string
   inspect?: boolean
 }

--- a/packages/slidev/node/plugins/extendConfig.ts
+++ b/packages/slidev/node/plugins/extendConfig.ts
@@ -109,12 +109,13 @@ export function createConfigPlugin(options: ResolvedSlidevOptions): Plugin {
 
 export function getDefine(options: ResolvedSlidevOptions): Record<string, string> {
   return {
+    __DEV__: options.mode === 'dev' ? 'true' : 'false',
     __SLIDEV_CLIENT_ROOT__: JSON.stringify(toAtFS(options.clientRoot)),
     __SLIDEV_HASH_ROUTE__: JSON.stringify(options.data.config.routerMode === 'hash'),
     __SLIDEV_FEATURE_DRAWINGS__: JSON.stringify(options.data.config.drawings.enabled === true || options.data.config.drawings.enabled === options.mode),
     __SLIDEV_FEATURE_DRAWINGS_PERSIST__: JSON.stringify(!!options.data.config.drawings.persist === true),
     __SLIDEV_FEATURE_RECORD__: JSON.stringify(options.data.config.record === true || options.data.config.record === options.mode),
     __SLIDEV_FEATURE_PRESENTER__: JSON.stringify(options.data.config.presenter === true || options.data.config.presenter === options.mode),
-    __DEV__: options.mode === 'dev' ? 'true' : 'false',
+    __USE_SERVER__: options.mode !== 'build' ? 'true' : 'false',
   }
 }

--- a/shim.d.ts
+++ b/shim.d.ts
@@ -7,6 +7,7 @@ declare global {
   const __SLIDEV_FEATURE_DRAWINGS_PERSIST__: boolean
   const __SLIDEV_FEATURE_RECORD__: boolean
   const __SLIDEV_FEATURE_PRESENTER__: boolean
+  const __USE_SERVER__: boolean
 }
 
 declare module 'vue' {
@@ -18,5 +19,6 @@ declare module 'vue' {
     __SLIDEV_FEATURE_DRAWINGS_PERSIST__: boolean
     __SLIDEV_FEATURE_RECORD__: boolean
     __SLIDEV_FEATURE_PRESENTER__: boolean
+    __USE_SERVER__: boolean
   }
 }


### PR DESCRIPTION
Fixes https://github.com/slidevjs/slidev/issues/692

Added a new global variable `__USE_SERVER__` and a new `"export"` mode:

* `mode="dev"` means `__DEV__=true` and `__USE_SERVER__=true`
* `mode="export"` means `__DEV__=false` and `__USE_SERVER__=true`
* `mode="build"` means `__DEV__=false` and `__USE_SERVER__=false`

I didn't forced the export to be in dev mode because in that mod we renders additionnal things like the Monaco editor...etc. we won't use in the export.