### PR TITLE
fix(layout): two-cols-header grid with bottom

### DIFF
--- a/packages/client/layouts/two-cols-header.vue
+++ b/packages/client/layouts/two-cols-header.vue
@@ -11,6 +11,8 @@ This shows on the left
 ::right::
 # Right
 This shows on the right
+::bottom::
+This shows at the bottom, aligned to the end (bottom) of the grid
 ```
 -->
 
@@ -36,6 +38,9 @@ const props = defineProps({
     <div class="col-right" :class="props.class">
       <slot name="right" />
     </div>
+    <div class="col-bottom" :class="props.class">
+      <slot name="bottom" />
+    </div>
   </div>
 </template>
 
@@ -49,4 +54,8 @@ const props = defineProps({
 .col-header { grid-area: 1 / 1 / 2 / 3; }
 .col-left { grid-area: 2 / 1 / 3 / 2; }
 .col-right { grid-area: 2 / 2 / 3 / 3; }
+.col-bottom {
+  align-self: end;
+  grid-area: 3 / 1 / 3 / 3;
+}
 </style>


### PR DESCRIPTION
Restores the `bottom` slot from [the original feature PR](https://github.com/slidevjs/slidev/pull/1114) by fixing the grid layout.

### With `bottom` slot content

<img width="849" alt="CSS grid with bottom slot" src="https://github.com/slidevjs/slidev/assets/2229946/3c001407-e43c-443f-8836-375e8757cf4e">

### With no `bottom` slot content provided

<img width="848" alt="image" src="https://github.com/slidevjs/slidev/assets/2229946/09df0877-edf8-4083-b16b-c01e3e1fcaff">
