### PR TITLE
refactor!: remove build-in vue-starport support

### DIFF
--- a/packages/client/App.vue
+++ b/packages/client/App.vue
@@ -6,5 +6,4 @@ setupRoot()
 
 <template>
   <RouterView />
-  <StarportCarrier />
 </template>

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -47,7 +47,6 @@
     "vite-plugin-windicss": "^1.9.3",
     "vue": "^3.4.15",
     "vue-router": "^4.2.5",
-    "vue-starport": "^0.4.0",
     "windicss": "^3.5.6"
   },
   "devDependencies": {

--- a/packages/client/setup/main.ts
+++ b/packages/client/setup/main.ts
@@ -2,7 +2,6 @@
 
 import type { AppContext } from '@slidev/types'
 import { MotionPlugin } from '@vueuse/motion'
-import StarportPlugin from 'vue-starport'
 import TwoSlashFloatingVue from '@shikijs/vitepress-twoslash/client'
 
 export default function setupMain(context: AppContext) {
@@ -15,7 +14,6 @@ export default function setupMain(context: AppContext) {
   window.addEventListener('resize', setMaxHeight)
 
   context.app.use(MotionPlugin)
-  context.app.use(StarportPlugin({ keepAlive: true }))
   context.app.use(TwoSlashFloatingVue as any)
 
   // @ts-expect-error inject in runtime

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -295,9 +295,6 @@ importers:
       vue-router:
         specifier: ^4.2.5
         version: 4.2.5(vue@3.4.15)
-      vue-starport:
-        specifier: ^0.4.0
-        version: 0.4.0(typescript@5.3.3)
       windicss:
         specifier: ^3.5.6
         version: 3.5.6
@@ -8996,16 +8993,6 @@ packages:
     dependencies:
       '@vue/devtools-api': 6.5.1
       vue: 3.4.15(typescript@5.3.3)
-    dev: false
-
-  /vue-starport@0.4.0(typescript@5.3.3):
-    resolution: {integrity: sha512-02odSlCxGyUaDam1VzNP/d/lj2p/SO3ji5pvuajXrC1Ol7iqSqIt+n/x4xoBugUIctyGyCQoJbMuoyaiyGy9ag==}
-    dependencies:
-      '@vueuse/core': 10.7.2(vue@3.4.15)
-      vue: 3.4.15(typescript@5.3.3)
-    transitivePeerDependencies:
-      - '@vue/composition-api'
-      - typescript
     dev: false
 
   /vue-template-compiler@2.7.15:


### PR DESCRIPTION
This PR removes the built-in [vue-starport](https://github.com/antfu/vue-starport) support, as the [View Transitions API](https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API) should cover it in a much better way.