### PR TITLE
fix(cli): can not extract class for layout in frontmatter

### DIFF
--- a/packages/slidev/node/plugins/extractor.ts
+++ b/packages/slidev/node/plugins/extractor.ts
@@ -1,0 +1,28 @@
+import type { Extractor } from '@unocss/core'
+
+// ---
+// layout: two-cols
+// class: bg-red text-white
+// layoutClass: bg-blue text-white
+// ---
+
+const regexFrontmatterRange = /^---\n((?:.|\n)*?)---/gm
+const regexPossibleClassInFrontmatter = /^.*[cC]lass.*:\s*(.*)\s*$/gm
+
+export function extractorFrontmatterClass(): Extractor {
+  return {
+    name: 'class-in-frontmatter',
+    extract(ctx) {
+      if (!ctx.code.endsWith('.frontmatter'))
+        return
+
+      ctx.code.match(regexFrontmatterRange)?.forEach((range) => {
+        for (const item of range.matchAll(regexPossibleClassInFrontmatter)) {
+          item[1].split(/\s+/).forEach((c) => {
+            ctx.extracted.add(c)
+          })
+        }
+      })
+    },
+  }
+}

--- a/packages/slidev/node/plugins/unocss.ts
+++ b/packages/slidev/node/plugins/unocss.ts
@@ -8,6 +8,7 @@ import jiti from 'jiti'
 import UnoCSS from 'unocss/vite'
 import type { ResolvedSlidevOptions, SlidevPluginOptions } from '..'
 import { loadSetups } from './setupNode'
+import { extractorFrontmatterClass } from './extractor'
 
 export async function createUnocssPlugin(
   { themeRoots, addonRoots, clientRoot, roots, userRoot, data }: ResolvedSlidevOptions,
@@ -34,7 +35,23 @@ export async function createUnocssPlugin(
 
   configs.reverse()
 
-  let config = mergeConfigs([...configs, unoOptions as UserConfig<Theme>])
+  let config = mergeConfigs([
+    {
+      content: {
+        pipeline: {
+          include: [
+            /\.(vue|svelte|[jt]sx|mdx?|astro|elm|php|phtml|html)($|\?)/,
+            /\.(frontmatter)/,
+          ],
+        },
+      },
+      extractors: [
+        extractorFrontmatterClass(),
+      ],
+    },
+    ...configs,
+    unoOptions as UserConfig<Theme>,
+  ])
 
   config = await loadSetups(roots, 'unocss.ts', {}, config, true)
 


### PR DESCRIPTION
When I use the built-in `two-cols` layout, I habitually pass the `class` in the frontmatter to the layout. class was added correctly, but the style did not take effect.

```md
---
layout: two-cols
class: bg-red
---

# Left

This shows on the left

::right::

# Right

This shows on the right
```

I realized this was because of limitations of build-time scanning, so tried to fix it this way. I'm not quite sure if this is a necessary fix, or if this is the correct way to fix it. Looking forward to your opinions.