### PR TITLE
feat: add "cards" option to 'Tweet' component

### DIFF
--- a/packages/client/builtin/Tweet.vue
+++ b/packages/client/builtin/Tweet.vue
@@ -15,6 +15,7 @@ const props = defineProps<{
   id: string | number
   scale?: string | number
   conversation?: string
+  cards?: 'hidden' | 'visible'
 }>()
 
 const tweet = ref<HTMLElement | null>()
@@ -31,6 +32,7 @@ async function create() {
     {
       theme: isDark.value ? 'dark' : 'light',
       conversation: props.conversation || 'none',
+      cards: props.cards,
     },
   )
   loaded.value = true


### PR DESCRIPTION
This PR:
- adds a `cards` prop to the `<Tweet />` component which corresponds to the [`cards` parameter of the 'Embedded Tweet' API](https://developer.twitter.com/en/docs/twitter-for-websites/embedded-tweets/guides/embedded-tweet-parameter-reference)

Setting `cards` to `"hidden"` makes it so link previews do not appear, which is pretty useful in presentations considering they add a ton of vertical space to the 'embed'

---

*I can make a pr updating the docs site as well if this goes through*