### PR TITLE
feat: table support for v-clicks

### DIFF
--- a/packages/client/builtin/VClicks.ts
+++ b/packages/client/builtin/VClicks.ts
@@ -118,6 +118,24 @@ export default defineComponent({
     if (defaults.length === 1 && listTags.includes(defaults[0].type as string) && Array.isArray(defaults[0].children))
       return h(defaults[0], {}, [mapChildren(defaults[0].children)[0]])
 
+    if (defaults.length === 1 && defaults[0].type as string === 'table') {
+      const tableNode = defaults[0]
+      if (Array.isArray(tableNode.children)) {
+        return h(tableNode, {}, tableNode.children.map((i) => {
+          if (!isVNode(i)) {
+            return i
+          }
+          else {
+            if (i.type === 'tbody' && Array.isArray(i.children))
+              return h(i, {}, [mapChildren(i.children)[0]])
+
+            else
+              return h(i)
+          }
+        }))
+      }
+    }
+
     return mapChildren(defaults)[0]
   },
 })


### PR DESCRIPTION
## Description 
Implemented VClicks feature for table tags in response to the request in issue #1102. 
Now, each row in a table shows up upon each click.


## Demo

### Code
```markdown
# VClicks for Table

<v-clicks>

|                  | emacs | vim            |
| ---------------- | ----- | -------------- |
| startup          | slow  | fast           |
| difficult to use | yes   | yes            |
| keybinds used on | Mac   | Linux-Commands |
| GUI              | yes   | no             |

</v-clicks>
```

### Movie
https://github.com/slidevjs/slidev/assets/19663115/afc70227-ae39-4019-ae6a-6649e5b88fa4


