### PR TITLE
fix: remove deprecated `@types/mermaid` and `@hedgedoc/markdown-it-task-lists`

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "@types/js-yaml": "^4.0.5",
     "@types/katex": "^0.16.0",
     "@types/markdown-it": "^12.2.3",
-    "@types/mermaid": "^9.2.0",
     "@types/node": "^18.11.18",
     "@types/prettier": "^2.7.2",
     "@types/prismjs": "^1.26.0",

--- a/packages/slidev/node/plugins/markdown.ts
+++ b/packages/slidev/node/plugins/markdown.ts
@@ -6,7 +6,7 @@ import { slash } from '@antfu/utils'
 import mila from 'markdown-it-link-attributes'
 // @ts-expect-error missing types
 import mif from 'markdown-it-footnote'
-import mitl from '@hedgedoc/markdown-it-task-lists'
+import { taskLists } from '@hedgedoc/markdown-it-plugins'
 import type { KatexOptions } from 'katex'
 import type MarkdownIt from 'markdown-it'
 import type { ShikiOptions } from '@slidev/types'
@@ -66,7 +66,7 @@ export async function createMarkdownPlugin(
       })
 
       md.use(mif)
-      md.use(mitl, { enabled: true, lineNumber: true, label: true })
+      md.use(taskLists, { enabled: true, lineNumber: true, label: true })
       md.use(Katex, KatexOptions)
 
       setups.forEach(i => i(md))

--- a/packages/slidev/package.json
+++ b/packages/slidev/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@antfu/utils": "^0.7.2",
-    "@hedgedoc/markdown-it-task-lists": "^2.0.1",
+    "@hedgedoc/markdown-it-plugins": "^2.0.0",
     "@iconify-json/carbon": "^1.1.14",
     "@iconify-json/ph": "^1.1.3",
     "@lillallol/outline-pdf": "^4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,6 @@ importers:
       '@types/js-yaml': ^4.0.5
       '@types/katex': ^0.16.0
       '@types/markdown-it': ^12.2.3
-      '@types/mermaid': ^9.2.0
       '@types/node': ^18.11.18
       '@types/prettier': ^2.7.2
       '@types/prismjs': ^1.26.0
@@ -65,7 +64,6 @@ importers:
       '@types/js-yaml': 4.0.5
       '@types/katex': 0.16.0
       '@types/markdown-it': 12.2.3
-      '@types/mermaid': 9.2.0
       '@types/node': 18.11.18
       '@types/prettier': 2.7.2
       '@types/prismjs': 1.26.0
@@ -236,7 +234,7 @@ importers:
   packages/slidev:
     specifiers:
       '@antfu/utils': ^0.7.2
-      '@hedgedoc/markdown-it-task-lists': ^2.0.1
+      '@hedgedoc/markdown-it-plugins': ^2.0.0
       '@iconify-json/carbon': ^1.1.14
       '@iconify-json/ph': ^1.1.3
       '@lillallol/outline-pdf': ^4.0.0
@@ -292,7 +290,7 @@ importers:
       yargs: ^17.6.2
     dependencies:
       '@antfu/utils': 0.7.2
-      '@hedgedoc/markdown-it-task-lists': 2.0.1_markdown-it@13.0.1
+      '@hedgedoc/markdown-it-plugins': 2.0.0_markdown-it@13.0.1
       '@iconify-json/carbon': 1.1.14
       '@iconify-json/ph': 1.1.3
       '@lillallol/outline-pdf': 4.0.0
@@ -1073,9 +1071,8 @@ packages:
       - supports-color
     dev: true
 
-  /@hedgedoc/markdown-it-task-lists/2.0.1_markdown-it@13.0.1:
-    resolution: {integrity: sha512-/iwO+hlzh+Jg+jQqE1SkI3Fr9LPBLqS2rgWQFOFSj0HH7KEYbegYru+dc+B2V89ZcY0AwwT6LzU4f5oqsgyvEw==}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+  /@hedgedoc/markdown-it-plugins/2.0.0_markdown-it@13.0.1:
+    resolution: {integrity: sha512-UQMgOX2JrGe0rIseLab+L7gcP+RRHYDCcmeVty6MVcmUri6ogRxAOlxOZkdbCvk/JuA3yYKcqYC3WmTH+fWB4Q==}
     peerDependencies:
       markdown-it: '>=12'
     dependencies:
@@ -1436,13 +1433,6 @@ packages:
 
   /@types/mdurl/1.0.2:
     resolution: {integrity: sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==}
-
-  /@types/mermaid/9.2.0:
-    resolution: {integrity: sha512-AlvLWYer6u4BkO4QzMkHo0t9RkvVIgqggVZmO+5snUiuX2caTKqtdqygX6GeE1VQa/TnXw9WoH0spcmHtG0inQ==}
-    deprecated: This is a stub types definition. mermaid provides its own type definitions, so you do not need this installed.
-    dependencies:
-      mermaid: 9.3.0
-    dev: true
 
   /@types/minimist/1.2.2:
     resolution: {integrity: sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==}


### PR DESCRIPTION
Both npm packages are marked as `deprecated`.

- `@types/mermaid` - no longer required.
- `@hedgedoc/markdown-it-task-lists` was moved to `@hedgedoc/markdown-it-plugins` 
  - deprecated repo - https://github.com/hedgedoc/markdown-it-better-task-lists 
  - new new repo https://github.com/hedgedoc/markdown-it-plugins

