### PR TITLE
feat: support setting startLines for codeblocks (#310)

### DIFF
--- a/packages/client/builtin/CodeBlockWrapper.vue
+++ b/packages/client/builtin/CodeBlockWrapper.vue
@@ -78,11 +78,12 @@ onMounted(() => {
       return
     const isDuoTone = el.value.querySelector('.shiki-dark')
     const targets = isDuoTone ? Array.from(el.value.querySelectorAll('.shiki')) : [el.value]
+    const startLine = props.options.startLine ?? 1
     for (const target of targets) {
       const lines = Array.from(target.querySelectorAll('.line'))
-      const highlights: number[] = parseRangeString(lines.length + props.options.startLine - 1, rangeStr.value)
+      const highlights: number[] = parseRangeString(lines.length + startLine - 1, rangeStr.value)
       lines.forEach((line, idx) => {
-        const highlighted = highlights.includes(idx + (props.options.startLine))
+        const highlighted = highlights.includes(idx + startLine)
         line.classList.toggle(CLASS_VCLICK_TARGET, true)
         line.classList.toggle('highlighted', highlighted)
         line.classList.toggle('dishonored', !highlighted)
@@ -109,18 +110,25 @@ function copyCode() {
   if (code)
     copy(code)
 }
+
+function showLines() {
+  if (props.options.lines == null)
+    return configs.lineNumbers ?? false
+  else
+    return props.options.lines ?? false
+}
 </script>
 
 <template>
   <div
     ref="el" class="slidev-code-wrapper relative group"
     :class="{
-      'slidev-code-line-numbers': props.options.lines,
+      'slidev-code-line-numbers': showLines(),
     }"
     :style="{
       'max-height': props.maxHeight,
       'overflow-y': props.maxHeight ? 'scroll' : undefined,
-      '--start': props.options.startLine,
+      '--start': props.options.startLine ?? 1,
     }"
   >
     <slot />

--- a/packages/client/builtin/CodeBlockWrapper.vue
+++ b/packages/client/builtin/CodeBlockWrapper.vue
@@ -23,6 +23,13 @@ const props = defineProps({
   ranges: {
     default: () => [],
   },
+  options: {
+    type: Object,
+    default: () => ({
+      startLine: 1,
+      lines: false,
+    }),
+  },
   at: {
     type: Number,
     default: undefined,
@@ -73,9 +80,9 @@ onMounted(() => {
     const targets = isDuoTone ? Array.from(el.value.querySelectorAll('.shiki')) : [el.value]
     for (const target of targets) {
       const lines = Array.from(target.querySelectorAll('.line'))
-      const highlights: number[] = parseRangeString(lines.length, rangeStr.value)
+      const highlights: number[] = parseRangeString(lines.length + props.options.startLine - 1, rangeStr.value)
       lines.forEach((line, idx) => {
-        const highlighted = highlights.includes(idx + 1)
+        const highlighted = highlights.includes(idx + (props.options.startLine))
         line.classList.toggle(CLASS_VCLICK_TARGET, true)
         line.classList.toggle('highlighted', highlighted)
         line.classList.toggle('dishonored', !highlighted)
@@ -107,9 +114,13 @@ function copyCode() {
 <template>
   <div
     ref="el" class="slidev-code-wrapper relative group"
+    :class="{
+      'slidev-code-line-numbers': props.options.lines,
+    }"
     :style="{
       'max-height': props.maxHeight,
       'overflow-y': props.maxHeight ? 'scroll' : undefined,
+      '--start': props.options.startLine,
     }"
   >
     <slot />

--- a/packages/client/internals/PrintContainer.vue
+++ b/packages/client/internals/PrintContainer.vue
@@ -29,7 +29,6 @@ if (currentRoute.value.query.range) {
 
 const className = computed(() => ({
   'select-none': !configs.selectable,
-  'slidev-code-line-numbers': configs.lineNumbers,
 }))
 
 provide(injectionSlideScale, scale)

--- a/packages/client/internals/SlideContainer.vue
+++ b/packages/client/internals/SlideContainer.vue
@@ -50,7 +50,6 @@ const style = computed(() => ({
 
 const className = computed(() => ({
   'select-none': !configs.selectable,
-  'slidev-code-line-numbers': configs.lineNumbers,
 }))
 
 provide(injectionSlideScale, scale)

--- a/packages/client/styles/code.css
+++ b/packages/client/styles/code.css
@@ -43,7 +43,7 @@ html:not(.dark) .shiki-dark {
 
 .slidev-code-line-numbers .slidev-code code {
   counter-reset: step;
-  counter-increment: step 0;
+  counter-increment: step calc(var(--start, 1) - 1);
 }
 
 .slidev-code-line-numbers .slidev-code code .line::before {

--- a/packages/slidev/node/plugins/markdown.ts
+++ b/packages/slidev/node/plugins/markdown.ts
@@ -151,8 +151,8 @@ export function transformHighlighter(md: string) {
   return md.replace(/^```(\w+?)(?:\s*{([\d\w*,\|-]+)}\s*?({.*?})?\s*?)?\n([\s\S]+?)^```/mg, (full, lang = '', rangeStr = '', options = '', code: string) => {
     const ranges = (rangeStr as string).split(/\|/g).map(i => i.trim())
     code = code.trimEnd()
-    options = options.trim() || '{}'
-    return `\n<CodeBlockWrapper v-bind="${options}" :ranges='${JSON.stringify(ranges)}'>\n\n\`\`\`${lang}\n${code}\n\`\`\`\n\n</CodeBlockWrapper>`
+    options = options.trim() || undefined
+    return `\n<CodeBlockWrapper :options="${options}" :ranges='${JSON.stringify(ranges)}'>\n\n\`\`\`${lang}\n${code}\n\`\`\`\n\n</CodeBlockWrapper>`
   })
 }
 


### PR DESCRIPTION
Code example:

https://gist.github.com/fr0zn/fe5292397f614b46bcbb5e6909bc9aad

Demo:

<img width="1659" alt="image" src="https://github.com/slidevjs/slidev/assets/8972753/c79c00c1-5863-4113-b079-4846aa5b60dc">

Reference: #310 