### PR TITLE
feat: Support highlight start at for latex

### DIFF
--- a/packages/client/builtin/KaTexBlockWrapper.vue
+++ b/packages/client/builtin/KaTexBlockWrapper.vue
@@ -34,6 +34,10 @@ const props = defineProps({
     type: Number,
     default: 1,
   },
+  at: {
+    type: Number,
+    default: undefined,
+  },
 })
 
 const clicks = inject(injectionClicks)
@@ -44,7 +48,7 @@ const el = ref<HTMLDivElement>()
 const vm = getCurrentInstance()
 
 onMounted(() => {
-  const prev = elements?.value.length
+  const prev = props.at == null ? elements?.value.length : props.at
   const index = computed(() => {
     if (disabled?.value)
       return props.ranges.length - 1

--- a/packages/slidev/node/plugins/markdown.ts
+++ b/packages/slidev/node/plugins/markdown.ts
@@ -136,10 +136,11 @@ export async function createMarkdownPlugin(
 }
 
 export function transformKaTex(md: string) {
-  return md.replace(/^\$\$(?:\s*{([\d\w*,\|-]+)}\s*?({.*?})?\s*?)?\n([\s\S]+?)^\$\$/mg, (full, rangeStr = '', _, code: string) => {
+  return md.replace(/^\$\$(?:\s*{([\d\w*,\|-]+)}\s*?({.*?})?\s*?)?\n([\s\S]+?)^\$\$/mg, (full, rangeStr = '', options = '', code: string) => {
     const ranges = (rangeStr as string).split(/\|/g).map(i => i.trim())
     code = code.trimEnd()
-    return `<KaTexBlockWrapper :ranges='${JSON.stringify(ranges)}'>\n\n\$\$\n${code}\n\$\$\n</KaTexBlockWrapper>\n`
+    options = options.trim() || '{}'
+    return `<KaTexBlockWrapper v-bind="${options}" :ranges='${JSON.stringify(ranges)}'>\n\n\$\$\n${code}\n\$\$\n</KaTexBlockWrapper>\n`
   })
 }
 


### PR DESCRIPTION
Code blocks support providing an "at:0" to start at the nth click.
Latex blocks didn't support this feature... until now :).

This PR allows using the {at:0} syntax for latex blocks to synchronize clicks