### PR TITLE
feat: add start offset and customization option to ToC list

### DIFF
--- a/packages/client/builtin/Toc.vue
+++ b/packages/client/builtin/Toc.vue
@@ -16,6 +16,8 @@ const props = withDefaults(
   defineProps<{
     columns?: string | number
     listClass?: string | string[]
+    start?: string | number
+    listStyle?: string | string[]
     maxDepth?: string | number
     minDepth?: string | number
     mode?: 'all' | 'onlyCurrentTree' | 'onlySiblings'
@@ -23,6 +25,8 @@ const props = withDefaults(
   {
     columns: 1,
     listClass: '',
+    start: 1,
+    listStyle: '',
     maxDepth: Number.POSITIVE_INFINITY,
     minDepth: 1,
     mode: 'all',
@@ -85,6 +89,6 @@ const toc = computed(() => {
 
 <template>
   <div class="slidev-toc" :style="`column-count:${columns}`">
-    <TocList :level="1" :list="toc" :list-class="listClass" />
+    <TocList :level="1" :start="start" :listStyle="listStyle" :list="toc" :list-class="listClass" />
   </div>
 </template>

--- a/packages/client/builtin/Toc.vue
+++ b/packages/client/builtin/Toc.vue
@@ -89,6 +89,12 @@ const toc = computed(() => {
 
 <template>
   <div class="slidev-toc" :style="`column-count:${columns}`">
-    <TocList :level="1" :start="start" :listStyle="listStyle" :list="toc" :list-class="listClass" />
+    <TocList
+      :level="1"
+      :start="start"
+      :list-style="listStyle"
+      :list="toc"
+      :list-class="listClass"
+    />
   </div>
 </template>

--- a/packages/client/builtin/TocList.vue
+++ b/packages/client/builtin/TocList.vue
@@ -14,6 +14,8 @@ import Titles from '/@slidev/titles.md'
 
 const props = withDefaults(defineProps<{
   level: number
+  start: number
+  listStyle?: string | string[]
   list: TocItem[]
   listClass?: string | string[]
 }>(), { level: 1 })
@@ -25,10 +27,20 @@ const classes = computed(() => {
     `slidev-toc-list-level-${props.level}`,
   ]
 })
+
+const styles = computed(() => {
+  return [
+    ...toArray(props.listStyle || [])
+  ]
+})
 </script>
 
 <template>
-  <ol v-if="list && list.length > 0" :class="classes">
+  <ol v-if="list && list.length > 0" 
+    :class="classes"
+    :start="level === 1 ? start : null"
+    :style="styles.length >= level ? 'list-style:' + styles[level-1] : null"
+  >
     <li
       v-for="item of list"
       :key="item.path" class="slidev-toc-item"
@@ -40,6 +52,7 @@ const classes = computed(() => {
       <TocList
         v-if="item.children.length > 0"
         :level="level + 1"
+        :listStyle="listStyle"
         :list="item.children"
         :list-class="listClass"
       />

--- a/packages/client/builtin/TocList.vue
+++ b/packages/client/builtin/TocList.vue
@@ -14,7 +14,7 @@ import Titles from '/@slidev/titles.md'
 
 const props = withDefaults(defineProps<{
   level: number
-  start: number
+  start?: number
   listStyle?: string | string[]
   list: TocItem[]
   listClass?: string | string[]
@@ -30,16 +30,17 @@ const classes = computed(() => {
 
 const styles = computed(() => {
   return [
-    ...toArray(props.listStyle || [])
+    ...toArray(props.listStyle || []),
   ]
 })
 </script>
 
 <template>
-  <ol v-if="list && list.length > 0" 
+  <ol
+    v-if="list && list.length > 0"
     :class="classes"
-    :start="level === 1 ? start : null"
-    :style="styles.length >= level ? 'list-style:' + styles[level-1] : null"
+    :start="level === 1 ? start : undefined"
+    :style="styles.length >= level ? `list-style:${styles[level - 1]}` : undefined"
   >
     <li
       v-for="item of list"
@@ -52,7 +53,7 @@ const styles = computed(() => {
       <TocList
         v-if="item.children.length > 0"
         :level="level + 1"
-        :listStyle="listStyle"
+        :list-style="listStyle"
         :list="item.children"
         :list-class="listClass"
       />


### PR DESCRIPTION
Hello,

To improve the usability and use cases provided by the table of content component (`ToC`), I propose to add two new functionalities which are as follow:

- An offset applied to the highest level of the ToC. It allows to create presentation which does not start at the 1st 'chapter'. This is useful for example when you want to create a long presentation with multiple chapter but split in multiple documents. Function is implemented by adding a `start` attribute to the `ToC` component. The given number corresponds to the offset as used with the HTML `ol` element.
- Add the possibility to customize the style of the ordered list used in the ToC. Function is implemented by adding a `listStyle` attribute to the ToC component. It takes a string or a list of string (ex: `:listStyle="['upper-roman', 'lower-roman']"`) to define the style whatever the depths on the ToC. Given style is set in the given order of the list from the lowest level (1) to the highest (ex: 5). If list depth is higher than user provided `listStyle` default HTML value is used (`decimal`). Style names are the same as the ones valid for the CSS property `list-style-type`. This functionality gives flexibility and personalization capabilities to the user.

Adding those functionnalities would be very welcomed.
Thanks.