### PR TITLE
fix: slide note sync (#1157)

### DIFF
--- a/packages/client/logic/note.ts
+++ b/packages/client/logic/note.ts
@@ -40,6 +40,10 @@ export function useSlideInfo(id: number | undefined): UseSlideInfo {
       if (payload.id === id)
         info.value = payload.data
     })
+    import.meta.hot?.on('slidev-update-note', (payload) => {
+      if (payload.id === id && info.value.note.trim() !== payload.note.trim())
+        info.value = { ...info.value, ...payload }
+    })
   }
 
   return {

--- a/packages/slidev/node/plugins/loaders.ts
+++ b/packages/slidev/node/plugins/loaders.ts
@@ -115,7 +115,11 @@ export function createSlidesLoader(
           if (type === 'json' && req.method === 'POST') {
             const body = await getBodyJson(req)
             const slide = data.slides[idx]
-            hmrPages.add(idx)
+
+            const onlyNoteChanged = Object.keys(body).length === 2
+              && 'note' in body && body.raw === null
+            if (!onlyNoteChanged)
+              hmrPages.add(idx)
 
             if (slide.source) {
               Object.assign(slide.source, body)
@@ -173,7 +177,6 @@ export function createSlidesLoader(
           if (
             a?.content.trim() === b?.content.trim()
             && a?.title?.trim() === b?.title?.trim()
-            && a?.note === b?.note
             && equal(a.frontmatter, b.frontmatter)
             && Object.entries(a.snippetsUsed ?? {}).every(([file, oldContent]) => {
               try {
@@ -184,8 +187,20 @@ export function createSlidesLoader(
                 return false
               }
             })
-          )
+          ) {
+            if (a?.note !== b?.note) {
+              ctx.server.ws.send({
+                type: 'custom',
+                event: 'slidev-update-note',
+                data: {
+                  id: i,
+                  note: b!.note || '',
+                  noteHTML: md.render(b!.note || ''),
+                },
+              })
+            }
             continue
+          }
 
           ctx.server.ws.send({
             type: 'custom',


### PR DESCRIPTION
In this PR, slide note editing is handled separately.

- When appending or prepending newlines and whitespaces in the note editor in Presenter mode, the note written to the disk is trimmed, but in the editor the whitespaces are reserved.
- Avoid unnecessary HMRs.
- fix #1157