### PR TITLE
fix: timeout export with windicss

### DIFF
--- a/packages/slidev/node/plugins/loaders.ts
+++ b/packages/slidev/node/plugins/loaders.ts
@@ -511,10 +511,9 @@ defineProps<{ no: number | string }>()`)
         'import "virtual:windi-components.css"',
         'import "virtual:windi-base.css"',
       )
-      imports.push(
-        'import "virtual:windi-utilities.css"',
-        'import "virtual:windi-devtools"',
-      )
+      imports.push('import "virtual:windi-utilities.css"')
+      if (process.env.NODE_ENV !== 'production')
+        imports.push('import "virtual:windi-devtools"')
     }
 
     return imports.join('\n')


### PR DESCRIPTION
Fixes https://github.com/slidevjs/slidev/issues/865

Remove import of `virtual:windi-devtools` causing pending call to `/@windicss-devtools-update` to hang indefinitely 
![windi](https://user-images.githubusercontent.com/5246045/218438938-94af0e91-4b17-4b62-a17f-3fe8f538825d.png)
