### PR TITLE
fix: vue hmr

### DIFF
--- a/packages/slidev/node/plugins/loaders.ts
+++ b/packages/slidev/node/plugins/loaders.ts
@@ -182,26 +182,10 @@ export function createSlidesLoader(
         if (hmrPages.size > 0)
           moduleIds.add('/@slidev/titles.md')
 
-        const vueModules = (
-          await Promise.all(
-            Array.from(hmrPages).map(async (i) => {
-              const file = `${slidePrefix}${i + 1}.md`
-              try {
-                const md = await transformMarkdown((await (<any>MarkdownPlugin.transform)(newData.slides[i]?.content, file)).code, i, newData)
-                const handleHotUpdate = 'handler' in VuePlugin.handleHotUpdate! ? VuePlugin.handleHotUpdate!.handler : VuePlugin.handleHotUpdate!
-                return await handleHotUpdate({
-                  ...ctx,
-                  modules: Array.from(ctx.server.moduleGraph.getModulesByFile(file) || []),
-                  file,
-                  read() { return md },
-                })
-              }
-              catch (e) {
-                console.error('[Slidev] failed to send HMR', e)
-              }
-            }),
-          )
-        ).flatMap(i => i || [])
+        const vueModules = Array.from(hmrPages).map(i =>
+          ctx.server.moduleGraph.getModuleById(`${slidePrefix}${i + 1}.md`),
+        )
+
         hmrPages.clear()
 
         const moduleEntries = [

--- a/packages/slidev/package.json
+++ b/packages/slidev/package.json
@@ -57,7 +57,7 @@
     "@slidev/client": "workspace:*",
     "@slidev/parser": "workspace:*",
     "@slidev/types": "workspace:*",
-    "@vitejs/plugin-vue": "4.3.3",
+    "@vitejs/plugin-vue": "^4.3.3",
     "@vitejs/plugin-vue-jsx": "^3.0.2",
     "@windicss/config": "^1.9.1",
     "cli-progress": "^3.12.0",

--- a/packages/slidev/package.json
+++ b/packages/slidev/package.json
@@ -57,7 +57,7 @@
     "@slidev/client": "workspace:*",
     "@slidev/parser": "workspace:*",
     "@slidev/types": "workspace:*",
-    "@vitejs/plugin-vue": "4.3.1",
+    "@vitejs/plugin-vue": "4.3.3",
     "@vitejs/plugin-vue-jsx": "^3.0.2",
     "@windicss/config": "^1.9.1",
     "cli-progress": "^3.12.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -358,7 +358,7 @@ importers:
         specifier: workspace:*
         version: link:../types
       '@vitejs/plugin-vue':
-        specifier: 4.3.3
+        specifier: ^4.3.3
         version: 4.3.3(vite@4.4.9)(vue@3.3.4)
       '@vitejs/plugin-vue-jsx':
         specifier: ^3.0.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -358,8 +358,8 @@ importers:
         specifier: workspace:*
         version: link:../types
       '@vitejs/plugin-vue':
-        specifier: 4.3.1
-        version: 4.3.1(vite@4.4.9)(vue@3.3.4)
+        specifier: 4.3.3
+        version: 4.3.3(vite@4.4.9)(vue@3.3.4)
       '@vitejs/plugin-vue-jsx':
         specifier: ^3.0.2
         version: 3.0.2(vite@4.4.9)(vue@3.3.4)
@@ -694,7 +694,7 @@ packages:
       debug: 4.3.4(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
-      semver: 6.3.0
+      semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -764,7 +764,7 @@ packages:
       '@babel/helper-validator-option': 7.21.0
       browserslist: 4.21.4
       lru-cache: 5.1.1
-      semver: 6.3.0
+      semver: 6.3.1
     dev: false
     optional: true
 
@@ -2246,7 +2246,7 @@ packages:
       colorette: 2.0.20
       consola: 3.2.3
       fast-glob: 3.3.1
-      magic-string: 0.30.2
+      magic-string: 0.30.3
       pathe: 1.1.1
       perfect-debounce: 1.0.0
     transitivePeerDependencies:
@@ -2425,8 +2425,8 @@ packages:
       - supports-color
     dev: false
 
-  /@vitejs/plugin-vue@4.3.1(vite@4.4.9)(vue@3.3.4):
-    resolution: {integrity: sha512-tUBEtWcF7wFtII7ayNiLNDTCE1X1afySEo+XNVMNkFXaThENyCowIEX095QqbJZGTgoOcSVDJGlnde2NG4jtbQ==}
+  /@vitejs/plugin-vue@4.3.3(vite@4.4.9)(vue@3.3.4):
+    resolution: {integrity: sha512-ssxyhIAZqB0TrpUg6R0cBpCuMk9jTIlO1GNSKKQD6S8VjnXi6JXKfUXjSsxey9IwQiaRGsO1WnW9Rkl1L6AJVw==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
       vite: ^4.0.0
@@ -7147,13 +7147,6 @@ packages:
     hasBin: true
     dev: true
 
-  /semver@6.3.0:
-    resolution: {integrity: sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==}
-    hasBin: true
-    requiresBuild: true
-    dev: false
-    optional: true
-
   /semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
@@ -7756,7 +7749,7 @@ packages:
     dependencies:
       acorn: 8.9.0
       estree-walker: 3.0.3
-      magic-string: 0.30.2
+      magic-string: 0.30.3
       unplugin: 1.4.0
     dev: false
     optional: true
@@ -7782,7 +7775,7 @@ packages:
       escape-string-regexp: 5.0.0
       fast-glob: 3.3.1
       local-pkg: 0.4.3
-      magic-string: 0.30.2
+      magic-string: 0.30.3
       mlly: 1.4.0
       pathe: 1.1.1
       pkg-types: 1.0.3


### PR DESCRIPTION
closes #1092

Initially support Vue HMR of the latest `@vitejs/plugin-vue`. Removed hacked internal `handleHotUpdate` that from `@vitejs/plugin-vue` for avoiding breaking changes in the future.

For support finer-grained update, now needs to be handled HMR logic, comparing which part `script` or `template` is changed, by slidev itself.