### PR TITLE
fix: 'preload: false' in frontmatter not working, fix #1164

### DIFF
--- a/packages/client/routes.ts
+++ b/packages/client/routes.ts
@@ -82,6 +82,7 @@ declare module 'vue-router' {
     class?: string
     clicks?: number
     transition?: string | TransitionGroupProps | undefined
+    preload?: boolean
 
     // slide info
     slide?: {

--- a/packages/slidev/node/plugins/loaders.ts
+++ b/packages/slidev/node/plugins/loaders.ts
@@ -295,6 +295,7 @@ export function createSlidesLoader(
                     class: computed(() => frontmatter.class),
                     clicks: computed(() => frontmatter.clicks),
                     name: computed(() => frontmatter.name),
+                    preload: computed(() => frontmatter.preload),
                     slide: {
                       ...(${JSON.stringify({
                         ...prepareSlideInfo(slide),


### PR DESCRIPTION
This Pr fix the issue #1164.
from v0.43.0 the frontmatter is not merged in route.meta in slidev/node/plugin/loaders.js , but some fields are injected as computed property.

As a result the "preload" field is not anymore injected in route.meta and not found in :
https://github.com/slidevjs/slidev/blob/main/packages/client/internals/SlidesShow.vue#L21-L26
This Pr add preload in RouteMeta as other existing property (clicks, ...).
