### PR TITLE
Option disable end slide (for #974)

### DIFF
--- a/packages/client/internals/PrintContainer.vue
+++ b/packages/client/internals/PrintContainer.vue
@@ -22,7 +22,9 @@ const scale = computed(() => {
 })
 
 // Remove the default "end" slide
-let routes = configs.includeDefaultEnd ? rawRoutes.slice(0, -1) : rawRoutes
+const slidesIncludeDefaultEnd = rawRoutes.some(route => route.meta.slide == null)
+let routes = slidesIncludeDefaultEnd ? rawRoutes.slice(0, -1) : rawRoutes
+
 if (currentRoute.value.query.range) {
   const r = parseRangeString(routes.length, currentRoute.value.query.range as string)
   routes = r.map(i => routes[i - 1])

--- a/packages/client/internals/PrintContainer.vue
+++ b/packages/client/internals/PrintContainer.vue
@@ -21,8 +21,8 @@ const scale = computed(() => {
   return (height.value * slideAspect) / slideWidth
 })
 
-// Remove the "end" slide
-let routes = rawRoutes.slice(0, -1)
+// Remove the default "end" slide
+let routes = configs.includeDefaultEnd ? rawRoutes.slice(0, -1) : rawRoutes
 if (currentRoute.value.query.range) {
   const r = parseRangeString(routes.length, currentRoute.value.query.range as string)
   routes = r.map(i => routes[i - 1])

--- a/packages/parser/src/config.ts
+++ b/packages/parser/src/config.ts
@@ -32,6 +32,7 @@ export function getDefaultConfig(): SlidevConfig {
     presenter: true,
     htmlAttrs: {},
     transition: undefined,
+    includeDefaultEnd: true,
   }
 }
 

--- a/packages/parser/src/config.ts
+++ b/packages/parser/src/config.ts
@@ -32,7 +32,7 @@ export function getDefaultConfig(): SlidevConfig {
     presenter: true,
     htmlAttrs: {},
     transition: undefined,
-    includeDefaultEnd: true,
+    includeDefaultEnd: 'auto',
   }
 }
 

--- a/packages/slidev/node/plugins/loaders.ts
+++ b/packages/slidev/node/plugins/loaders.ts
@@ -572,7 +572,7 @@ defineProps<{ no: number | string }>()`)
         .filter(notNullish),
     ]
 
-    if (data.config.includeDefaultEnd) {
+    if (includeDefaultEnd()) {
       const layouts = await getLayouts()
       imports.push(`import __layout__end from '${layouts.end}'`)
       routes.push(`{ path: "${no}", component: __layout__end, meta: { layout: "end" } }`)
@@ -581,6 +581,19 @@ defineProps<{ no: number | string }>()`)
     const routesStr = `export default [\n${routes.join(',\n')}\n]`
 
     return [...imports, routesStr].join('\n')
+  }
+
+  function includeDefaultEnd(): boolean {
+    const configValue = data.config.includeDefaultEnd
+    if (typeof configValue === 'boolean')
+      return configValue
+
+    // if in the future the possible values change, you can find issues with forgetting this method faster with this.
+    // eslint-disable-next-line no-console
+    console.assert(configValue === 'auto', 'expected includeDefaultEnd to be "auto" at this point')
+
+    const alreadyHasEndSlide = data.slides.some(slide => slide.frontmatter.layout === 'end')
+    return !alreadyHasEndSlide
   }
 
   function generateConfigs() {

--- a/packages/slidev/node/plugins/loaders.ts
+++ b/packages/slidev/node/plugins/loaders.ts
@@ -544,9 +544,6 @@ defineProps<{ no: number | string }>()`)
 
   async function generateRoutes() {
     const imports: string[] = []
-    const layouts = await getLayouts()
-
-    imports.push(`import __layout__end from '${layouts.end}'`)
 
     let no = 1
     const routes = [
@@ -573,8 +570,13 @@ defineProps<{ no: number | string }>()`)
         })
         .flat()
         .filter(notNullish),
-      `{ path: "${no}", component: __layout__end, meta: { layout: "end" } }`,
     ]
+
+    if (data.config.includeDefaultEnd) {
+      const layouts = await getLayouts()
+      imports.push(`import __layout__end from '${layouts.end}'`)
+      routes.push(`{ path: "${no}", component: __layout__end, meta: { layout: "end" } }`)
+    }
 
     const routesStr = `export default [\n${routes.join(',\n')}\n]`
 

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -198,6 +198,12 @@ export interface SlidevConfig {
    * @see https://vuejs.org/guide/built-ins/transition.html
    */
   transition?: BuiltinSlideTransition | string | TransitionGroupProps
+  /**
+    * Include the blank standard "end" slide.
+    *
+    * @default true
+  */
+  includeDefaultEnd: boolean
 }
 
 export interface FontOptions {

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -201,9 +201,15 @@ export interface SlidevConfig {
   /**
     * Include the blank standard "end" slide.
     *
-    * @default true
+    * If set to 'auto', it will only include the blank default end slide,
+    * if there is no slide with layout 'end' already.
+    * Note: If you add an empty 'end' slide by yourself,
+    * that slide will be included in the export.
+    * Only 'auto' included end-slide will be omitted on export.
+    *
+    * @default 'auto'
   */
-  includeDefaultEnd: boolean
+  includeDefaultEnd: boolean | 'auto'
 }
 
 export interface FontOptions {


### PR DESCRIPTION
With the new frontmatter-option 'includeDefaultEnd' the user can choose whether they want to:
- specifically include the last blank default end (true)
- specifically exclude the last blank default end (false)
- let slidev decide on the fact whether there is a user-added end-slide ('auto')

On export, the default blank page is always omitted but the user-added end-slide will be included.

PR for #974 