### PR TITLE
fix: update Netlify configuration to allow for Let's Encrypt verifications

### DIFF
--- a/packages/create-app/template/netlify.toml
+++ b/packages/create-app/template/netlify.toml
@@ -6,6 +6,11 @@
   command = "npm run build"
 
 [[redirects]]
+  from = "/.well-known/*"
+  to = "/.well-known/:splat"
+  status = 200
+
+[[redirects]]
   from = "/*"
   to = "/index.html"
   status = 200


### PR DESCRIPTION
Hello there 👋🏽 

I noticed when I was setting things up that because the `netlify.toml` file redirects _all_ traffic to `/index.html` it was blocking Netlify from completing the Let's Encrypt certificate verifcation process.

This PR adds an additional redirect to `netlify.toml` to resolve this which ensures that requests to the `.well-known` path continue as expected.