### PR TITLE
feat: add lintSide preparser extension

### DIFF
--- a/demo/starter/setup/preparser.ts
+++ b/demo/starter/setup/preparser.ts
@@ -1,0 +1,14 @@
+import { definePreparserSetup } from '@slidev/types'
+import { red } from 'kolorist'
+
+export default definePreparserSetup(() => {
+    return [
+        {
+            lintSlide(slide) {
+                if(slide.note?.length > 500 ){
+                    console.warn(red("[slidev-lint] Long text passage in slide "+slide.index+", "+slide.note?.length+" chars, might overflow handout"))
+                }
+            },
+        },
+    ]
+})

--- a/packages/parser/src/core.ts
+++ b/packages/parser/src/core.ts
@@ -132,6 +132,9 @@ export async function parse(
           if (newContent !== undefined)
             slide.content = newContent
         }
+        if(e.lintSlide){
+            await e.lintSlide(slide)
+        }
       }
     }
     slides.push(slide)

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -59,6 +59,7 @@ export interface SlidevPreparserExtension {
   name: string
   transformRawLines?(lines: string[]): Promise<void> | void
   transformSlide?(content: string, frontmatter: any): Promise<string | undefined>
+  lintSlide?(slide: any): Promise<string | undefined>
 }
 
 export type PreparserExtensionLoader = (headmatter?: Record<string, unknown>, filepath?: string) => Promise<SlidevPreparserExtension[]>


### PR DESCRIPTION
Add preparser extension `lintSlide` that allows for linting checks to be run on the parsed slide.