### PR TITLE
fix: don't apply view-transition between previous slide

### DIFF
--- a/packages/client/composables/useViewTransition.ts
+++ b/packages/client/composables/useViewTransition.ts
@@ -10,8 +10,17 @@ export function useViewTransition() {
 
   const supportViewTransition = typeof document !== 'undefined' && 'startViewTransition' in document
 
-  router.beforeResolve((from, to) => {
-    if (!(from.meta.transition === 'view-transition' || to.meta.transition === 'view-transition')) {
+  router.beforeResolve((to, from) => {
+    const fromNo = from.meta.slide?.no
+    const toNo = to.meta.slide?.no
+    if (
+      !(
+        fromNo !== undefined && toNo !== undefined && (
+          (from.meta.transition === 'view-transition' && fromNo < toNo)
+          || (to.meta.transition === 'view-transition' && toNo < fromNo)
+        )
+      )
+    ) {
       isViewTransition.value = false
       return
     }


### PR DESCRIPTION
Setting transitions on a slide applies to the transition between that slide and the next slide.
For example, in the following example,
```
foo

---
transition: slide-left
---

bar

---

baz
```
`transition: slide-left` will apply to `bar -> baz`/`bar <- baz`, but not to `foo -> bar`/`bar <- foo`.

`transition: view-transition` was not working like that. It was applied to both of them. This PR fixes that.

