### PR TITLE
Fix attribute preset in template

### DIFF
--- a/demo/starter/slides.md
+++ b/demo/starter/slides.md
@@ -212,7 +212,7 @@ class: px-20
 
 Slidev comes with powerful theming support. Themes can provide styles, layouts, components, or even configurations for tools. Switching between themes by just **one edit** in your frontmatter:
 
-<div grid="~ cols-2 gap-2" m="-t-2">
+<div grid="~ cols-2 gap-2" m="t-2">
 
 ```yaml
 ---

--- a/packages/slidev/template.md
+++ b/packages/slidev/template.md
@@ -164,7 +164,7 @@ class: px-20
 
 Slidev comes with powerful theming support. Themes are able to provide styles, layouts, components, or even configurations for tools. Switching between themes by just **one edit** in your frontmatter:
 
-<div grid="~ cols-2 gap-2" m="-t-2">
+<div grid="~ cols-2 gap-2" m="t-2">
 
 ```yaml
 ---


### PR DESCRIPTION
`m="-t-2"` doesn't seem to work, while `m="t-2"` works fine
