### PR TITLE
feat: support katex line highlighting

### DIFF
--- a/demo/starter/slides.md
+++ b/demo/starter/slides.md
@@ -321,7 +321,7 @@ LaTeX is supported out-of-box powered by [KaTeX](https://katex.org/).
 Inline $\sqrt{3x-1}+(1+x)^2$
 
 Block
-$$
+$$ {all|1|2|all}
 \begin{array}{c}
 
 \nabla \times \vec{\mathbf{B}} -\, \frac1c\, \frac{\partial\vec{\mathbf{E}}}{\partial t} &

--- a/demo/starter/slides.md
+++ b/demo/starter/slides.md
@@ -321,7 +321,7 @@ LaTeX is supported out-of-box powered by [KaTeX](https://katex.org/).
 Inline $\sqrt{3x-1}+(1+x)^2$
 
 Block
-$$ {all|1|2|all}
+$$ {1|3|all}
 \begin{array}{c}
 
 \nabla \times \vec{\mathbf{B}} -\, \frac1c\, \frac{\partial\vec{\mathbf{E}}}{\partial t} &

--- a/packages/client/builtin/CodeBlockWrapper.vue
+++ b/packages/client/builtin/CodeBlockWrapper.vue
@@ -18,6 +18,7 @@ import { useClipboard } from '@vueuse/core'
 import { computed, getCurrentInstance, inject, onMounted, onUnmounted, ref, watchEffect } from 'vue'
 import { configs } from '../env'
 import { CLASS_VCLICK_TARGET, injectionClicks, injectionClicksDisabled, injectionClicksElements } from '../constants'
+import { makeId } from '../logic/utils'
 
 const props = defineProps({
   ranges: {
@@ -44,15 +45,6 @@ const props = defineProps({
 const clicks = inject(injectionClicks)
 const elements = inject(injectionClicksElements)
 const disabled = inject(injectionClicksDisabled)
-
-function makeId(length = 5) {
-  const result = []
-  const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
-  const charactersLength = characters.length
-  for (let i = 0; i < length; i++)
-    result.push(characters.charAt(Math.floor(Math.random() * charactersLength)))
-  return result.join('')
-}
 
 const el = ref<HTMLDivElement>()
 const vm = getCurrentInstance()

--- a/packages/client/builtin/KaTexBlockWrapper.vue
+++ b/packages/client/builtin/KaTexBlockWrapper.vue
@@ -1,3 +1,24 @@
+<!--
+Line highlighting for KaTex blocks/
+(auto transformed, you don't need to use this component directly)
+
+Usage:
+$$ {1|3|all}
+\begin{array}{c}
+
+\nabla \times \vec{\mathbf{B}} -\, \frac1c\, \frac{\partial\vec{\mathbf{E}}}{\partial t} &
+= \frac{4\pi}{c}\vec{\mathbf{j}}    \nabla \cdot \vec{\mathbf{E}} & = 4 \pi \rho \\
+
+\nabla \times \vec{\mathbf{E}}\, +\, \frac1c\, \frac{\partial\vec{\mathbf{B}}}{\partial t} & = \vec{\mathbf{0}} \\
+
+\nabla \cdot \vec{\mathbf{B}} & = 0
+
+\end{array}
+$$
+
+Learn more: https://deploy-preview-145--slidev.netlify.app/guide/syntax.html#latex-line-highlighting
+-->
+
 <script setup lang="ts">
 import { range, remove } from '@antfu/utils'
 import { computed, getCurrentInstance, inject, onMounted, onUnmounted, ref, watchEffect } from 'vue'

--- a/packages/client/builtin/KaTexBlockWrapper.vue
+++ b/packages/client/builtin/KaTexBlockWrapper.vue
@@ -1,0 +1,78 @@
+<script setup lang="ts">
+import { range, remove } from '@antfu/utils'
+import { computed, getCurrentInstance, inject, onMounted, onUnmounted, ref, watchEffect } from 'vue'
+import { parseRangeString } from '@slidev/parser'
+import { CLASS_VCLICK_TARGET, injectionClicks, injectionClicksDisabled, injectionClicksElements } from '../constants'
+import { makeId } from '../logic/utils'
+
+const props = defineProps({
+  ranges: {
+    default: () => [],
+  },
+  startLine: {
+    type: Number,
+    default: 1,
+  },
+})
+
+const clicks = inject(injectionClicks)
+const elements = inject(injectionClicksElements)
+const disabled = inject(injectionClicksDisabled)
+
+const el = ref<HTMLDivElement>()
+const vm = getCurrentInstance()
+
+onMounted(() => {
+  const prev = elements?.value.length
+  const index = computed(() => {
+    if (disabled?.value)
+      return props.ranges.length - 1
+    return Math.min(Math.max(0, (clicks?.value || 0) - (prev || 0)), props.ranges.length - 1)
+  })
+  const rangeStr = computed(() => props.ranges[index.value] || '')
+  if (props.ranges.length >= 2 && !disabled?.value) {
+    const id = makeId()
+    const ids = range(props.ranges.length - 1).map(i => id + i)
+    if (elements?.value) {
+      elements.value.push(...ids)
+      onUnmounted(() => ids.forEach(i => remove(elements.value, i)), vm)
+    }
+  }
+
+  watchEffect(() => {
+    if (!el.value)
+      return
+    const baseTargets = Array.from(el.value.querySelectorAll('.col-align-c > .vlist-t > .vlist-r > .vlist'))
+    const lines: Element[][] = []
+    baseTargets.forEach((baseTarget) => {
+      Array.from(baseTarget.children).forEach((childNode, idx) => {
+        const realNode = childNode.querySelector('.mord')
+        if (!realNode)
+          return
+        if (Array.isArray(lines[idx]))
+          lines[idx].push(realNode)
+        else
+          lines[idx] = [realNode]
+      })
+    })
+    const startLine = props.startLine
+    const highlights: number[] = parseRangeString(lines.length + startLine - 1, rangeStr.value)
+    lines.forEach((line, idx) => {
+      const highlighted = highlights.includes(idx + startLine)
+      line.forEach((node) => {
+        node.classList.toggle(CLASS_VCLICK_TARGET, true)
+        node.classList.toggle('highlighted', highlighted)
+        node.classList.toggle('dishonored', !highlighted)
+      })
+    })
+  })
+})
+</script>
+
+<template>
+  <div
+    ref="el" class="slidev-katex-wrapper"
+  >
+    <slot />
+  </div>
+</template>

--- a/packages/client/builtin/KaTexBlockWrapper.vue
+++ b/packages/client/builtin/KaTexBlockWrapper.vue
@@ -16,7 +16,7 @@ $$ {1|3|all}
 \end{array}
 $$
 
-Learn more: https://deploy-preview-145--slidev.netlify.app/guide/syntax.html#latex-line-highlighting
+Learn more: https://sli.dev/guide/syntax.html#latex-line-highlighting
 -->
 
 <script setup lang="ts">

--- a/packages/client/logic/utils.ts
+++ b/packages/client/logic/utils.ts
@@ -21,3 +21,12 @@ export function useTimer() {
     resetTimer,
   }
 }
+
+export function makeId(length = 5) {
+  const result = []
+  const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
+  const charactersLength = characters.length
+  for (let i = 0; i < length; i++)
+    result.push(characters.charAt(Math.floor(Math.random() * charactersLength)))
+  return result.join('')
+}

--- a/packages/client/styles/katex.css
+++ b/packages/client/styles/katex.css
@@ -1,0 +1,5 @@
+.slidev-katex-wrapper .mord.highlighted {
+}
+.slidev-katex-wrapper .mord.dishonored {
+  opacity: 0.3;
+}

--- a/packages/slidev/node/plugins/loaders.ts
+++ b/packages/slidev/node/plugins/loaders.ts
@@ -532,6 +532,7 @@ defineProps<{ no: number | string }>()`)
       `import "${toAtFS(join(clientRoot, 'styles/vars.css'))}"`,
       `import "${toAtFS(join(clientRoot, 'styles/index.css'))}"`,
       `import "${toAtFS(join(clientRoot, 'styles/code.css'))}"`,
+      `import "${toAtFS(join(clientRoot, 'styles/katex.css'))}"`,
       `import "${toAtFS(join(clientRoot, 'styles/transitions.css'))}"`,
     ]
     const roots = uniq([

--- a/packages/slidev/node/plugins/markdown.ts
+++ b/packages/slidev/node/plugins/markdown.ts
@@ -94,11 +94,20 @@ export async function createMarkdownPlugin(
         code = monaco(code)
         code = transformHighlighter(code)
         code = transformPageCSS(code, id)
+        code = transformKaTex(code)
 
         return code
       },
     },
   }) as Plugin
+}
+
+export function transformKaTex(md: string) {
+  return md.replace(/^\$\$(?:\s*{([\d\w*,\|-]+)}\s*?({.*?})?\s*?)?\n([\s\S]+?)^\$\$/mg, (full, rangeStr = '', _, code: string) => {
+    const ranges = (rangeStr as string).split(/\|/g).map(i => i.trim())
+    code = code.trimEnd()
+    return `<KaTexBlockWrapper :ranges='${JSON.stringify(ranges)}'>\n\n\$\$\n${code}\n\$\$\n</KaTexBlockWrapper>\n`
+  })
 }
 
 export function transformMarkdownMonaco(md: string) {


### PR DESCRIPTION
Reslove #266 

## Syntax
Base syntax is as same as [code blocks line highlighting](https://sli.dev/guide/syntax.html#line-highlighting)

Example:
```latex
$$ {2-3|all}
\begin{array}{c}
\nabla \cdot \vec{\mathbf{B}} & = 0
\end{array}
$$
```

## TODO
- [x] Support katex line highlighting
- [x] Add documentation(https://github.com/slidevjs/docs/pull/145)