### PR TITLE
fix: double scroll bars in CodeMirror editor

### DIFF
--- a/packages/client/internals/Editor.vue
+++ b/packages/client/internals/Editor.vue
@@ -182,6 +182,6 @@ throttledWatch(
 
 <style lang="postcss">
 .CodeMirror {
-  @apply px-3 py-2 h-full overflow-auto bg-transparent font-mono text-sm z-0;
+  @apply px-3 py-2 h-full overflow-hidden bg-transparent font-mono text-sm z-0;
 }
 </style>


### PR DESCRIPTION
This PR fixes the double vertical scroll bars in the CodeMirror editor.

| **Before** | **After** |
| - | - |
| ![image](https://github.com/slidevjs/slidev/assets/63178754/a72b6669-0726-4562-b184-aca1430e8a9c) | ![image](https://github.com/slidevjs/slidev/assets/63178754/31392b4c-b5a3-4358-ae2a-61c9368937ad) |

Tested in normal mode and presenter mode.