### PR TITLE
[WIP] Fix/goto route alias

### DIFF
--- a/packages/client/builtin/TocList.vue
+++ b/packages/client/builtin/TocList.vue
@@ -31,7 +31,7 @@ const classes = computed(() => {
 <template>
   <ol v-if="list && list.length > 0" :class="classes">
     <li
-      v-for="item in list"
+      v-for="item of list"
       :key="item.path" class="slidev-toc-item"
       :class="[{ 'slidev-toc-item-active': item.active }, { 'slidev-toc-item-parent-active': item.activeParent }]"
     >

--- a/packages/client/internals/Goto.vue
+++ b/packages/client/internals/Goto.vue
@@ -1,43 +1,73 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
 import { aliases, availablePaths, go } from '../logic/nav'
-import { showGotoDialog } from '../state'
+import { activeElement, showGotoDialog } from '../state'
 
+const container = ref<HTMLDivElement>()
 const input = ref<HTMLInputElement>()
 const text = ref('')
+const selectedItem = ref(-1)
 
+const path = computed(() => text.value.startsWith('/') ? text.value.substring(1) : text.value)
 const valid = computed(() => isValid(false))
+const autocompleteList = computed(() => [...aliases.value.keys()])
+const autocomplete = computed(() => autocompleteList.value
+  .filter(item => path.value !== '' && item.toLowerCase().startsWith(path.value.toLowerCase())))
 
 function isValid(strict: boolean): boolean {
-  let path = text.value
-  if (text.value.startsWith('/'))
-    path = text.value.substring(1)
   if (strict)
-    return availablePaths.value.includes(path)
+    return availablePaths.value.includes(path.value)
   else
-    return availablePaths.value.some(availablePath => availablePath.startsWith(path))
+    return availablePaths.value.some(availablePath => availablePath.toLowerCase().startsWith(path.value.toLowerCase()))
 }
 
 function goTo() {
+  if (selectedItem.value >= 0 && selectedItem.value < autocomplete.value.length)
+    text.value = autocomplete.value.at(selectedItem.value)
   if (isValid(true)) {
-    let path = text.value
-    if (text.value.startsWith('/'))
-      path = text.value.substring(1)
-    if (aliases.value.has(path))
-      go(+aliases.value.get(path)!)
+    if (aliases.value.has(path.value))
+      go(+aliases.value.get(path.value)!)
     else
-      go(+path)
+      go(+path.value)
   }
   close()
 }
 
 function close() {
+  text.value = ''
   showGotoDialog.value = false
+}
+
+function focusDown(event: Event) {
+  if (autocomplete.value.length > 0)
+    event.preventDefault()
+  selectedItem.value++
+  if (selectedItem.value >= autocomplete.value.length)
+    selectedItem.value = -1
+}
+
+function focusUp(event: Event) {
+  if (autocomplete.value.length > 0)
+    event.preventDefault()
+  selectedItem.value--
+  if (selectedItem.value <= -2)
+    selectedItem.value = autocomplete.value.length - 1
+}
+
+function updateText(event: Event) {
+  selectedItem.value = -1
+  text.value = (event.target as HTMLInputElement).value
+}
+
+function select(item: string) {
+  go(+aliases.value.get(item)!)
+  close()
 }
 
 watch(showGotoDialog, async (show) => {
   if (show) {
     text.value = ''
+    selectedItem.value = -1
     // delay the focus to avoid the g character coming from the key that triggered showGotoDialog
     setTimeout(() => input.value?.focus(), 0)
   }
@@ -45,28 +75,85 @@ watch(showGotoDialog, async (show) => {
     input.value?.blur()
   }
 })
+
+watch(activeElement, () => {
+  if (!container.value?.contains(activeElement.value as Node))
+    close()
+})
 </script>
 
 <template>
   <div
     id="slidev-goto-dialog"
-    class="fixed right-5 bg-main transform transition-all"
+    ref="container"
+    class="fixed right-5 transition-all"
     :class="showGotoDialog ? 'top-5' : '-top-20'"
-    shadow="~"
-    p="x-4 y-2"
-    border="~ transparent rounded dark:gray-400 dark:opacity-25"
   >
-    <input
-      ref="input"
-      v-model="text"
-      type="text"
-      :disabled="!showGotoDialog"
-      class="outline-none bg-transparent"
-      placeholder="Goto..."
-      :class="{ 'text-red-400': !valid && text }"
-      @keydown.enter="goTo"
-      @keydown.escape="close"
-      @blur="close"
+    <div
+      class="bg-main transform"
+      shadow="~"
+      p="x-4 y-2"
+      border="~ transparent rounded dark:gray-400 dark:opacity-25"
     >
+      <input
+        ref="input"
+        :value="text"
+        type="text"
+        :disabled="!showGotoDialog"
+        class="outline-none bg-transparent"
+        placeholder="Goto..."
+        :class="{ 'text-red-400': !valid && text }"
+        @keydown.enter="goTo"
+        @keydown.escape="close"
+        @keydown.down="focusDown"
+        @keydown.up="focusUp"
+        @input="updateText"
+      >
+    </div>
+    <ul
+      v-if="autocomplete.length > 0"
+      class="bg-main transform mt-1"
+      shadow="~"
+      p="x-4 y-2"
+      border="~ transparent rounded dark:gray-400 dark:opacity-25"
+    >
+      <li
+        v-for="(item, index) of autocomplete"
+        :key="item" class="autocomplete"
+        :class="{ selected: selectedItem === index }"
+        role="button"
+        tabindex="0"
+        @click.stop="select(item)"
+      >
+        {{ item }}
+      </li>
+    </ul>
   </div>
 </template>
+
+<style scoped lang="postcss">
+.autocomplete {
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: underline
+  }
+}
+
+.selected {
+  position: relative;
+
+  &::before {
+    @apply rounded;
+    content: '';
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: -0.25em;
+    right: -0.25em;
+    background-color: var(--slidev-theme-primary);
+    opacity: 0.5;
+    z-index: -1;
+  }
+}
+</style>

--- a/packages/client/logic/nav.ts
+++ b/packages/client/logic/nav.ts
@@ -85,6 +85,11 @@ export const rawTree = computed(() => rawRoutes
 export const treeWithActiveStatuses = computed(() => getTreeWithActiveStatuses(rawTree.value, currentRoute.value))
 export const tree = computed(() => filterTree(treeWithActiveStatuses.value))
 
+export const aliases = computed(() => new Map(rawRoutes
+  .filter((route: RouteRecordRaw) => route.meta?.slide?.frontmatter?.routeAlias)
+  .map((route: RouteRecordRaw) => [route.meta?.slide?.frontmatter?.routeAlias, route.path])))
+export const availablePaths = computed(() => rawRoutes.map(route => route.path).concat([...aliases.value.keys()]))
+
 export function next() {
   if (clicksTotal.value <= clicks.value)
     nextSlide()

--- a/packages/client/routes.ts
+++ b/packages/client/routes.ts
@@ -66,6 +66,9 @@ declare module 'vue-router' {
       filepath: string
       title?: string
       level?: number
+      raw: string
+      content: string
+      frontmatter: Record<string, any>
     }
 
     // private fields


### PR DESCRIPTION
Fixes https://github.com/slidevjs/slidev/issues/794

I used the frontmatter `routeAlias` because it was already existing for creating route alias by giving a route a name, so it appears to be very close to that notion of chapter and also because that `routeAlias` frontmatter parameter it not very useful by itself.
But maybe we want to split both feature, tell me.

Also I realized that maybe we can automatically create the autocomplete list by using the slides title and thus we can search for a page without having to specifically give it a `routeAlias` parameter.
But maybe this can leads to having too much items in large presentation...
In that case, maybe we can have a new parameter to enable the automatic chaptering or not.
And maybe we can still use that `routeAlias` frontmatter parameter to override the title for a specific slide (but currently we can override a slide title by using the `title` frontmatter parameter).

So do we want to limit the number of parameters and reuse them for feature that are close ?
Or do we want to create dedicated parameter ?

Also I maybe need to limit the number of autocomplete items (there is no limitation yet).