### PR TITLE
fix: prevent ToC links to be blocking element

### DIFF
--- a/demo/starter/slides.md
+++ b/demo/starter/slides.md
@@ -92,7 +92,21 @@ Here is another comment.
 -->
 
 ---
+layout: default
+---
+
+# Table of contents
+
+```
+<Toc minDepth="1" maxDepth="5"></Toc>
+```
+
+<Toc></Toc>
+
+---
 transition: slide-up
+
+level: 2
 ---
 
 # Navigation
@@ -427,3 +441,8 @@ class: text-center
 # Learn More
 
 [Documentations](https://sli.dev) · [GitHub](https://github.com/slidevjs/slidev) · [Showcases](https://sli.dev/showcases.html)
+
+---
+layout: end
+---
+

--- a/packages/client/builtin/TocList.vue
+++ b/packages/client/builtin/TocList.vue
@@ -52,4 +52,7 @@ const classes = computed(() => {
 .slidev-layout .slidev-toc-item p {
   margin: 0;
 }
+.slidev-layout .slidev-toc-item div, .slidev-layout .slidev-toc-item div p {
+    display: initial;
+}
 </style>

--- a/packages/client/builtin/TocList.vue
+++ b/packages/client/builtin/TocList.vue
@@ -53,6 +53,6 @@ const classes = computed(() => {
   margin: 0;
 }
 .slidev-layout .slidev-toc-item div, .slidev-layout .slidev-toc-item div p {
-    display: initial;
+  display: initial;
 }
 </style>


### PR DESCRIPTION
In Firefox the built-in `TOC` element gets rendered with implicit blocking `div` + `p` which results in follwing problem:
![slidev-toc-display-block](https://user-images.githubusercontent.com/19560252/230799007-01dc0f45-fe18-49d9-b3da-ebb47aac6faf.png)

Chromium seems to think otherwise of those blocking elements. Nonetheless, resetting those element styles fixes the problem both for Firefox and Chromium browsers.