### PR TITLE
feat(monaco): support tsx and jsx

### DIFF
--- a/packages/client/iframes/monaco/index.ts
+++ b/packages/client/iframes/monaco/index.ts
@@ -29,7 +29,9 @@ document.body.appendChild(styleObject)
 function lang() {
   switch (props.lang) {
     case 'ts':
+    case 'tsx':
       return 'typescript'
+    case 'jsx':
     case 'js':
       return 'javascript'
     default:


### PR DESCRIPTION
support tsx and jsx,and then add following code to `setup/monaco.ts`.

```ts
monaco.languages.typescript.typescriptDefaults.setDiagnosticsOptions({
  noSemanticValidation: true,
  noSyntaxValidation: true, // This line disables errors in jsx tags like <div>, etc.
});

monaco.languages.typescript.typescriptDefaults.setCompilerOptions({
  jsx: monaco.languages.typescript.JsxEmit.React,
  jsxFactory: 'React.createElement',
  reactNamespace: 'React',
  allowNonTsExtensions: true,
  allowJs: true,
  target: monaco.languages.typescript.ScriptTarget.Latest,
});
```