### PR TITLE
fix: hideInToc bug

### DIFF
--- a/packages/client/logic/nav.ts
+++ b/packages/client/logic/nav.ts
@@ -195,7 +195,7 @@ export function addToTree(tree: TocItem[], route: RouteRecordRaw, level = 1) {
       children: [],
       level,
       path: route.path,
-      hideInToc: Boolean(route.meta?.hideInToc),
+      hideInToc: Boolean(route.meta?.slide?.frontmatter?.hideInToc),
       title: route.meta?.slide?.title,
     })
   }


### PR DESCRIPTION
@pposca raised a bug on hideInToc flag used on the Toc component which makes the hideInToc flag ineffective in latest versions. (https://github.com/slidevjs/slidev/issues/1109)

I observed the same bug and tries to propose a fix to the issue.

Context:
- The bug has been added between version `0.43.0-beta.5` and version `0.43.0-beta.6`. 
- Responsible commit is https://github.com/slidevjs/slidev/commit/16c41ce51fe094ccc7e03dccd6ba0faf5c7acacc
- Changed code is on line `571-572`
- Impacted code creating the bug is in `packages/client/logic/nav.ts` line `198`

Fix:
I propose a fix which uses what seems to be a more safe and stable way of accessing `hideInToc`. I don't have great experience on the architecture of the application so I let it at the maintainer's appreciation to validate the solution.
`route.meta?.hideInToc` (old) vs `route.meta?.slide?.frontmatter?.hideInToc` (new)
