### PR TITLE
feat: include public assets from theme in build, fixes #727

### DIFF
--- a/packages/slidev/node/plugins/preset.ts
+++ b/packages/slidev/node/plugins/preset.ts
@@ -9,6 +9,7 @@ import RemoteAssets, { DefaultRules } from 'vite-plugin-remote-assets'
 import ServerRef from 'vite-plugin-vue-server-ref'
 import { notNullish } from '@antfu/utils'
 import Inspect from 'vite-plugin-inspect'
+import { viteStaticCopy } from 'vite-plugin-static-copy'
 import type { ResolvedSlidevOptions, SlidevPluginOptions, SlidevServerOptions } from '../options'
 import { loadDrawings, writeDrawings } from '../drawings'
 import { createConfigPlugin } from './extendConfig'
@@ -166,6 +167,15 @@ export async function ViteSlidevPlugin(
         if (key === 'drawings')
           writeDrawings(options, patch ?? data)
       },
+    }),
+
+    viteStaticCopy({
+      targets: themeRoots.map((i) => {
+        return {
+          src: `${i}/public/*`,
+          dest: 'theme',
+        }
+      }),
     }),
 
     createConfigPlugin(options),

--- a/packages/slidev/package.json
+++ b/packages/slidev/package.json
@@ -96,6 +96,7 @@
     "vite": "^4.2.1",
     "vite-plugin-inspect": "^0.7.19",
     "vite-plugin-remote-assets": "^0.3.2",
+    "vite-plugin-static-copy": "^0.13.1",
     "vite-plugin-vue-markdown": "^0.22.4",
     "vite-plugin-vue-server-ref": "^0.3.1",
     "vite-plugin-windicss": "^1.8.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -479,6 +479,9 @@ importers:
       vite-plugin-remote-assets:
         specifier: ^0.3.2
         version: 0.3.2(vite@4.2.1)
+      vite-plugin-static-copy:
+        specifier: ^0.13.1
+        version: 0.13.1(vite@4.2.1)
       vite-plugin-vue-markdown:
         specifier: ^0.22.4
         version: 0.22.4(vite@4.2.1)
@@ -7589,6 +7592,19 @@ packages:
       vite: 4.2.1(@types/node@18.15.11)
     transitivePeerDependencies:
       - supports-color
+    dev: false
+
+  /vite-plugin-static-copy@0.13.1(vite@4.2.1):
+    resolution: {integrity: sha512-KwIcGBT1aOxSq+laK3VmSngoEa3HXWj/6ZEXdv+y59eZ7p/XSuPahoDo+CfYW22JjTdnstgeKWiX+78KNgDu6g==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^3.0.0 || ^4.0.0
+    dependencies:
+      chokidar: 3.5.3
+      fast-glob: 3.2.12
+      fs-extra: 11.1.1
+      picocolors: 1.0.0
+      vite: 4.2.1(@types/node@18.15.11)
     dev: false
 
   /vite-plugin-vue-markdown@0.22.4(vite@4.2.1):


### PR DESCRIPTION
This feature will allow theme authors to include public assets (e.g. images) that can be used in slides by users of that theme. Any files present in the `public` folder of a theme will be copied over to the `theme/` folder in the output directory when slides are being built.

These files can be referenced in slides using `/theme/path/to/asset.ext`. Example:

In the theme:

```
public/my-image.png
public/nested/another-image.png
```

will be available under

```
theme/my-image.png
theme/nested/another-image.png
```

I will open a PR for the documentation after/when this PR is accepted :) 