### PR TITLE
fix: code animation pdf exports the first step instead of last

### DIFF
--- a/packages/client/internals/PrintSlideClick.vue
+++ b/packages/client/internals/PrintSlideClick.vue
@@ -4,6 +4,7 @@ import { computed, provide, reactive, shallowRef } from 'vue'
 import { useVModel } from '@vueuse/core'
 import { useNavClicks } from '../composables/useNavClicks'
 import { injectionSlidevContext } from '../constants'
+import { isClicksDisabled } from '../logic/nav'
 import { configs, slideHeight, slideWidth } from '../env'
 import { getSlideClass } from '../utils'
 import type { SlidevContextNav } from '../modules/context'
@@ -53,8 +54,8 @@ provide(injectionSlidevContext, reactive({
     <SlideWrapper
       :is="route?.component!"
       v-model:clicks-elements="clicksElements"
-      :clicks="clicks"
-      :clicks-disabled="false"
+      :clicks="isClicksDisabled ? undefined : clicks"
+      :clicks-disabled="isClicksDisabled"
       :class="getSlideClass(route)"
       :route="route"
     />


### PR DESCRIPTION
Slides with animations (e.g., code highlight clicks, or custom (non v-click) clicks) were exported in their initial state instead of their final state.

The cause was the /print view that was always passing `:clicksDisabled="false"` even for full slide export.

When clicks are disabled, the print view now uses the same delegation as the Overview https://github.com/slidevjs/slidev/blob/ce8c338e9d15d9e818c11f5badb2ff2afe10c19b/packages/client/internals/SlidesOverview.vue#L133-L140