### PR TITLE
fix: remove rounded class to fix blurry text

### DIFF
--- a/packages/client/builtin/Monaco.vue
+++ b/packages/client/builtin/Monaco.vue
@@ -126,5 +126,5 @@ useEventListener(window, 'message', ({ data: payload }) => {
 </script>
 
 <template>
-  <iframe ref="iframe" class="text-base w-full rounded" :style="{ height }" />
+  <iframe ref="iframe" class="text-base w-full" :style="{ height }" />
 </template>


### PR DESCRIPTION
hover interface with rounded class

![image](https://user-images.githubusercontent.com/13401668/233790966-483c5bb8-e856-485f-8e2f-53b6e8aff8dc.png)

hover interface without rounded class

![image](https://user-images.githubusercontent.com/13401668/233790991-f5badd6c-b788-4a8a-97d9-83f9ee800077.png)
