### PR TITLE
fix: changing pages in presenter mode didn't trigger animations in play mode

### DIFF
--- a/packages/client/setup/root.ts
+++ b/packages/client/setup/root.ts
@@ -8,6 +8,7 @@ import { initDrawingState } from '../state/drawings'
 import { clicks, currentPage, getPath, isNotesViewer, isPresenter } from '../logic/nav'
 import { router } from '../routes'
 import { TRUST_ORIGINS } from '../constants'
+import { skipTransition } from '../composables/hmr'
 
 export default function setupRoot() {
   // @ts-expect-error injected in runtime
@@ -58,6 +59,7 @@ export default function setupRoot() {
     if (!routePath.match(/^\/(\d+|presenter)\/?/))
       return
     if (state.lastUpdate?.type === 'presenter' && (+state.page !== +currentPage.value || +clicks.value !== +state.clicks)) {
+      skipTransition.value = false
       router.replace({
         path: getPath(state.page),
         query: {


### PR DESCRIPTION
[Video.webm](https://github.com/slidevjs/slidev/assets/49056869/6d5ce251-af92-4d1c-9a0b-c1e7d5565b68)

Changing pages in play mode triggers slide transitions. But changing pages in presenter mode didn't trigger slide transitions in play mode.
