### PR TITLE
fix: allow more characters for slot names

### DIFF
--- a/packages/slidev/node/plugins/markdown.ts
+++ b/packages/slidev/node/plugins/markdown.ts
@@ -144,7 +144,7 @@ export function transformSlotSugar(md: string) {
     if (isLineInsideCodeblocks(idx))
       return
 
-    const match = line.trimEnd().match(/^::\s*(\S+)\s*::$/)
+    const match = line.trimEnd().match(/^::\s*([\w\.\-\:]+)\s*::$/)
     if (match) {
       lines[idx] = `${prevSlot ? '\n\n</template>\n' : '\n'}<template v-slot:${match[1]}="slotProps">\n`
       prevSlot = true

--- a/packages/slidev/node/plugins/markdown.ts
+++ b/packages/slidev/node/plugins/markdown.ts
@@ -144,7 +144,7 @@ export function transformSlotSugar(md: string) {
     if (isLineInsideCodeblocks(idx))
       return
 
-    const match = line.trimEnd().match(/^::\s*(\w+)\s*::$/)
+    const match = line.trimEnd().match(/^::\s*(\S+)\s*::$/)
     if (match) {
       lines[idx] = `${prevSlot ? '\n\n</template>\n' : '\n'}<template v-slot:${match[1]}="slotProps">\n`
       prevSlot = true

--- a/test/__snapshots__/transform.test.ts.snap
+++ b/test/__snapshots__/transform.test.ts.snap
@@ -112,7 +112,7 @@ exports[`markdown transform > slot-sugar with symbols in name 1`] = `
 
 Default Slot
 
-<template v-slot:slot-[1]=\\"slotProps\\">
+<template v-slot:slot::1=\\"slotProps\\">
 
 First Slot
 

--- a/test/__snapshots__/transform.test.ts.snap
+++ b/test/__snapshots__/transform.test.ts.snap
@@ -105,3 +105,23 @@ Default Slot
 
 </template>"
 `;
+
+exports[`markdown transform > slot-sugar with symbols in name 1`] = `
+"
+# Page 
+
+Default Slot
+
+<template v-slot:slot-[1]=\\"slotProps\\">
+
+First Slot
+
+
+</template>
+<template v-slot:slot.2=\\"slotProps\\">
+
+Second Slot
+
+
+</template>"
+`;

--- a/test/transform.test.ts
+++ b/test/transform.test.ts
@@ -48,6 +48,18 @@ Slot Usage
 `)).toMatchSnapshot()
   })
 
+  it('slot-sugar with symbols in name', () => {
+    expect(transformSlotSugar(`
+# Page 
+
+Default Slot
+::slot-[1]::
+First Slot
+::slot.2::
+Second Slot
+`)).toMatchSnapshot()
+  })
+
   it('inline CSS', () => {
     expect(transformPageCSS(`
 # Page 

--- a/test/transform.test.ts
+++ b/test/transform.test.ts
@@ -53,7 +53,7 @@ Slot Usage
 # Page 
 
 Default Slot
-::slot-[1]::
+::slot::1::
 First Slot
 ::slot.2::
 Second Slot


### PR DESCRIPTION
Closes #1208.

Switched `\w` to `\S` in the regexp for matching the `::slot-name::` syntax.
`\S` matches any non white-space character, not sure if it is the right group or if we need some other custom matching list.
I am not familiar enough with Vue to know which characters are allowed for slot names.