### PR TITLE
fix: next operation (#1251)

### DIFF
--- a/packages/client/logic/nav.ts
+++ b/packages/client/logic/nav.ts
@@ -83,9 +83,9 @@ watch(currentRoute, (next, prev) => {
   navDirection.value = Number(next?.path) - Number(prev?.path)
 })
 
-export function next() {
+export async function next() {
   if (clicksTotal.value <= queryClicks.value)
-    nextSlide()
+    await nextSlide()
   else
     queryClicks.value += 1
 }
@@ -101,9 +101,9 @@ export function getPath(no: number | string) {
   return isPresenter.value ? `/presenter/${no}` : `/${no}`
 }
 
-export function nextSlide() {
-  const next = Math.min(rawRoutes.length, currentPage.value + 1)
-  return go(next)
+export async function nextSlide() {
+  if (currentPage.value < rawRoutes.length)
+    await go(currentPage.value + 1)
 }
 
 export async function prevSlide(lastClicks = true) {


### PR DESCRIPTION
fix #1251

Previously, the `next()` will set clicks to `0` when it is the last click of the last slide.

This PR makes `next()` a no-op in that situation.