### PR TITLE
fix: `codemirror` import error (#1281)

### DIFF
--- a/packages/client/setup/codemirror.ts
+++ b/packages/client/setup/codemirror.ts
@@ -1,6 +1,6 @@
 import type { Ref, WritableComputedRef } from 'vue'
 import { watch } from 'vue'
-import * as CodeMirror from 'codemirror'
+import CodeMirror from 'codemirror'
 import 'codemirror/mode/javascript/javascript'
 import 'codemirror/mode/css/css'
 import 'codemirror/mode/markdown/markdown'

--- a/packages/client/setup/codemirror.ts
+++ b/packages/client/setup/codemirror.ts
@@ -1,6 +1,6 @@
 import type { Ref, WritableComputedRef } from 'vue'
 import { watch } from 'vue'
-import CodeMirror from 'codemirror'
+import * as _CodeMirror from 'codemirror'
 import 'codemirror/mode/javascript/javascript'
 import 'codemirror/mode/css/css'
 import 'codemirror/mode/markdown/markdown'
@@ -8,6 +8,10 @@ import 'codemirror/mode/xml/xml'
 import 'codemirror/mode/htmlmixed/htmlmixed'
 import 'codemirror/addon/display/placeholder'
 import 'codemirror/lib/codemirror.css'
+
+// eslint-disable-next-line ts/ban-ts-comment
+// @ts-expect-error
+const CodeMirror: typeof _CodeMirror = _CodeMirror.fromTextArea ? _CodeMirror : globalThis.CodeMirror
 
 export async function useCodeMirror(
   textarea: Ref<HTMLTextAreaElement | null | undefined>,

--- a/packages/slidev/node/plugins/extendConfig.ts
+++ b/packages/slidev/node/plugins/extendConfig.ts
@@ -8,16 +8,6 @@ import type { ResolvedSlidevOptions } from '../options'
 import { resolveGlobalImportPath, resolveImportPath, toAtFS } from '../utils'
 import { searchForWorkspaceRoot } from '../vite/searchRoot'
 
-const INCLUDE = [
-  'codemirror',
-  'codemirror/mode/javascript/javascript',
-  'codemirror/mode/css/css',
-  'codemirror/mode/markdown/markdown',
-  'codemirror/mode/xml/xml',
-  'codemirror/mode/htmlmixed/htmlmixed',
-  'codemirror/addon/display/placeholder',
-]
-
 const EXCLUDE = [
   '@slidev/shared',
   '@slidev/types',
@@ -46,7 +36,6 @@ export function createConfigPlugin(options: ResolvedSlidevOptions): Plugin {
           dedupe: ['vue'],
         },
         optimizeDeps: {
-          include: INCLUDE,
           exclude: EXCLUDE,
         },
         css: options.data.config.css === 'unocss'

--- a/packages/slidev/node/plugins/extendConfig.ts
+++ b/packages/slidev/node/plugins/extendConfig.ts
@@ -8,6 +8,16 @@ import type { ResolvedSlidevOptions } from '../options'
 import { resolveGlobalImportPath, resolveImportPath, toAtFS } from '../utils'
 import { searchForWorkspaceRoot } from '../vite/searchRoot'
 
+const INCLUDE = [
+  'codemirror',
+  'codemirror/mode/javascript/javascript',
+  'codemirror/mode/css/css',
+  'codemirror/mode/markdown/markdown',
+  'codemirror/mode/xml/xml',
+  'codemirror/mode/htmlmixed/htmlmixed',
+  'codemirror/addon/display/placeholder',
+]
+
 const EXCLUDE = [
   '@slidev/shared',
   '@slidev/types',
@@ -36,6 +46,7 @@ export function createConfigPlugin(options: ResolvedSlidevOptions): Plugin {
           dedupe: ['vue'],
         },
         optimizeDeps: {
+          include: INCLUDE,
           exclude: EXCLUDE,
         },
         css: options.data.config.css === 'unocss'


### PR DESCRIPTION
fix #1281

This PR fixes #1281 by partly reverts 4ef7fc934586758d2c8bdaa8bb0afa6e4605fad2.

It is confusing that the `codemirror` package isn't explicitly excluded from `optimizeDeps`, but it is in fact not optimized (**only when `@slidev/cli` and `@slidev/client` are installed from npm registry. In this monorepo, it is OK**). And `codemirror@5` is a UMD package, but it is then wrongly imported as an ESM package, which causes the issue. This PR re-adds `codemirror` related packages to `optimizeDeps.include` array, and import `CodeMirror` as default import.

I am not sure whether other packages removed from the `include` list by 4ef7fc934586758d2c8bdaa8bb0afa6e4605fad2 (listed below) should be added again or not.


**Lines removed in 4ef7fc934586758d2c8bdaa8bb0afa6e4605fad2**:
```ts
import { dependencies } from '../../../client/package.json'
//      optimizeDeps: {
          include: [
            ...Object.keys(dependencies).filter(i => !EXCLUDE.includes(i)),
            'codemirror/mode/javascript/javascript',
            'codemirror/mode/css/css',
            'codemirror/mode/markdown/markdown',
            'codemirror/mode/xml/xml',
            'codemirror/mode/htmlmixed/htmlmixed',
            'codemirror/addon/display/placeholder',
            'prettier/plugins/babel',
            'prettier/plugins/html',
            'prettier/plugins/typescript',
            'mermaid/dist/mermaid.esm.min.mjs',
            'mermaid/dist/mermaid.esm.mjs',
            'vite-plugin-vue-server-ref/client',
          ],
```

**This PR re-adds these**:
```ts
const INCLUDE = [
  'codemirror',
  'codemirror/mode/javascript/javascript',
  'codemirror/mode/css/css',
  'codemirror/mode/markdown/markdown',
  'codemirror/mode/xml/xml',
  'codemirror/mode/htmlmixed/htmlmixed',
  'codemirror/addon/display/placeholder',
]
```