### PR TITLE
feat: support slot for `end` layout

### DIFF
--- a/packages/client/layouts/end.vue
+++ b/packages/client/layouts/end.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="slidev-layout end">
-    END
+    <slot>END</slot>
   </div>
 </template>
 


### PR DESCRIPTION
Defaults to `END` if no slot is set (like before)