### PR TITLE
fix: type exports

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/slidevjs/slidev"
   },
   "bugs": "https://github.com/slidevjs/slidev/issues",
-  "main": "dist/index.js",
+  "main": "dist/index.mjs",
   "module": "dist/index.mjs",
   "types": "index.d.ts",
   "files": [


### PR DESCRIPTION
This should allow the `@slidev/types` exports to properly resolve.

I wasn't able to test locally, but I believe this should resolve #1167