### PR TITLE
fix(layouts): show righthand-side of iframe-left

### DIFF
--- a/packages/client/layouts/iframe-left.vue
+++ b/packages/client/layouts/iframe-left.vue
@@ -17,9 +17,9 @@ const scaleInvertPercent = computed(() => `${(1 / (props.scale || 1)) * 100}%`)
         :src="url"
         :style="scale ? { transform: `scale(${scale})`, transformOrigin: 'top left' } : {}"
       />
-      <div class="slidev-layout default" v-bind="$attrs">
-        <slot />
-      </div>
+    </div>
+    <div class="slidev-layout default" v-bind="$attrs">
+      <slot />
     </div>
   </div>
 </template>


### PR DESCRIPTION
This broke in 1d4e2d1 and resulted in the righthand-side content being placed outside of the slide.