### PR TITLE
fix: update windicss import of default configure Files

### DIFF
--- a/packages/slidev/node/plugins/windicss.ts
+++ b/packages/slidev/node/plugins/windicss.ts
@@ -11,7 +11,9 @@ export async function createWindiCSSPlugin(
   { themeRoots, addonRoots, clientRoot, userRoot, roots, data }: ResolvedSlidevOptions,
   { windicss: windiOptions }: SlidevPluginOptions,
 ) {
-  const { default: WindiCSS, defaultConfigureFiles } = await import('vite-plugin-windicss')
+  const { default: WindiCSS } = await import('vite-plugin-windicss')
+  const { defaultConfigureFiles } = await import('@windicss/config')
+  
   const configFiles = uniq([
     ...defaultConfigureFiles.map(i => resolve(userRoot, i)),
     ...themeRoots.map(i => `${i}/windi.config.ts`),


### PR DESCRIPTION
Trying to build the project i ran into issues where windi `defaultConfigureFiles` was undefined.

![image](https://user-images.githubusercontent.com/3102683/213950776-2e379394-a7ae-4334-b433-db3f87b72c1d.png)

Looking into the https://github.com/windicss/vite-plugin-windicss repo it appears the windi config files where moved to the `'@windicss/config'` package.

so changing to this appears to fix. 
```typescript

const { defaultConfigureFiles } = await import('@windicss/config')
```

