### PR TITLE
fix: Latex line highlighting for vector equations

### DIFF
--- a/packages/client/builtin/KaTexBlockWrapper.vue
+++ b/packages/client/builtin/KaTexBlockWrapper.vue
@@ -70,7 +70,7 @@ onMounted(() => {
 
     // For each row we extract the individual equation rows
     const equationRowsOfEachParent = Array.from(equationParents)
-      .map(item => Array.from(item.querySelectorAll('.vlist-t > .vlist-r > .vlist > span > .mord')))
+      .map(item => Array.from(item.querySelectorAll(':scope > .vlist-t > .vlist-r > .vlist > span > .mord')))
     // This list maps rows from different parents to line them up
     const lines: Element[][] = []
     for (const equationRowParent of equationRowsOfEachParent) {


### PR DESCRIPTION
PR: https://github.com/slidevjs/slidev/pull/1228

Introduced a regression in which vector symbols get classified as a latex line, causing the line highlighting to break.

By adding [:scope](https://developer.mozilla.org/en-US/docs/Web/CSS/:scope) to the css selector only the direct descendants on the parent will be selected, thereby skipping child elements (vectors) that have the same css structure

```
---
layout: default
---
# Slide

$$ {0|1|2|3|all}
\begin{array}{c}

\nabla \times \vec{\mathbf{B}} -\, \frac1c\, \frac{\partial\vec{\mathbf{E}}}{\partial t} &
= \frac{4\pi}{c}\vec{\mathbf{j}} \nabla \cdot \vec{\mathbf{E}} & = 4 \pi \rho \\

\nabla \times \vec{\mathbf{E}}\, +\, \frac1c\, \frac{\partial\vec{\mathbf{B}}}{\partial t} & = \vec{\mathbf{0}}\\

\nabla \cdot \vec{\mathbf{B}} & = 0 

\end{array}
$$
```

Before (clicks=1)

![image](https://github.com/slidevjs/slidev/assets/30316353/35fe55ec-6a17-43cc-94d9-5847251d1e25)

After the fix

![image](https://github.com/slidevjs/slidev/assets/30316353/10eb51f9-2cdd-4046-9887-7b3f26a9b73b)

