### PR TITLE
fix: Highlighting latex equations when using \begin{align*}

### DIFF
--- a/packages/client/builtin/KaTexBlockWrapper.vue
+++ b/packages/client/builtin/KaTexBlockWrapper.vue
@@ -68,7 +68,7 @@ onMounted(() => {
     if (!equationParents)
       return
 
-    // We extract each equation row from the parents
+    // For each row we extract the individual equation rows
     const equationRowsOfEachParent = Array.from(equationParents)
       .map(item => Array.from(item.querySelectorAll('.vlist-t > .vlist-r > .vlist > span > .mord')))
     // This list maps rows, which pairs up rows from different equationParents

--- a/packages/client/builtin/KaTexBlockWrapper.vue
+++ b/packages/client/builtin/KaTexBlockWrapper.vue
@@ -71,7 +71,7 @@ onMounted(() => {
     // For each row we extract the individual equation rows
     const equationRowsOfEachParent = Array.from(equationParents)
       .map(item => Array.from(item.querySelectorAll('.vlist-t > .vlist-r > .vlist > span > .mord')))
-    // This list maps rows, which pairs up rows from different equationParents
+    // This list maps rows from different parents to line them up
     const lines: Element[][] = []
     for (const equationRowParent of equationRowsOfEachParent) {
       equationRowParent.forEach((equationRow, idx) => {

--- a/packages/client/builtin/KaTexBlockWrapper.vue
+++ b/packages/client/builtin/KaTexBlockWrapper.vue
@@ -63,19 +63,27 @@ onMounted(() => {
   watchEffect(() => {
     if (!el.value)
       return
-    const baseTargets = Array.from(el.value.querySelectorAll('.col-align-c > .vlist-t > .vlist-r > .vlist'))
+    // KaTeX equations have col-align-XXX as parent
+    const equationParents = el.value.querySelectorAll('.mtable > [class*=col-align]')
+    if (!equationParents)
+      return
+
+    // We extract each equation row from the parents
+    const equationRowsOfEachParent = Array.from(equationParents)
+      .map(item => Array.from(item.querySelectorAll('.vlist-t > .vlist-r > .vlist > span > .mord')))
+    // This list maps rows, which pairs up rows from different equationParents
     const lines: Element[][] = []
-    baseTargets.forEach((baseTarget) => {
-      Array.from(baseTarget.children).forEach((childNode, idx) => {
-        const realNode = childNode.querySelector('.mord')
-        if (!realNode)
+    for (const equationRowParent of equationRowsOfEachParent) {
+      equationRowParent.forEach((equationRow, idx) => {
+        if (!equationRow)
           return
         if (Array.isArray(lines[idx]))
-          lines[idx].push(realNode)
+          lines[idx].push(equationRow)
         else
-          lines[idx] = [realNode]
+          lines[idx] = [equationRow]
       })
-    })
+    }
+
     const startLine = props.startLine
     const highlights: number[] = parseRangeString(lines.length + startLine - 1, rangeStr.value)
     lines.forEach((line, idx) => {


### PR DESCRIPTION
Consider the following `slides.md` file

```
---
layout: default
---
# Slide

$$ {1|2|3|4}

\begin{align*}

R=& (111....)_2 + (111....)_2 \\
=& \sum_{n=0}^{n-1} 2^n + \sum_{n=0}^{n-1} 2^n \\

=& \: 2*{\sum_{n=0}^{n-1} 2^n} \\

=& \: 2*(2^{n} - 1)

\end{align*}

$$

```

I would expect the [highlighting to work for LaTeX ](https://sli.dev/guide/syntax.html#latex-line-highlighting).
However it doesn't.

This generalizes the logic of finding the individual rows by iterating over all .col-align-XXX classes that contain the individual equation rows.

