### PR TITLE
fix: preserve dynamic import of vite

### DIFF
--- a/packages/slidev/node/plugins/monacoTransform.ts
+++ b/packages/slidev/node/plugins/monacoTransform.ts
@@ -3,7 +3,11 @@ import { slash } from '@antfu/utils'
 import type { Plugin } from 'vite'
 
 async function getPackageData(pkg: string) {
-  const { resolvePackageData } = await import('vite')
+  // Trick the bundler to avoid transforming dynamic import to require.
+  // The "resolvePackageData" is not available in CommonJS build of Vite.
+  // eslint-disable-next-line no-eval
+  const { resolvePackageData } = await eval('import("vite")')
+
   const info = resolvePackageData(pkg, process.cwd())
   if (!info)
     return


### PR DESCRIPTION
- Fixes #959

When CJS build is bundled the compiler transforms dynamic `import()` into `require()`:

```diff
- const { resolvePackageData } = await import("vite");
+ const { resolvePackageData } = await Promise.resolve().then(() => require("vite"));
```

Vite's CJS build does not support the `resolvePackageData` and throws following error:

```
5:34:30 PM [vite] Internal server error: "resolvePackageData" is not supported in CJS build of Vite 4.
Please use ESM or dynamic imports `const { resolvePackageData } = await import('vite')`.
      at module.exports.<computed> (/Users/x/project/node_modules/.pnpm/vite@4.3.3/node_modules/vite/index.cjs:30:11)
      at getPackageData (/Users/x/project/node_modules/.pnpm/@slidev+cli@0.40.16_patch_hash=a53stzchrmu3p273saucptgjli_postcss@8.4.23_react-dom@16.14.0_react@16.14.0/node_modules/@slidev/cli/dist/chunk-UL7Y3R6S.js:989:16)
      at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
      at async Context.load (/Users/x/project/node_modules/.pnpm/@slidev+cli@0.40.16_patch_hash=a53stzchrmu3p273saucptgjli_postcss@8.4.23_react-dom@16.14.0_react@16.14.0/node_modules/@slidev/cli/dist/chunk-UL7Y3R6S.js:1009:29)
      at async Object.load (file:///Users/x/project/node_modules/.pnpm/vite@4.3.3/node_modules/vite/dist/node/chunks/dep-a178814b.js:42850:32)
      at async loadAndTransform (file:///Users/x/project/node_modules/.pnpm/vite@4.3.3/node_modules/vite/dist/node/chunks/dep-a178814b.js:53267:24) (x53)
```

This PR ensures the dynamic import is preserved by using `eval` 😨. Other suggestions are welcome. 