### PR TITLE
fix: prism highlighted line breaking

### DIFF
--- a/packages/slidev/package.json
+++ b/packages/slidev/package.json
@@ -67,6 +67,7 @@
     "fs-extra": "^11.1.1",
     "get-port-please": "^3.0.1",
     "global-dirs": "^3.0.1",
+    "htmlparser2": "^9.0.0",
     "import-from": "^4.0.0",
     "is-installed-globally": "^0.4.0",
     "jiti": "^1.18.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
@@ -396,6 +396,9 @@ importers:
       global-dirs:
         specifier: ^3.0.1
         version: 3.0.1
+      htmlparser2:
+        specifier: ^9.0.0
+        version: 9.0.0
       import-from:
         specifier: ^4.0.0
         version: 4.0.0
@@ -3899,30 +3902,26 @@ packages:
     dependencies:
       domelementtype: 2.3.0
       domhandler: 5.0.3
-      entities: 4.4.0
-    dev: true
+      entities: 4.5.0
 
   /domelementtype@2.3.0:
     resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
-    dev: true
 
   /domhandler@5.0.3:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
     dependencies:
       domelementtype: 2.3.0
-    dev: true
 
   /dompurify@3.0.3:
     resolution: {integrity: sha512-axQ9zieHLnAnHh0sfAamKYiqXMJAVwu+LM/alQ7WDagoWessyWvMSFyW65CqF3owufNu8HBcE4cM2Vflu7YWcQ==}
 
-  /domutils@3.0.1:
-    resolution: {integrity: sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==}
+  /domutils@3.1.0:
+    resolution: {integrity: sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==}
     dependencies:
       dom-serializer: 2.0.0
       domelementtype: 2.3.0
       domhandler: 5.0.3
-    dev: true
 
   /dotenv@16.0.3:
     resolution: {integrity: sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==}
@@ -3999,10 +3998,9 @@ packages:
     engines: {node: '>=0.12'}
     dev: false
 
-  /entities@4.4.0:
-    resolution: {integrity: sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==}
+  /entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
-    dev: true
 
   /errno@0.1.8:
     resolution: {integrity: sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==}
@@ -4347,7 +4345,7 @@ packages:
   /eslint-import-resolver-node@0.3.7:
     resolution: {integrity: sha512-gozW2blMLJCeFpBwugLTGyvVjNoeo1knonXAcatC6bjPBZitotxdWf7Gimr25N4c0AAOo4eOUfaG82IJPDpqCA==}
     dependencies:
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7(supports-color@5.5.0)
       is-core-module: 2.12.1
       resolve: 1.22.2
     transitivePeerDependencies:
@@ -4376,7 +4374,7 @@ packages:
         optional: true
     dependencies:
       '@typescript-eslint/parser': 5.59.7(eslint@8.42.0)(typescript@5.1.3)
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7(supports-color@5.5.0)
       eslint: 8.42.0
       eslint-import-resolver-node: 0.3.7
     transitivePeerDependencies:
@@ -4444,7 +4442,7 @@ packages:
       array-includes: 3.1.6
       array.prototype.flat: 1.3.1
       array.prototype.flatmap: 1.3.1
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7(supports-color@5.5.0)
       doctrine: 2.1.0
       eslint: 8.42.0
       eslint-import-resolver-node: 0.3.7
@@ -5382,9 +5380,18 @@ packages:
     dependencies:
       domelementtype: 2.3.0
       domhandler: 5.0.3
-      domutils: 3.0.1
-      entities: 4.4.0
+      domutils: 3.1.0
+      entities: 4.5.0
     dev: true
+
+  /htmlparser2@9.0.0:
+    resolution: {integrity: sha512-uxbSI98wmFT/G4P2zXx4OVx04qWUmyFPrD2/CNepa2Zo3GPNaCaaxElDgwUrwYWkK1nr9fft0Ya8dws8coDLLQ==}
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.1.0
+      entities: 4.5.0
+    dev: false
 
   /http-signature@1.3.6:
     resolution: {integrity: sha512-3adrsD6zqo4GsTqtO7FyrejHNv+NgiIfAfv68+jVlFmSr9OGy7zrxONceFRLKvnnZA5jbxQBX1u9PpB6Wi32Gw==}

--- a/test/__snapshots__/markdown-it-prism.test.ts.snap
+++ b/test/__snapshots__/markdown-it-prism.test.ts.snap
@@ -1,10 +1,25 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`markdown-it-prism > should render multi-line strings correctly 1`] = `
+exports[`markdown-it-prism > should render multi-line JS strings and comments correctly 1`] = `
 "<pre class=\\"slidev-code language-js\\"><code><span class=\\"line\\"><span class=\\"token template-string\\"><span class=\\"token template-punctuation string\\">\`</span><span class=\\"token string\\">Multi</span></span></span>
 <span class=\\"line\\"><span class=\\"token string\\"><span class=\\"token template-string\\">line</span><span class=\\"token template-punctuation string\\">\`</span></span></span>
 <span class=\\"line\\"><span class=\\"token comment\\">/**</span></span>
 <span class=\\"line\\"><span class=\\"token comment\\"> * Hello</span></span>
 <span class=\\"line\\"><span class=\\"token comment\\"> */</span></span></code></pre>
+"
+`;
+
+exports[`markdown-it-prism > should render multi-line XML nodes correctly 1`] = `
+"<pre class=\\"slidev-code language-xml\\"><code><span class=\\"line\\"><span class=\\"token tag\\"><span class=\\"token tag\\"><span class=\\"token punctuation\\">&lt;</span>a</span><span class=\\"token punctuation\\">/></span></span></span>
+<span class=\\"line\\"><span class=\\"token tag\\"><span class=\\"token tag\\"><span class=\\"token punctuation\\">&lt;</span>b</span></span></span>
+<span class=\\"line\\"><span class=\\"token tag\\">  <span class=\\"token attr-name\\">attr</span><span class=\\"token attr-value\\"><span class=\\"token punctuation attr-equals\\">=</span><span class=\\"token punctuation\\">\\"</span>value<span class=\\"token punctuation\\">\\"</span></span></span></span>
+<span class=\\"line\\"><span class=\\"token tag\\"><span class=\\"token punctuation\\">/></span></span></span></code></pre>
+"
+`;
+
+exports[`markdown-it-prism > should render non-multiline statements correctly 1`] = `
+"<pre class=\\"slidev-code language-ts\\"><code><span class=\\"line\\"><span class=\\"token keyword\\">const</span> a <span class=\\"token operator\\">=</span> <span class=\\"token number\\">1</span><span class=\\"token punctuation\\">;</span></span>
+<span class=\\"line\\"><span class=\\"token keyword\\">const</span> b <span class=\\"token operator\\">=</span> <span class=\\"token number\\">2</span><span class=\\"token punctuation\\">;</span></span>
+<span class=\\"line\\"><span class=\\"token keyword\\">const</span> c <span class=\\"token operator\\">=</span> a <span class=\\"token operator\\">+</span> b<span class=\\"token punctuation\\">;</span></span></code></pre>
 "
 `;

--- a/test/__snapshots__/markdown-it-prism.test.ts.snap
+++ b/test/__snapshots__/markdown-it-prism.test.ts.snap
@@ -1,0 +1,10 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`markdown-it-prism > should render multi-line strings correctly 1`] = `
+"<pre class=\\"slidev-code language-js\\"><code><span class=\\"line\\"><span class=\\"token template-string\\"><span class=\\"token template-punctuation string\\">\`</span><span class=\\"token string\\">Multi</span></span></span>
+<span class=\\"line\\"><span class=\\"token string\\"><span class=\\"token template-string\\">line</span><span class=\\"token template-punctuation string\\">\`</span></span></span>
+<span class=\\"line\\"><span class=\\"token comment\\">/**</span></span>
+<span class=\\"line\\"><span class=\\"token comment\\"> * Hello</span></span>
+<span class=\\"line\\"><span class=\\"token comment\\"> */</span></span></code></pre>
+"
+`;

--- a/test/markdown-it-prism.test.ts
+++ b/test/markdown-it-prism.test.ts
@@ -3,7 +3,10 @@ import Markdown from 'markdown-it'
 import markdownItPrism from '../packages/slidev/node/plugins/markdown-it-prism'
 
 describe('markdown-it-prism', () => {
-  it('should render multi-line strings correctly', () => {
+  const md = Markdown()
+  markdownItPrism(md, { plugins: [], init: () => {} })
+
+  it('should render multi-line JS strings and comments correctly', () => {
     const text = `
 \`\`\`js
 \`Multi
@@ -13,8 +16,31 @@ line\`
  */
 \`\`\`
 `
-    const md = Markdown()
-    markdownItPrism(md, { plugins: [], init: () => {} })
+    const actual = md.render(text)
+    expect(actual).toMatchSnapshot()
+  })
+
+  it('should render multi-line XML nodes correctly', () => {
+    const text = `
+\`\`\`xml
+<a/>
+<b
+  attr="value"
+/>
+\`\`\`
+`
+    const actual = md.render(text)
+    expect(actual).toMatchSnapshot()
+  })
+
+  it('should render non-multiline statements correctly', () => {
+    const text = `
+\`\`\`ts
+const a = 1;
+const b = 2;
+const c = a + b;
+\`\`\`
+`
     const actual = md.render(text)
     expect(actual).toMatchSnapshot()
   })

--- a/test/markdown-it-prism.test.ts
+++ b/test/markdown-it-prism.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import Markdown from 'markdown-it'
+import markdownItPrism from '../packages/slidev/node/plugins/markdown-it-prism'
+
+describe('markdown-it-prism', () => {
+  it('should render multi-line strings correctly', () => {
+    const text = `
+\`\`\`js
+\`Multi
+line\`
+/**
+ * Hello
+ */
+\`\`\`
+`
+    const md = Markdown()
+    markdownItPrism(md, { plugins: [], init: () => {} })
+    const actual = md.render(text)
+    expect(actual).toMatchSnapshot()
+  })
+})


### PR DESCRIPTION
The current implementation of line breaking of Prism-highlighted code is incorrect. It first splits code in separate lines and feed these to the highlight method. This does not work correctly for many kinds of code: JavaScript multiline strings and doc comments, XML attributes over multiple lines, etc.

As an alternative this PR sends the whole code to Prism and then splits line by line. A problem that then occurs: a newline can start when one or more tags are still open. In the PR I addressed this by parsing the HTML and closing/reopening tags for each line. I've searched the Prism API to see if there is some way around this, but haven't found it yet.