### PR TITLE
Add gap between columns in two-cols-* layouts

### DIFF
--- a/packages/client/layouts/two-cols-header.vue
+++ b/packages/client/layouts/two-cols-header.vue
@@ -27,7 +27,7 @@ const props = defineProps({
     <div class="col-span-2">
       <slot />
     </div>
-    <div class="grid grid-cols-2">
+    <div class="grid grid-cols-2 gap-4">
       <div class="col-left" :class="props.class">
         <slot name="left" />
       </div>

--- a/packages/client/layouts/two-cols.vue
+++ b/packages/client/layouts/two-cols.vue
@@ -28,7 +28,7 @@ const props = defineProps({
 </script>
 
 <template>
-  <div class="slidev-layout two-columns w-full h-full grid grid-cols-2">
+  <div class="slidev-layout two-columns w-full h-full grid grid-cols-2 gap-4">
     <div class="col-left" :class="props.class">
       <slot />
     </div>


### PR DESCRIPTION
This way the background of code boxes don't butt against each other.