### PR TITLE
feat: add `scale` arg for image export (#1263)

### DIFF
--- a/packages/slidev/node/cli.ts
+++ b/packages/slidev/node/cli.ts
@@ -534,6 +534,10 @@ function exportOptions<T>(args: Argv<T>) {
       type: 'boolean',
       describe: 'slide slides slide by slide. Works better with global components, but will break cross slide links and TOC in PDF',
     })
+    .option('scale', {
+      type: 'number',
+      describe: 'scale factor for image export',
+    })
 }
 
 function printInfo(

--- a/packages/slidev/node/export.ts
+++ b/packages/slidev/node/export.ts
@@ -33,6 +33,7 @@ export interface ExportOptions {
    * @default false
    */
   perSlide?: boolean
+  scale?: number
 }
 
 function addToTree(tree: TocItem[], info: SlideInfo, slideIndexes: Record<number, number>, level = 1) {
@@ -161,6 +162,7 @@ export async function exportSlides({
   executablePath = undefined,
   withToc = false,
   perSlide = false,
+  scale = 1,
 }: ExportOptions) {
   const pages: number[] = parseRangeString(total, range)
 
@@ -174,7 +176,7 @@ export async function exportSlides({
       // Calculate height for every slides to be in the viewport to trigger the rendering of iframes (twitter, youtube...)
       height: perSlide ? height : height * pages.length,
     },
-    deviceScaleFactor: 1,
+    deviceScaleFactor: scale,
   })
   const page = await context.newPage()
   const progress = createSlidevProgress(!perSlide)
@@ -449,6 +451,7 @@ export function getExportOptions(args: ExportArgs, options: ResolvedSlidevOption
     executablePath,
     withToc,
     perSlide,
+    scale,
   } = config
   outFilename = output || options.data.config.exportFilename || outFilename || `${path.basename(entry, '.md')}-export`
   if (outDir)
@@ -468,6 +471,7 @@ export function getExportOptions(args: ExportArgs, options: ResolvedSlidevOption
     executablePath,
     withToc: withToc || false,
     perSlide: perSlide || false,
+    scale: scale || 1,
   }
 }
 

--- a/packages/types/src/cli.ts
+++ b/packages/types/src/cli.ts
@@ -13,6 +13,7 @@ export interface ExportArgs extends CommonArgs {
   'executable-path'?: string
   'with-toc'?: boolean
   'per-slide'?: boolean
+  scale?: number
 }
 
 export interface BuildArgs extends ExportArgs {


### PR DESCRIPTION
This PR adds a new command line argument `--scale`:

```sh
slidev export --format png --scale 100
slidev export --format png --scale 0.1 --per-slide
slidev export --format md --scale 100
```

The internal of this feature is:

```ts
const context = await browser.newContext({
  // ...
  deviceScaleFactor: scale,
})
```

This can be a way to control the quality of the png export. (#1263)

### Result

| 0.1x | ![0.1x](https://github.com/slidevjs/slidev/assets/63178754/d2683fb6-8b74-4d6c-906b-d95c328012c6) |
| --- | --- |
| 2x | ![2x](https://github.com/slidevjs/slidev/assets/63178754/748dfb11-40bc-4d42-a4f8-8c634e4c7c1c) |