### PR TITLE
fix: Windi CSS plugin must be before ServerRef plugin

### DIFF
--- a/packages/slidev/node/plugins/preset.ts
+++ b/packages/slidev/node/plugins/preset.ts
@@ -148,6 +148,13 @@ export async function ViteSlidevPlugin(
       })
       : null,
 
+    // Must be before ServerRef.
+    config.css === 'none'
+      ? null
+      : config.css === 'unocss'
+        ? await createUnocssPlugin(options, pluginOptions)
+        : await createWindiCSSPlugin(options, pluginOptions),
+
     ServerRef({
       debug: process.env.NODE_ENV === 'development',
       state: {
@@ -179,12 +186,6 @@ export async function ViteSlidevPlugin(
         build: true,
       })
       : null,
-
-    config.css === 'none'
-      ? null
-      : config.css === 'unocss'
-        ? await createUnocssPlugin(options, pluginOptions)
-        : await createWindiCSSPlugin(options, pluginOptions),
   ]
     .flat()
     .filter(notNullish)


### PR DESCRIPTION
Fixes https://github.com/slidevjs/slidev/issues/898
Maybe also:
* https://github.com/slidevjs/slidev/issues/897
* https://github.com/slidevjs/slidev/issues/894