### PR TITLE
refactor: remove using resolvePackageData from Vite

### DIFF
--- a/packages/slidev/package.json
+++ b/packages/slidev/package.json
@@ -105,6 +105,7 @@
     "vite-plugin-static-copy": "^0.17.0",
     "vite-plugin-vue-server-ref": "^0.3.4",
     "vite-plugin-windicss": "^1.9.1",
+    "vitefu": "^0.2.5",
     "vue": "^3.3.4",
     "windicss": "^3.5.6",
     "yargs": "^17.7.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -501,6 +501,9 @@ importers:
       vite-plugin-windicss:
         specifier: ^1.9.1
         version: 1.9.1(vite@4.4.11)
+      vitefu:
+        specifier: ^0.2.5
+        version: 0.2.5(vite@4.4.11)
       vue:
         specifier: ^3.3.4
         version: 3.3.4
@@ -8109,6 +8112,17 @@ packages:
       rollup: 3.28.0
     optionalDependencies:
       fsevents: 2.3.2
+
+  /vitefu@0.2.5(vite@4.4.11):
+    resolution: {integrity: sha512-SgHtMLoqaeeGnd2evZ849ZbACbnwQCIwRH57t18FxcXoZop0uQu0uzlIhJBlF/eWVzuce0sHeqPcDo+evVcg8Q==}
+    peerDependencies:
+      vite: ^3.0.0 || ^4.0.0 || ^5.0.0
+    peerDependenciesMeta:
+      vite:
+        optional: true
+    dependencies:
+      vite: 4.4.11(@types/node@20.8.3)
+    dev: false
 
   /vitest@0.34.6:
     resolution: {integrity: sha512-+5CALsOvbNKnS+ZHMXtuUC7nL8/7F1F2DnHGjSsszX8zCjWSSviphCb/NuS9Nzf4Q03KyyDRBAXhF/8lffME4Q==}


### PR DESCRIPTION
https://github.com/vitejs/vite/pull/14584 is removing the API for future perf optimizations and bug fixes. Since the API is not widely used, I've made a PR to refactor it away directly.

This uses [`vitefu`](https://github.com/svitejs/vitefu) which I maintain on the side and implements the same heuristic, and is also used by frameworks like Svelte, Solid, and Astro today.

(I've not tested this particular code, but I hope the CI covers it)