### PR TITLE
feat: allow `Text` as `VClick`'s top-level child (#1214)

### DIFF
--- a/packages/client/builtin/VClick.ts
+++ b/packages/client/builtin/VClick.ts
@@ -4,14 +4,14 @@
  * Learn more: https://sli.dev/guide/animations.html#click-animations
  */
 
-import { createVNode, defineComponent } from 'vue'
+import { Text, defineComponent, h } from 'vue'
 import VClicks from './VClicks'
 
 export default defineComponent({
   props: {
     at: {
       type: [Number, String],
-      default: null,
+      default: null, // should be 'flow' after #1279 is merged
     },
     hide: {
       type: Boolean,
@@ -23,7 +23,7 @@ export default defineComponent({
     },
   },
   render() {
-    return createVNode(
+    return h(
       VClicks,
       {
         every: 99999,
@@ -31,7 +31,14 @@ export default defineComponent({
         hide: this.hide,
         fade: this.fade,
       },
-      { default: this.$slots.default },
+      {
+        default: () =>
+          this.$slots.default?.().map(v =>
+            v.type === Text
+              ? h('span', v)
+              : v,
+          ),
+      },
     )
   },
 })

--- a/packages/client/builtin/VClick.ts
+++ b/packages/client/builtin/VClick.ts
@@ -22,7 +22,7 @@ export default defineComponent({
       type: Boolean,
       default: false,
     },
-    wrapTextAs: {
+    wrapText: {
       type: Function as PropType<(text: VNode) => VNode>,
       default: (text: VNode) => h('span', text),
     },
@@ -40,7 +40,7 @@ export default defineComponent({
         default: () =>
           this.$slots.default?.().map(v =>
             v.type === Text
-              ? this.wrapTextAs(v)
+              ? this.wrapText(v)
               : v,
           ),
       },

--- a/packages/client/builtin/VClick.ts
+++ b/packages/client/builtin/VClick.ts
@@ -4,6 +4,7 @@
  * Learn more: https://sli.dev/guide/animations.html#click-animations
  */
 
+import type { PropType, VNode } from 'vue'
 import { Text, defineComponent, h } from 'vue'
 import VClicks from './VClicks'
 
@@ -21,6 +22,10 @@ export default defineComponent({
       type: Boolean,
       default: false,
     },
+    wrapTextAs: {
+      type: Function as PropType<(text: VNode) => VNode>,
+      default: (text: VNode) => h('span', text),
+    },
   },
   render() {
     return h(
@@ -35,7 +40,7 @@ export default defineComponent({
         default: () =>
           this.$slots.default?.().map(v =>
             v.type === Text
-              ? h('span', v)
+              ? this.wrapTextAs(v)
               : v,
           ),
       },

--- a/packages/client/builtin/VClick.ts
+++ b/packages/client/builtin/VClick.ts
@@ -12,7 +12,7 @@ export default defineComponent({
   props: {
     at: {
       type: [Number, String],
-      default: null, // should be 'flow' after #1279 is merged
+      default: null,
     },
     hide: {
       type: Boolean,


### PR DESCRIPTION
fix #1214

This PR wraps `VClick`'s **top-level** text node child into a `span`, or other element specified by the `wrapText` prop.

Now, the following click animations work properly.

```markdown
<v-click> 123 </v-click>

<v-click :wrap-text="v=>h('div', v)">
0 <del>2</del>
</v-click>

abcd <v-click>_d_ ef</v-click> ghi <v-click>j**kl**</v-click>
```