### PR TITLE
feat: ViteSlidevPlugin `pluginOptions` argument now can be modified by themes and addons

### DIFF
--- a/packages/slidev/node/server.ts
+++ b/packages/slidev/node/server.ts
@@ -1,7 +1,7 @@
 import { join } from 'node:path'
 import process from 'node:process'
 import type { InlineConfig } from 'vite'
-import { createServer as createViteServer, resolveConfig } from 'vite'
+import { createServer as createViteServer, mergeConfig } from 'vite'
 import { mergeViteConfigs } from './common'
 import type { ResolvedSlidevOptions, SlidevServerOptions } from './options'
 import { ViteSlidevPlugin } from './plugins/preset'
@@ -11,28 +11,31 @@ export async function createServer(
   viteConfig: InlineConfig = {},
   serverOptions: SlidevServerOptions = {},
 ) {
-  const rawConfig = await resolveConfig({}, 'serve', options.entry)
-  const pluginOptions = rawConfig.slidev || {}
-
   // default open editor to code, #312
   process.env.EDITOR = process.env.EDITOR || 'code'
 
-  const server = await createViteServer(
-    await mergeViteConfigs(
-      options,
-      viteConfig,
-      <InlineConfig>({
-        root: options.userRoot,
-        optimizeDeps: {
-          entries: [
-            join(options.clientRoot, 'main.ts'),
-          ],
-        },
-        plugins: [
-          await ViteSlidevPlugin(options, pluginOptions, serverOptions),
+  const config = await mergeViteConfigs(
+    options,
+    viteConfig,
+    <InlineConfig>({
+      root: options.userRoot,
+      optimizeDeps: {
+        entries: [
+          join(options.clientRoot, 'main.ts'),
         ],
-      }),
-      'serve',
+      },
+    }),
+    'serve',
+  )
+
+  const server = await createViteServer(
+    mergeConfig(
+      config,
+      {
+        plugins: [
+          await ViteSlidevPlugin(options, config.slidev || {}, serverOptions),
+        ],
+      },
     ),
   )
 


### PR DESCRIPTION
Closes #1040.

# Changes
- `mergeViteConfigs` now also loads the local `vite.config.ts` file and merges the `slidev` options from it.
  (I first tried merging everything from the local config, but it contains loads of default vite plugins and made the pipeline crash.)
- In the `build` and `createServer` functions, we first create a merged viteConfig object without `ViteSlidevPlugin`.
  We then create the plugin, using `viteConfig.slidev` as the `pluginOptions` argument, effectively allowing themes and addons to override the options.
  Finally, we add the plugin to the `viteConfig`.


# Remarks
I did not add any tests for this feature.
Is this necessary and if so, from which test can I start as a reference ? 