### PR TITLE
feat: custom `backgroundSize` for image layouts (#798)

### DIFF
--- a/packages/client/layoutHelper.ts
+++ b/packages/client/layoutHelper.ts
@@ -9,7 +9,7 @@ export function resolveAssetUrl(url: string) {
   return url
 }
 
-export function handleBackground(background?: string, dim = false): CSSProperties {
+export function handleBackground(background?: string, dim = false, backgroundSize = 'cover'): CSSProperties {
   const isColor = background && (background[0] === '#' || background.startsWith('rgb'))
 
   const style = {
@@ -28,7 +28,7 @@ export function handleBackground(background?: string, dim = false): CSSPropertie
         : undefined,
     backgroundRepeat: 'no-repeat',
     backgroundPosition: 'center',
-    backgroundSize: 'cover',
+    backgroundSize,
   }
 
   if (!style.background)

--- a/packages/client/layouts/image-left.vue
+++ b/packages/client/layouts/image-left.vue
@@ -9,9 +9,13 @@ const props = defineProps({
   class: {
     type: String,
   },
+  backgroundSize: {
+    type: String,
+    default: 'cover',
+  },
 })
 
-const style = computed(() => handleBackground(props.image))
+const style = computed(() => handleBackground(props.image, false, props.backgroundSize))
 </script>
 
 <template>

--- a/packages/client/layouts/image-right.vue
+++ b/packages/client/layouts/image-right.vue
@@ -9,9 +9,13 @@ const props = defineProps({
   class: {
     type: String,
   },
+  backgroundSize: {
+    type: String,
+    default: 'cover',
+  },
 })
 
-const style = computed(() => handleBackground(props.image))
+const style = computed(() => handleBackground(props.image, false, props.backgroundSize))
 </script>
 
 <template>

--- a/packages/client/layouts/image.vue
+++ b/packages/client/layouts/image.vue
@@ -6,9 +6,13 @@ const props = defineProps({
   image: {
     type: String,
   },
+  backgroundSize: {
+    type: String,
+    default: 'cover',
+  },
 })
 
-const style = computed(() => handleBackground(props.image))
+const style = computed(() => handleBackground(props.image, false, props.backgroundSize))
 </script>
 
 <template>


### PR DESCRIPTION
fixes https://github.com/slidevjs/slidev/issues/798

Continue of the previous [PR](https://github.com/slidevjs/slidev/pull/862), accidentally deleted branch while rebasing.

With this additional prop to image layouts (image, image-left, image-right), we can now able give custom css [background-size](https://developer.mozilla.org/en-US/docs/Web/CSS/background-size). The default will remain `cover` 

My main motivation was to be able to use `contain`. Because I wasn't able to fit vertical photographs, let's cover all the different needs.  

Example usages:

```
---
layout: image
image: https://iili.io/HzdAhJV.png
backgroundSize: contain
---
```

```
---
layout: image-left
image: https://iili.io/HzdAhJV.png
backgroundSize: 20em 70%
---
```

On this PR, I also excluded 
- image-custom layout [from that discussion](https://github.com/slidevjs/slidev/pull/862#discussion_r1274314432)
- the demo starter commit [from that discussion](https://github.com/slidevjs/slidev/pull/862#discussion_r1274313100).
