### PR TITLE
feat: allow export presentation with notes on A4

### DIFF
--- a/demo/starter/global-handout-cover.vue
+++ b/demo/starter/global-handout-cover.vue
@@ -1,0 +1,47 @@
+<template>
+    <div>
+        <div class="break-after-page">
+            <span class="font-bold text-xl border-b-4 border-r-4 px-1 py-1 border-gray-800 ">{{ shortname }}</span>
+
+            <div class="h-58"></div>
+            <div class="w-120 mx-auto font-bold flex flex-wrap gap-4">
+                <h1 class="text-5xl font-bold border-b-4 border-gray-800">
+                    {{ title }}
+                </h1>
+                {{ version }}
+            </div>
+            <div class="h-32"></div>
+            <div class="text-2xl font-bold mx-auto w-120 text-right">{{ doctitle }}</div>
+        </div>
+        <div class="break-after-page mt-68 ">
+
+
+            <div class="font-bold text-xl">ATTENTION</div>
+
+            <p class="mt-4">
+                The Information contained in this guide is intended for training purposes only.
+            </p>
+
+            <div class="font-bold text-xl mt-8">COPYRIGHT</div>
+
+            <div class="flex flex-row gap-4 mt-4 align-center items-center">
+
+             
+                © <span>{{ new Date().getFullYear().toString() }}</span> All rights reserved.
+
+            </div>
+
+            <p class="mt-4">
+                All other brands and product names are trademarks of their respective owners.</p>
+
+        </div>
+
+    </div>
+</template>
+<script setup>
+import { ref } from 'vue'
+const shortname = ref("SHORTNAME")
+const version = ref("Version 1.0.0")
+const title = ref("Course Name")
+const doctitle = "Student Guide"
+</script>

--- a/demo/starter/global-handout.vue
+++ b/demo/starter/global-handout.vue
@@ -1,0 +1,12 @@
+<template>
+    <div class="relative">
+        <div class="top-0 absolute bg-black h-[2px] w-full -rotate-1" />
+        <div class="-top-0 absolute bg-gray-400 h-[1px] w-full" />
+
+        <div class="top-3.0 absolute left-14 !text-[11px]">© 2023 Company</div>
+        <div class="top-3.0 absolute right-20 !text-[11px]">Text</div>
+    </div>
+</template>
+<script setup lang="ts">
+
+</script>

--- a/demo/starter/package.json
+++ b/demo/starter/package.json
@@ -4,7 +4,8 @@
     "build": "slidev build",
     "dev": "nodemon -w '../../packages/slidev/dist/*.js' --exec \"slidev ./slides.md --open=false --log=info\"",
     "export": "slidev export",
-    "export-notes": "slidev export-notes"
+    "export-notes": "slidev export-notes",
+    "export-handouts": "slidev export-handouts"
   },
   "devDependencies": {
     "@slidev/cli": "workspace:*",

--- a/packages/client/internals/HandoutPrintSlide.vue
+++ b/packages/client/internals/HandoutPrintSlide.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+import type { RouteRecordRaw } from 'vue-router'
+import { computed, ref } from 'vue'
+import { useNav } from '../composables/useNav'
+import PrintSlideClick from './PrintSlideClick.vue'
+
+const props = defineProps<{ route: RouteRecordRaw }>()
+
+const clicksElements = ref(props.route.meta?.__clicksElements || [])
+
+const route = computed(() => props.route)
+const nav = useNav(route)
+</script>
+
+<template>
+  <PrintSlideClick v-model:clicks-elements="clicksElements" :clicks="9999" :nav="nav" :route="route" />
+</template>

--- a/packages/client/internals/HandoutsPrint.vue
+++ b/packages/client/internals/HandoutsPrint.vue
@@ -1,0 +1,73 @@
+<script setup lang="ts">
+import { useStyleTag } from '@vueuse/core'
+import { useHead } from '@vueuse/head'
+import { configs } from '../env'
+import { rawRoutes } from '../logic/nav'
+import NoteDisplay from './NoteDisplay.vue'
+import HandoutPrintSlide from './HandoutPrintSlide.vue'
+
+// @ts-expect-error virtual module
+import GlobalHandout from '/@slidev/global-components/handout'
+
+// @ts-expect-error virtual module
+import GlobalHandoutCover from '/@slidev/global-components/handout-cover'
+
+useStyleTag(`
+@page {
+  size: A4;
+  margin-top: 1.5cm;
+  margin-bottom: 1cm;
+}
+* {
+  -webkit-print-color-adjust: exact;
+}
+html,
+html body,
+html #app,
+html #page-root {
+  height: auto;
+  overflow: auto !important;
+}
+`)
+
+useHead({ title: `Notes - ${configs.title}` })
+</script>
+
+<template>
+  <div id="page-root">
+    <div class="m-4">
+      <div v-if="true" id="print-container">
+        <div id="print-content" class="max-h-full">
+          <GlobalHandoutCover />
+          <div v-for="(route, idx) of rawRoutes" :key="route.path" class=" break-after-page">
+            <HandoutPrintSlide :route="route" class=" p-0 border-1 border-gray-700 max-w-full max-h-130" />
+
+            <div class="mt-8 h-110 flex flex-col">
+              <NoteDisplay
+                v-if="route.meta?.slide!.noteHTML" :note-html="route.meta?.slide!.noteHTML"
+                class="max-w-full grow"
+              />
+              <div v-else class="grow" />
+              <div class="">
+                <GlobalHandout />
+              </div>
+              <div class="text-right mt-3 text-xs">
+                {{ idx + 1 }}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style lang="postcss">
+#print-content {
+  @apply bg-main;
+}
+
+.print-slide-container {
+  @apply relative overflow-hidden !break-after-avoid;
+}
+</style>

--- a/packages/client/routes.ts
+++ b/packages/client/routes.ts
@@ -42,6 +42,7 @@ if (__SLIDEV_FEATURE_PRESENTER__) {
     return { path: '' }
   }
   routes.push({ path: '/presenter/print', component: () => import('./internals/PresenterPrint.vue') })
+  routes.push({ path: '/handouts/print', component: () => import('./internals/HandoutsPrint.vue') })
   routes.push({
     name: 'notes',
     path: '/notes',

--- a/packages/slidev/node/plugins/loaders.ts
+++ b/packages/slidev/node/plugins/loaders.ts
@@ -249,6 +249,13 @@ export function createSlidesLoader(
         if (id === '/@slidev/global-components/bottom')
           return generateGlobalComponents('bottom')
 
+        // global component
+        if (id === '/@slidev/global-components/handout')
+          return generateGlobalComponents('handout')
+
+        if (id === '/@slidev/global-components/handout-cover')
+          return generateGlobalComponents('handout-cover')
+
         // custom nav controls
         if (id === '/@slidev/custom-nav-controls')
           return generateCustomNavControls()
@@ -597,7 +604,7 @@ defineProps<{ no: number | string }>()`)
     return `export default ${JSON.stringify(config)}`
   }
 
-  async function generateGlobalComponents(layer: 'top' | 'bottom') {
+  async function generateGlobalComponents(layer: 'top' | 'bottom' | 'handout' | 'handout-cover') {
     const components = roots
       .flatMap((root) => {
         if (layer === 'top') {
@@ -605,6 +612,20 @@ defineProps<{ no: number | string }>()`)
             join(root, 'global.vue'),
             join(root, 'global-top.vue'),
             join(root, 'GlobalTop.vue'),
+          ]
+        }
+        else if (layer === 'handout') {
+          return [
+            join(root, 'handout.vue'),
+            join(root, 'global-handout.vue'),
+            join(root, 'GlobalHandout.vue'),
+          ]
+        }
+        else if (layer === 'handout-cover') {
+          return [
+            join(root, 'handout-cover.vue'),
+            join(root, 'global-handout-cover.vue'),
+            join(root, 'GlobalHandoutCover.vue'),
           ]
         }
         else {


### PR DESCRIPTION
This adds a new export "export-handouts" with the top half showing the slide and the bottom half showing the speaker notes.

It also adds two new global layers (`global-handout.vue` and `global-handout-cover.vue`), that allow for customization of the handouts.