### PR TITLE
fix: nested multiple-entry slides

### DIFF
--- a/packages/client/internals/Editor.vue
+++ b/packages/client/internals/Editor.vue
@@ -38,7 +38,6 @@ watch(
 async function save() {
   dirty.value = false
   await update({
-    raw: null!,
     note: note.value || undefined,
     content: content.value,
     // frontmatter: frontmatter.value,

--- a/packages/client/internals/NoteEditor.vue
+++ b/packages/client/internals/NoteEditor.vue
@@ -36,7 +36,7 @@ const { ignoreUpdates } = ignorableWatch(
     const id = currentSlideId.value
     clearTimeout(timer)
     timer = setTimeout(() => {
-      update({ raw: null!, note: v }, id)
+      update({ note: v }, id)
     }, 500)
   },
 )

--- a/packages/client/logic/note.ts
+++ b/packages/client/logic/note.ts
@@ -2,17 +2,17 @@ import type { MaybeRef } from '@vueuse/core'
 import { useFetch } from '@vueuse/core'
 import type { Ref } from 'vue'
 import { computed, ref, unref } from 'vue'
-import type { SlideInfo, SlideInfoExtended } from '@slidev/types'
+import type { SlideInfo } from '@slidev/types'
 
 export interface UseSlideInfo {
-  info: Ref<SlideInfoExtended | undefined>
-  update: (data: Partial<SlideInfo>) => Promise<SlideInfoExtended | void>
+  info: Ref<SlideInfo | undefined>
+  update: (data: Partial<SlideInfo>) => Promise<SlideInfo | void>
 }
 
 export function useSlideInfo(id: number | undefined): UseSlideInfo {
   if (id == null) {
     return {
-      info: ref() as Ref<SlideInfoExtended | undefined>,
+      info: ref() as Ref<SlideInfo | undefined>,
       update: async () => {},
     }
   }

--- a/packages/client/logic/note.ts
+++ b/packages/client/logic/note.ts
@@ -41,7 +41,7 @@ export function useSlideInfo(id: number | undefined): UseSlideInfo {
         info.value = payload.data
     })
     import.meta.hot?.on('slidev-update-note', (payload) => {
-      if (payload.id === id && info.value.note.trim() !== payload.note.trim())
+      if (payload.id === id && info.value.note?.trim() !== payload.note?.trim())
         info.value = { ...info.value, ...payload }
     })
   }

--- a/packages/parser/src/core.ts
+++ b/packages/parser/src/core.ts
@@ -216,7 +216,7 @@ export async function parse(
   if (start <= lines.length - 1)
     await slice(lines.length)
 
-  const headmatter = slides[0]?.frontmatter || {}
+  const headmatter = { ...slides[0]?.frontmatter } || {}
   headmatter.title = headmatter.title || slides[0]?.title
   const config = resolveConfig(headmatter, themeMeta, filepath)
   const features = detectFeatures(markdown)

--- a/packages/parser/src/fs.ts
+++ b/packages/parser/src/fs.ts
@@ -1,7 +1,9 @@
 import { promises as fs } from 'node:fs'
 import { dirname, resolve } from 'node:path'
-import type { PreparserExtensionLoader, SlideInfo, SlidevMarkdown, SlidevMarkdownWithPath, SlidevPreparserExtension, SlidevThemeMeta } from '@slidev/types'
-import { detectFeatures, mergeFeatureFlags, parse, parseRangeString, stringify } from './core'
+import YAML from 'js-yaml'
+import { slash } from '@antfu/utils'
+import type { PreparserExtensionLoader, SlideInfo, SlidevData, SlidevMarkdown, SlidevPreparserExtension, SlidevThemeMeta, SourceSlideInfo } from '@slidev/types'
+import { detectFeatures, parse, parseRangeString, resolveConfig, stringify } from './core'
 
 export * from './core'
 
@@ -11,108 +13,90 @@ export function injectPreparserExtensionLoader(fn: PreparserExtensionLoader) {
   preparserExtensionLoader = fn
 }
 
-export async function load(filepath: string, themeMeta?: SlidevThemeMeta, content?: string) {
-  const dir = dirname(filepath)
+export async function load(userRoot: string, filepath: string, themeMeta?: SlidevThemeMeta, content?: string): Promise<SlidevData> {
   const markdown = content ?? await fs.readFile(filepath, 'utf-8')
 
-  const preparserExtensions: SlidevPreparserExtension[] = []
-  const data = await parse(markdown, filepath, themeMeta, [], async (headmatter, exts: SlidevPreparserExtension[], filepath: string | undefined) => {
-    preparserExtensions.splice(
-      0,
-      preparserExtensions.length,
-      ...exts,
-      ...preparserExtensionLoader ? await preparserExtensionLoader(headmatter, filepath) : [],
-    )
-    return preparserExtensions
-  })
-
-  const entries = new Set([
-    filepath,
-  ])
-
-  for (let iSlide = 0; iSlide < data.slides.length;) {
-    const baseSlide = data.slides[iSlide]
-    if (!baseSlide.frontmatter.src) {
-      iSlide++
-      continue
+  let extensions: SlidevPreparserExtension[] | undefined
+  if (preparserExtensionLoader) {
+    // #703
+    // identify the headmatter, to be able to load preparser extensions
+    // (strict parsing based on the parsing code)
+    const lines = markdown.split(/\r?\n/g)
+    let hm = ''
+    if (lines[0].match(/^---([^-].*)?$/) && !lines[1]?.match(/^\s*$/)) {
+      let hEnd = 1
+      while (hEnd < lines.length && !lines[hEnd].trimEnd().match(/^---$/))
+        hEnd++
+      hm = lines.slice(1, hEnd).join('\n')
     }
-
-    if (baseSlide.frontmatter.hide)
-      continue
-
-    const [pathRaw, rangeRaw] = baseSlide.frontmatter.src.split('#')
-    let path: string
-    if (pathRaw.startsWith('/'))
-      path = resolve(dir, pathRaw.substring(1))
-    else if (baseSlide.source?.filepath)
-      path = resolve(dirname(baseSlide.source.filepath), pathRaw)
-    else
-      path = resolve(dir, pathRaw)
-
-    let subSlidesData = data.subSlides?.[path]
-    if (!subSlidesData) {
-      entries.add(path)
-      const raw = await fs.readFile(path, 'utf-8')
-      subSlidesData = await parse(raw, path, themeMeta, preparserExtensions) as SlidevMarkdownWithPath
-      subSlidesData.slides.forEach(s => s.filepath = path)
-      data.subSlides ??= {}
-      data.subSlides[path] = subSlidesData
-    }
-
-    let subSlides = subSlidesData.slides
-    let features = subSlidesData.features
-    if (rangeRaw) {
-      const range = parseRangeString(subSlides.length, rangeRaw)
-      subSlides = range.map(i => subSlides[i - 1])
-      const rawInRange = subSlides.map(s => s.raw).join('')
-      features = detectFeatures(rawInRange)
-    }
-
-    data.features = mergeFeatureFlags(data.features, features)
-
-    data.slides.splice(iSlide, 1, ...subSlides.map((subSlide, offset) => {
-      const slide: SlideInfo = {
-        ...baseSlide,
-        source: subSlide,
-      }
-
-      if (offset === 0 && !baseSlide.frontmatter.srcSequence) {
-        slide.inline = { ...baseSlide }
-        delete slide.inline.frontmatter.src
-        Object.assign(slide, slide.source, { raw: null })
-      }
-      else {
-        Object.assign(slide, slide.source)
-      }
-
-      const baseSlideFrontMatterWithoutSrc = { ...baseSlide.frontmatter }
-      delete baseSlideFrontMatterWithoutSrc.src
-
-      slide.frontmatter = {
-        ...subSlide.frontmatter,
-        ...baseSlideFrontMatterWithoutSrc,
-        srcSequence: `${baseSlide.frontmatter.srcSequence ? `${baseSlide.frontmatter.srcSequence},` : ''}${pathRaw}`,
-      }
-
-      return slide
-    }))
+    const o = YAML.load(hm) as Record<string, unknown> ?? {}
+    extensions = await preparserExtensionLoader(o, filepath)
   }
 
-  // re-index slides
-  for (let iSlide = 0; iSlide < data.slides.length; iSlide++)
-    data.slides[iSlide].index = iSlide === 0 ? 0 : 1 + data.slides[iSlide - 1].index
+  const markdownFiles: Record<string, SlidevMarkdown> = {}
+  const slides: SlideInfo[] = []
 
-  data.entries = Array.from(entries)
+  async function loadMarkdown(path: string, range?: string, frontmatterOverride?: Record<string, unknown>) {
+    let md = markdownFiles[path]
+    if (!md) {
+      const raw = await fs.readFile(path, 'utf-8')
+      md = await parse(raw, path, extensions)
+      markdownFiles[path] = md
+    }
 
-  return data
+    for (const index of parseRangeString(md.slides.length, range))
+      await loadSlide(md.slides[index - 1], frontmatterOverride)
+
+    return md
+  }
+
+  async function loadSlide(slide: SourceSlideInfo, frontmatterOverride?: Record<string, unknown>) {
+    if (slide.frontmatter.src) {
+      const [rawPath, rangeRaw] = slide.frontmatter.src.split('#')
+      const path = rawPath.startsWith('/')
+        ? resolve(userRoot, rawPath.substring(1))
+        : resolve(dirname(slide.filepath), rawPath)
+
+      frontmatterOverride = {
+        ...slide.frontmatter,
+        ...frontmatterOverride,
+      }
+      delete frontmatterOverride.src
+
+      await loadMarkdown(path, rangeRaw, frontmatterOverride)
+    }
+    else {
+      slides.push({
+        index: slides.length,
+        source: slide,
+        frontmatter: { ...slide.frontmatter, ...frontmatterOverride },
+        content: slide.content,
+        note: slide.note,
+        title: slide.title,
+        level: slide.level,
+      })
+    }
+  }
+
+  const entry = await loadMarkdown(filepath)
+
+  const headmatter = {
+    title: slides[0]?.title,
+    ...entry.slides[0]?.frontmatter,
+  }
+
+  return {
+    slides,
+    entry,
+    config: resolveConfig(headmatter, themeMeta, filepath),
+    headmatter,
+    features: detectFeatures(slides.map(s => s.source.raw).join('')),
+    themeMeta,
+    markdownFiles,
+    watchFiles: Object.keys(markdownFiles).map(slash),
+  }
 }
 
-export async function save(data: SlidevMarkdown, filepath?: string) {
-  filepath = filepath || data.filepath!
-
-  await fs.writeFile(filepath, stringify(data), 'utf-8')
-}
-
-export async function saveExternalSlide(data: SlidevMarkdown, filepath: string) {
-  await fs.writeFile(filepath, stringify(data.subSlides![filepath]), 'utf-8')
+export async function save(markdown: SlidevMarkdown) {
+  await fs.writeFile(markdown.filepath, stringify(markdown), 'utf-8')
 }

--- a/packages/parser/src/fs.ts
+++ b/packages/parser/src/fs.ts
@@ -51,6 +51,8 @@ export async function load(userRoot: string, filepath: string, themeMeta?: Slide
   }
 
   async function loadSlide(slide: SourceSlideInfo, frontmatterOverride?: Record<string, unknown>) {
+    if (slide.frontmatter.disabled)
+      return
     if (slide.frontmatter.src) {
       const [rawPath, rangeRaw] = slide.frontmatter.src.split('#')
       const path = rawPath.startsWith('/')

--- a/packages/slidev/node/cli.ts
+++ b/packages/slidev/node/cli.ts
@@ -369,9 +369,9 @@ cli.command(
           })
 
           const dirPath = `./${dir}`
-          data.slides[0].frontmatter.theme = dirPath
-          // @ts-expect-error remove the value
-          data.slides[0].raw = null
+          const firstSlide = data.entry.slides[0]
+          firstSlide.frontmatter.theme = dirPath
+          parser.prettifySlide(firstSlide)
           await parser.save(data.entry)
 
           console.log(`Theme "${theme}" ejected successfully to "${dirPath}"`)

--- a/packages/slidev/node/cli.ts
+++ b/packages/slidev/node/cli.ts
@@ -325,9 +325,9 @@ cli.command(
     .help(),
   async ({ entry }) => {
     for (const entryFile of entry as unknown as string[]) {
-      const data = await parser.load(entryFile)
-      parser.prettify(data)
-      await parser.save(data)
+      const md = await parser.parse(await fs.readFile(entryFile, 'utf-8'), entryFile)
+      parser.prettify(md)
+      await parser.save(md)
     }
   },
 )
@@ -346,7 +346,8 @@ cli.command(
             default: 'theme',
           }),
         async ({ entry, dir, theme: themeInput }) => {
-          const data = await parser.load(entry)
+          const { userRoot } = getUserRoot({ entry })
+          const data = await parser.load(userRoot, entry)
           const theme = await resolveThemeName(themeInput || data.config.theme)
           if (theme === 'none') {
             console.error('Cannot eject theme "none"')
@@ -371,7 +372,7 @@ cli.command(
           data.slides[0].frontmatter.theme = dirPath
           // @ts-expect-error remove the value
           data.slides[0].raw = null
-          await parser.save(data)
+          await parser.save(data.entry)
 
           console.log(`Theme "${theme}" ejected successfully to "${dirPath}"`)
         },
@@ -405,7 +406,6 @@ cli.command(
       )
       await server.listen(port)
       printInfo(options)
-      parser.filterDisabled(options.data)
       const result = await exportSlides({
         port,
         ...getExportOptions({ ...args, entry: entryFile }, options),
@@ -458,7 +458,6 @@ cli.command(
       await server.listen(port)
 
       printInfo(options)
-      parser.filterDisabled(options.data)
 
       const result = await exportNotes({
         port,

--- a/packages/slidev/node/options.ts
+++ b/packages/slidev/node/options.ts
@@ -11,7 +11,7 @@ import type RemoteAssets from 'vite-plugin-remote-assets'
 import type ServerRef from 'vite-plugin-vue-server-ref'
 import type { ArgumentsType } from '@antfu/utils'
 import { uniq } from '@antfu/utils'
-import type { SlidevMarkdown } from '@slidev/types'
+import type { SlidevData } from '@slidev/types'
 import _debug from 'debug'
 import { parser } from './parser'
 import { packageExists, resolveImportPath } from './utils'
@@ -52,7 +52,7 @@ export interface SlidevEntryOptions {
 }
 
 export interface ResolvedSlidevOptions {
-  data: SlidevMarkdown
+  data: SlidevData
   entry: string
   userRoot: string
   cliRoot: string
@@ -78,7 +78,7 @@ export interface SlidevPluginOptions extends SlidevEntryOptions {
 }
 
 export interface SlidevServerOptions {
-  onDataReload?: (newData: SlidevMarkdown, data: SlidevMarkdown) => void
+  onDataReload?: (newData: SlidevData, data: SlidevData) => void
 }
 
 export async function getClientRoot() {
@@ -136,7 +136,7 @@ export async function resolveOptions(
     entry,
     userRoot,
   } = getUserRoot(options)
-  const data = await parser.load(entry)
+  const data = await parser.load(userRoot, entry)
   const theme = await resolveThemeName(options.theme || data.config.theme)
 
   if (promptForInstallation) {

--- a/packages/slidev/node/plugins/loaders.ts
+++ b/packages/slidev/node/plugins/loaders.ts
@@ -1,6 +1,6 @@
 import { basename, join } from 'node:path'
 import type { Connect, HtmlTagDescriptor, ModuleNode, Plugin, Update, ViteDevServer } from 'vite'
-import { isString, isTruthy, notNullish, objectMap, range, slash, uniq } from '@antfu/utils'
+import { isString, isTruthy, notNullish, objectMap, range, uniq } from '@antfu/utils'
 import fg from 'fast-glob'
 import fs from 'fs-extra'
 import Markdown from 'markdown-it'
@@ -8,7 +8,7 @@ import { bold, gray, red, yellow } from 'kolorist'
 
 // @ts-expect-error missing types
 import mila from 'markdown-it-link-attributes'
-import type { SlideInfo, SlideInfoExtended } from '@slidev/types'
+import type { SlideInfo } from '@slidev/types'
 import * as parser from '@slidev/parser/fs'
 import equal from 'fast-deep-equal'
 
@@ -76,7 +76,7 @@ md.use(mila, {
   },
 })
 
-function prepareSlideInfo(data: SlideInfo): SlideInfoExtended {
+function renderNoteHTML(data: SlideInfo): SlideInfo {
   return {
     ...data,
     noteHTML: md.render(data?.note || ''),
@@ -110,7 +110,7 @@ export function createSlidesLoader(
           const [, no, type] = match
           const idx = Number.parseInt(no)
           if (type === 'json' && req.method === 'GET') {
-            res.write(JSON.stringify(prepareSlideInfo(data.slides[idx])))
+            res.write(JSON.stringify(renderNoteHTML(data.slides[idx])))
             return res.end()
           }
           if (type === 'json' && req.method === 'POST') {
@@ -122,17 +122,12 @@ export function createSlidesLoader(
             if (!onlyNoteChanged)
               hmrPages.add(idx)
 
-            if (slide.source) {
-              Object.assign(slide.source, body)
-              await parser.saveExternalSlide(data, slide.source.filepath)
-            }
-            else {
-              Object.assign(slide, body)
-              await parser.save(data, entry)
-            }
+            Object.assign(slide.source, body)
+            parser.prettifySlide(slide.source)
+            await parser.save(data.markdownFiles[slide.source.filepath])
 
             res.statusCode = 200
-            res.write(JSON.stringify(prepareSlideInfo(slide)))
+            res.write(JSON.stringify(renderNoteHTML(slide)))
             return res.end()
           }
 
@@ -141,12 +136,12 @@ export function createSlidesLoader(
       },
 
       async handleHotUpdate(ctx) {
-        if (!data.entries!.some(i => slash(i) === ctx.file))
+        if (!data.watchFiles.includes(ctx.file))
           return
 
         await ctx.read()
 
-        const newData = await parser.load(entry, data.themeMeta)
+        const newData = await parser.load(userRoot, entry, data.themeMeta)
 
         const moduleIds = new Set<string>()
 
@@ -208,7 +203,7 @@ export function createSlidesLoader(
             event: 'slidev-update',
             data: {
               id: i,
-              data: prepareSlideInfo(newData.slides[i]),
+              data: renderNoteHTML(newData.slides[i]),
             },
           })
           hmrPages.add(i)
@@ -309,7 +304,7 @@ export function createSlidesLoader(
             }
             else if (type === 'frontmatter') {
               const slideBase = {
-                ...prepareSlideInfo(slide),
+                ...renderNoteHTML(slide),
                 frontmatter: undefined,
                 // remove raw content in build, optimize the bundle size
                 ...(mode === 'build' ? { raw: '', content: '', note: '' } : {}),
@@ -447,7 +442,7 @@ export function createSlidesLoader(
   function updateServerWatcher() {
     if (!server)
       return
-    server.watcher.add(data.entries?.map(slash) || [])
+    server.watcher.add(data.watchFiles)
   }
 
   function getFrontmatter(pageNo: number) {
@@ -656,7 +651,7 @@ defineProps<{ no: number | string }>()`)
   }
 
   async function generateMonacoTypes() {
-    return `void 0; ${parser.scanMonacoModules(data.raw).map(i => `import('/@slidev-monaco-types/${i}')`).join('\n')}`
+    return `void 0; ${parser.scanMonacoModules(data.slides.map(s => s.source.raw).join()).map(i => `import('/@slidev-monaco-types/${i}')`).join('\n')}`
   }
 
   async function generateLayouts() {

--- a/packages/slidev/node/plugins/loaders.ts
+++ b/packages/slidev/node/plugins/loaders.ts
@@ -278,7 +278,6 @@ export function createSlidesLoader(
         if (id === '/@slidev/titles.md') {
           return {
             code: data.slides
-              .filter(({ frontmatter }) => !frontmatter?.disabled)
               .map(({ title }, i) => `<template ${i === 0 ? 'v-if' : 'v-else-if'}="+no === ${i + 1}">\n\n${title}\n\n</template>`)
               .join(''),
             map: { mappings: '' },
@@ -679,7 +678,6 @@ defineProps<{ no: number | string }>()`)
 
     let no = 1
     const routes = data.slides
-      .filter(({ frontmatter }) => !frontmatter?.disabled)
       .map((i, idx) => {
         imports.push(`import n${no} from '${slidePrefix}${idx + 1}.md'`)
         imports.push(`import { meta as f${no} } from '${slidePrefix}${idx + 1}.frontmatter'`)

--- a/packages/slidev/node/plugins/transformSnippet.ts
+++ b/packages/slidev/node/plugins/transformSnippet.ts
@@ -96,7 +96,7 @@ export function transformSnippet(md: string, options: ResolvedSlidevOptions, id:
         ? path.resolve(options!.userRoot, filepath.slice(2))
         : path.resolve(dir, filepath)
 
-      data.entries!.push(src)
+      data.watchFiles.push(src)
 
       const isAFile = fs.statSync(src).isFile()
       if (!fs.existsSync(src) || !isAFile) {

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -61,10 +61,16 @@ export interface SlidevFeatureFlags {
 export interface SlidevMarkdown {
   filepath: string
   raw: string
+  /**
+   * All slides in this markdown file
+   */
   slides: SourceSlideInfo[]
 }
 
 export interface SlidevData {
+  /**
+   * Slides that should be rendered
+   */
   slides: SlideInfo[]
   entry: SlidevMarkdown
   config: SlidevConfig

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -69,7 +69,7 @@ export interface SlidevMarkdown {
 
 export interface SlidevData {
   /**
-   * Slides that should be rendered
+   * Slides that should be rendered (disabled slides excluded)
    */
   slides: SlideInfo[]
   entry: SlidevMarkdown

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -4,31 +4,40 @@ import type { SlidevConfig } from './config'
 export type FrontmatterStyle = 'frontmatter' | 'yaml'
 
 export interface SlideInfoBase {
-  raw: string
+  frontmatter: Record<string, any>
   content: string
   note?: string
-  frontmatter: Record<string, any>
-  frontmatterRaw?: string
-  frontmatterStyle?: FrontmatterStyle
   title?: string
   level?: number
 }
 
-export interface SlideInfo extends SlideInfoBase {
+export interface SourceSlideInfo extends SlideInfoBase {
+  /**
+   * The filepath of the markdown file
+   */
+  filepath: string
+  /**
+   * The index of the slide in the markdown file
+   */
   index: number
+  /**
+   * The range of the slide in the markdown file
+   */
   start: number
   end: number
-  inline?: SlideInfoBase
-  source?: SlideInfoWithPath
+  raw: string
+  frontmatterRaw?: string
+  frontmatterStyle?: FrontmatterStyle
+}
+
+export interface SlideInfo extends SlideInfoBase {
+  /**
+   * The index of the slide in the presentation
+   */
+  index: number
+  source: SourceSlideInfo
   snippetsUsed?: LoadedSnippets
-}
-
-export interface SlideInfoWithPath extends SlideInfo {
-  filepath: string
-}
-
-export interface SlideInfoExtended extends SlideInfo {
-  noteHTML: string
+  noteHTML?: string
 }
 
 /**
@@ -50,21 +59,20 @@ export interface SlidevFeatureFlags {
 }
 
 export interface SlidevMarkdown {
-  slides: SlideInfo[]
+  filepath: string
   raw: string
-  config: SlidevConfig
-  features: SlidevFeatureFlags
-  headmatter: Record<string, unknown>
-
-  filepath?: string
-  entries?: string[]
-  themeMeta?: SlidevThemeMeta
-  subSlides?: Record<string, SlidevMarkdownWithPath>
+  slides: SourceSlideInfo[]
 }
 
-export interface SlidevMarkdownWithPath extends SlidevMarkdown {
-  filepath: string
-  slides: SlideInfoWithPath[]
+export interface SlidevData {
+  slides: SlideInfo[]
+  entry: SlidevMarkdown
+  config: SlidevConfig
+  headmatter: Record<string, unknown>
+  features: SlidevFeatureFlags
+  themeMeta?: SlidevThemeMeta
+  markdownFiles: Record<string, SlidevMarkdown>
+  watchFiles: string[]
 }
 
 export interface SlidevPreparserExtension {
@@ -74,9 +82,6 @@ export interface SlidevPreparserExtension {
 }
 
 export type PreparserExtensionLoader = (headmatter?: Record<string, unknown>, filepath?: string) => Promise<SlidevPreparserExtension[]>
-
-// internal type?
-export type PreparserExtensionFromHeadmatter = (headmatter: any, exts: SlidevPreparserExtension[], filepath?: string) => Promise<SlidevPreparserExtension[]>
 
 export type RenderContext = 'slide' | 'overview' | 'presenter' | 'previewNext'
 

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -59,7 +59,12 @@ export interface SlidevMarkdown {
   filepath?: string
   entries?: string[]
   themeMeta?: SlidevThemeMeta
-  subSlides?: Record<string, SlidevMarkdown>
+  subSlides?: Record<string, SlidevMarkdownWithPath>
+}
+
+export interface SlidevMarkdownWithPath extends SlidevMarkdown {
+  filepath: string
+  slides: SlideInfoWithPath[]
 }
 
 export interface SlidevPreparserExtension {

--- a/test/__snapshots__/parser.test.ts.snap
+++ b/test/__snapshots__/parser.test.ts.snap
@@ -79,10 +79,7 @@ exports[`md parser > frontmatter.md > features 1`] = `
 exports[`md parser > frontmatter.md > slides 1`] = `
 [
   {
-    "content": "
-# Hi
-",
-    "end": 8,
+    "content": "# Hi",
     "frontmatter": {
       "fonts": {
         "mono": "Fira Code",
@@ -90,38 +87,51 @@ exports[`md parser > frontmatter.md > slides 1`] = `
         "serif": "Mate SC",
       },
       "layout": "cover",
-      "title": "Hi",
     },
-    "frontmatterRaw": "layout: cover
+    "index": 0,
+    "level": 1,
+    "note": undefined,
+    "source": {
+      "content": "
+# Hi
+",
+      "end": 8,
+      "frontmatter": {
+        "fonts": {
+          "mono": "Fira Code",
+          "sans": "Roboto, Lato",
+          "serif": "Mate SC",
+        },
+        "layout": "cover",
+      },
+      "frontmatterRaw": "layout: cover
 fonts:
   sans: Roboto, Lato
   serif: Mate SC
   mono: Fira Code
 ",
-    "frontmatterStyle": "frontmatter",
-    "index": 0,
-    "level": 1,
-    "note": undefined,
-    "raw": "---
+      "frontmatterStyle": "frontmatter",
+      "index": 0,
+      "level": 1,
+      "note": undefined,
+      "raw": "---
 layout: cover
 fonts:
   sans: Roboto, Lato
   serif: Mate SC
   mono: Fira Code
-title: Hi
 ---
 
 # Hi
 
 ",
-    "start": 0,
+      "start": 0,
+      "title": "Hi",
+    },
     "title": "Hi",
   },
   {
-    "content": "
-# Hello
-",
-    "end": 16,
+    "content": "# Hello",
     "frontmatter": {
       "layout": "center",
       "meta": {
@@ -129,16 +139,31 @@ title: Hi
         "title": "FooBar",
       },
     },
-    "frontmatterRaw": "meta:
+    "index": 1,
+    "level": 1,
+    "note": "This is note",
+    "source": {
+      "content": "
+# Hello
+",
+      "end": 16,
+      "frontmatter": {
+        "layout": "center",
+        "meta": {
+          "duration": 12,
+          "title": "FooBar",
+        },
+      },
+      "frontmatterRaw": "meta:
   title: FooBar
   duration: 12
 layout: center
 ",
-    "frontmatterStyle": "frontmatter",
-    "index": 1,
-    "level": 1,
-    "note": "This is note",
-    "raw": "---
+      "frontmatterStyle": "frontmatter",
+      "index": 1,
+      "level": 1,
+      "note": "This is note",
+      "raw": "---
 meta:
   title: FooBar
   duration: 12
@@ -151,43 +176,62 @@ layout: center
 This is note
 -->
 ",
-    "start": 8,
+      "start": 8,
+      "title": "Hello",
+    },
     "title": "Hello",
   },
   {
-    "content": "
-# Morning
-",
-    "end": 19,
+    "content": "# Morning",
     "frontmatter": {},
-    "frontmatterRaw": undefined,
-    "frontmatterStyle": undefined,
     "index": 2,
     "level": 1,
     "note": undefined,
-    "raw": "
+    "source": {
+      "content": "
+# Morning
+",
+      "end": 19,
+      "frontmatter": {},
+      "frontmatterRaw": undefined,
+      "frontmatterStyle": undefined,
+      "index": 2,
+      "level": 1,
+      "note": undefined,
+      "raw": "
 # Morning
 
 ",
-    "start": 17,
+      "start": 17,
+      "title": "Morning",
+    },
     "title": "Morning",
   },
   {
-    "content": "
-<!-- This is not note -->
-Hey
-",
-    "end": 26,
+    "content": "<!-- This is not note -->
+Hey",
     "frontmatter": {
       "layout": "text",
     },
-    "frontmatterRaw": "layout: text
-",
-    "frontmatterStyle": "frontmatter",
     "index": 3,
     "level": undefined,
     "note": "This is note",
-    "raw": "---
+    "source": {
+      "content": "
+<!-- This is not note -->
+Hey
+",
+      "end": 26,
+      "frontmatter": {
+        "layout": "text",
+      },
+      "frontmatterRaw": "layout: text
+",
+      "frontmatterStyle": "frontmatter",
+      "index": 3,
+      "level": undefined,
+      "note": "This is note",
+      "raw": "---
 layout: text
 ---
 
@@ -198,26 +242,39 @@ Hey
 This is note
 -->
 ",
-    "start": 19,
+      "start": 19,
+      "title": undefined,
+    },
     "title": undefined,
   },
   {
-    "content": "
-\`\`\`md
+    "content": "\`\`\`md
 ---
 this should be treated as code block
 ---
 ----
-\`\`\`
-",
-    "end": 35,
+\`\`\`",
     "frontmatter": {},
-    "frontmatterRaw": undefined,
-    "frontmatterStyle": undefined,
     "index": 4,
     "level": undefined,
     "note": undefined,
-    "raw": "
+    "source": {
+      "content": "
+\`\`\`md
+---
+this should be treated as code block
+---
+----
+\`\`\`
+",
+      "end": 35,
+      "frontmatter": {},
+      "frontmatterRaw": undefined,
+      "frontmatterStyle": undefined,
+      "index": 4,
+      "level": undefined,
+      "note": undefined,
+      "raw": "
 \`\`\`md
 ---
 this should be treated as code block
@@ -226,37 +283,62 @@ this should be treated as code block
 \`\`\`
 
 ",
-    "start": 27,
+      "start": 27,
+      "title": undefined,
+    },
     "title": undefined,
   },
   {
-    "content": "
-Content 1
-",
-    "end": 44,
+    "content": "Content 1",
     "frontmatter": {
       "layout": "from yaml",
     },
-    "frontmatterRaw": "
-# The first yaml block should be treated as frontmatter
-layout: from yaml
-",
-    "frontmatterStyle": "yaml",
     "index": 5,
     "level": undefined,
     "note": undefined,
-    "raw": "\`\`\`yaml
+    "source": {
+      "content": "
+Content 1
+",
+      "end": 44,
+      "frontmatter": {
+        "layout": "from yaml",
+      },
+      "frontmatterRaw": "
+# The first yaml block should be treated as frontmatter
+layout: from yaml
+",
+      "frontmatterStyle": "yaml",
+      "index": 5,
+      "level": undefined,
+      "note": undefined,
+      "raw": "\`\`\`yaml
 layout: from yaml
 \`\`\`
 
 Content 1
 
 ",
-    "start": 36,
+      "start": 36,
+      "title": undefined,
+    },
     "title": undefined,
   },
   {
-    "content": "
+    "content": "\`\`\`yaml
+# When there is already a frontmatter, the first yaml block should be treated as content
+layout: should not from yaml 1
+\`\`\`
+
+Content 2",
+    "frontmatter": {
+      "layout": "cover",
+    },
+    "index": 6,
+    "level": 1,
+    "note": undefined,
+    "source": {
+      "content": "
 \`\`\`yaml
 # When there is already a frontmatter, the first yaml block should be treated as content
 layout: should not from yaml 1
@@ -264,17 +346,17 @@ layout: should not from yaml 1
 
 Content 2
 ",
-    "end": 55,
-    "frontmatter": {
-      "layout": "cover",
-    },
-    "frontmatterRaw": "layout: cover
+      "end": 55,
+      "frontmatter": {
+        "layout": "cover",
+      },
+      "frontmatterRaw": "layout: cover
 ",
-    "frontmatterStyle": "frontmatter",
-    "index": 6,
-    "level": 1,
-    "note": undefined,
-    "raw": "---
+      "frontmatterStyle": "frontmatter",
+      "index": 6,
+      "level": 1,
+      "note": undefined,
+      "raw": "---
 layout: cover
 ---
 
@@ -286,28 +368,43 @@ layout: should not from yaml 1
 Content 2
 
 ",
-    "start": 44,
+      "start": 44,
+      "title": "When there is already a frontmatter, the first yaml block should be treated as content",
+    },
     "title": "When there is already a frontmatter, the first yaml block should be treated as content",
   },
   {
-    "content": "
-# Title
+    "content": "# Title
 
 \`\`\`yaml
 # When there is already a frontmatter, the first yaml block should be treated as content
 layout: should not from yaml 2
 \`\`\`
 
-Content 3
-",
-    "end": 66,
+Content 3",
     "frontmatter": {},
-    "frontmatterRaw": undefined,
-    "frontmatterStyle": undefined,
     "index": 7,
     "level": 1,
     "note": undefined,
-    "raw": "
+    "source": {
+      "content": "
+# Title
+
+\`\`\`yaml
+# When there is already a frontmatter, the first yaml block should be treated as content
+layout: should not from yaml 2
+\`\`\`
+
+Content 3
+",
+      "end": 66,
+      "frontmatter": {},
+      "frontmatterRaw": undefined,
+      "frontmatterStyle": undefined,
+      "index": 7,
+      "level": 1,
+      "note": undefined,
+      "raw": "
 # Title
 
 \`\`\`yaml
@@ -318,7 +415,9 @@ layout: should not from yaml 2
 Content 3
 
 ",
-    "start": 56,
+      "start": 56,
+      "title": "Title",
+    },
     "title": "Title",
   },
 ]
@@ -394,25 +493,33 @@ exports[`md parser > mdc.md > features 1`] = `
 exports[`md parser > mdc.md > slides 1`] = `
 [
   {
-    "content": "
+    "content": "# MDC{style="color:red"}
+
+:arrow{x1=1 y1=1 x2=2 y2=2}",
+    "frontmatter": {
+      "mdc": true,
+    },
+    "index": 0,
+    "level": 1,
+    "note": undefined,
+    "source": {
+      "content": "
 # MDC{style="color:red"}
 
 :arrow{x1=1 y1=1 x2=2 y2=2}
 ",
-    "end": 8,
-    "frontmatter": {
-      "mdc": true,
-      "title": "MDC{style="color:red"}",
-    },
-    "frontmatterRaw": "mdc: true
+      "end": 8,
+      "frontmatter": {
+        "mdc": true,
+      },
+      "frontmatterRaw": "mdc: true
 ",
-    "frontmatterStyle": "frontmatter",
-    "index": 0,
-    "level": 1,
-    "note": undefined,
-    "raw": "---
+      "frontmatterStyle": "frontmatter",
+      "index": 0,
+      "level": 1,
+      "note": undefined,
+      "raw": "---
 mdc: true
-title: MDC{style="color:red"}
 ---
 
 # MDC{style="color:red"}
@@ -420,7 +527,9 @@ title: MDC{style="color:red"}
 :arrow{x1=1 y1=1 x2=2 y2=2}
 
 ",
-    "start": 0,
+      "start": 0,
+      "title": "MDC{style="color:red"}",
+    },
     "title": "MDC{style="color:red"}",
   },
 ]
@@ -495,8 +604,7 @@ exports[`md parser > minimal.md > features 1`] = `
 exports[`md parser > minimal.md > slides 1`] = `
 [
   {
-    "content": "
-# H1
+    "content": "# H1
 ## H2
 ### H3
 
@@ -504,21 +612,31 @@ Sample Text
 
 \`\`\`ts
 console.log('Hello World')
-\`\`\`
-",
-    "end": 10,
-    "frontmatter": {
-      "title": "H1",
-    },
-    "frontmatterRaw": undefined,
-    "frontmatterStyle": undefined,
+\`\`\`",
+    "frontmatter": {},
     "index": 0,
     "level": 1,
     "note": undefined,
-    "raw": "---
-title: H1
----
+    "source": {
+      "content": "
+# H1
+## H2
+### H3
 
+Sample Text
+
+\`\`\`ts
+console.log('Hello World')
+\`\`\`
+",
+      "end": 10,
+      "frontmatter": {},
+      "frontmatterRaw": undefined,
+      "frontmatterStyle": undefined,
+      "index": 0,
+      "level": 1,
+      "note": undefined,
+      "raw": "
 # H1
 ## H2
 ### H3
@@ -530,26 +648,39 @@ console.log('Hello World')
 \`\`\`
 
 ",
-    "start": 0,
+      "start": 0,
+      "title": "H1",
+    },
     "title": "H1",
   },
   {
-    "content": "
-# Hello
+    "content": "# Hello
 
 - Hello
 - Hi
 - Hey
-- Yo
-",
-    "end": 18,
+- Yo",
     "frontmatter": {},
-    "frontmatterRaw": undefined,
-    "frontmatterStyle": undefined,
     "index": 1,
     "level": 1,
     "note": undefined,
-    "raw": "
+    "source": {
+      "content": "
+# Hello
+
+- Hello
+- Hi
+- Hey
+- Yo
+",
+      "end": 18,
+      "frontmatter": {},
+      "frontmatterRaw": undefined,
+      "frontmatterStyle": undefined,
+      "index": 1,
+      "level": 1,
+      "note": undefined,
+      "raw": "
 # Hello
 
 - Hello
@@ -558,25 +689,35 @@ console.log('Hello World')
 - Yo
 
 ",
-    "start": 11,
+      "start": 11,
+      "title": "Hello",
+    },
     "title": "Hello",
   },
   {
-    "content": "
-Nice to meet you
-",
-    "end": 22,
+    "content": "Nice to meet you",
     "frontmatter": {},
-    "frontmatterRaw": undefined,
-    "frontmatterStyle": undefined,
     "index": 2,
     "level": undefined,
     "note": undefined,
-    "raw": "
+    "source": {
+      "content": "
+Nice to meet you
+",
+      "end": 22,
+      "frontmatter": {},
+      "frontmatterRaw": undefined,
+      "frontmatterStyle": undefined,
+      "index": 2,
+      "level": undefined,
+      "note": undefined,
+      "raw": "
 Nice to meet you
 
 ",
-    "start": 19,
+      "start": 19,
+      "title": undefined,
+    },
     "title": undefined,
   },
 ]
@@ -636,7 +777,7 @@ exports[`md parser > multi-entries.md > config 1`] = `
     ],
   },
   "src": "sub/page1.md",
-  "title": undefined,
+  "title": "Page 1",
 }
 `;
 
@@ -652,45 +793,11 @@ exports[`md parser > multi-entries.md > features 1`] = `
 exports[`md parser > multi-entries.md > slides 1`] = `
 [
   {
-    "content": "
-# Page 1
-",
-    "end": 2,
-    "frontmatter": {
-      "srcSequence": "sub/page1.md",
-      "title": undefined,
-    },
-    "frontmatterRaw": undefined,
-    "frontmatterStyle": undefined,
+    "content": "# Page 1",
+    "frontmatter": {},
     "index": 0,
-    "inline": {
-      "content": "",
-      "end": 4,
-      "frontmatter": {
-        "title": undefined,
-      },
-      "frontmatterRaw": "src: sub/page1.md
-",
-      "frontmatterStyle": "frontmatter",
-      "index": 0,
-      "level": undefined,
-      "note": undefined,
-      "raw": "---
-src: sub/page1.md
----
-",
-      "start": 0,
-      "title": undefined,
-    },
     "level": 1,
     "note": undefined,
-    "raw": "---
-srcSequence: sub/page1.md
----
-
-# Page 1
-
-",
     "source": {
       "content": "# Page 1",
       "end": 2,
@@ -705,59 +812,19 @@ srcSequence: sub/page1.md
       "start": 0,
       "title": "Page 1",
     },
-    "start": 0,
     "title": "Page 1",
   },
   {
-    "content": "
-# Page 2
+    "content": "# Page 2
 
-<Tweet />
-",
-    "end": 8,
+<Tweet />",
     "frontmatter": {
       "background": "https://sli.dev/demo-cover.png#2",
       "layout": "cover",
-      "srcSequence": "/sub/page2.md",
     },
-    "frontmatterRaw": "layout: cover
-",
-    "frontmatterStyle": "frontmatter",
     "index": 1,
-    "inline": {
-      "content": "",
-      "end": 9,
-      "frontmatter": {
-        "background": "https://sli.dev/demo-cover.png#2",
-      },
-      "frontmatterRaw": "src: /sub/page2.md
-background: https://sli.dev/demo-cover.png#2
-",
-      "frontmatterStyle": "frontmatter",
-      "index": 1,
-      "level": undefined,
-      "note": undefined,
-      "raw": "---
-src: /sub/page2.md
-background: https://sli.dev/demo-cover.png#2
----
-",
-      "start": 4,
-      "title": undefined,
-    },
     "level": 1,
     "note": undefined,
-    "raw": "---
-layout: cover
-background: https://sli.dev/demo-cover.png#2
-srcSequence: /sub/page2.md
----
-
-# Page 2
-
-<Tweet />
-
-",
     "source": {
       "content": "# Page 2
 
@@ -783,52 +850,16 @@ layout: cover
       "start": 0,
       "title": "Page 2",
     },
-    "start": 0,
     "title": "Page 2",
   },
   {
-    "content": "
-# Page 3
-",
-    "end": 2,
+    "content": "# Page 3",
     "frontmatter": {
       "background": "https://sli.dev/demo-cover.png#34",
-      "srcSequence": "./sub/pages3-4.md",
     },
-    "frontmatterRaw": undefined,
-    "frontmatterStyle": undefined,
     "index": 2,
-    "inline": {
-      "content": "",
-      "end": 14,
-      "frontmatter": {
-        "background": "https://sli.dev/demo-cover.png#34",
-      },
-      "frontmatterRaw": "src: ./sub/pages3-4.md
-background: https://sli.dev/demo-cover.png#34
-",
-      "frontmatterStyle": "frontmatter",
-      "index": 2,
-      "level": undefined,
-      "note": undefined,
-      "raw": "---
-src: ./sub/pages3-4.md
-background: https://sli.dev/demo-cover.png#34
----
-",
-      "start": 9,
-      "title": undefined,
-    },
     "level": 1,
     "note": undefined,
-    "raw": "---
-background: https://sli.dev/demo-cover.png#34
-srcSequence: ./sub/pages3-4.md
----
-
-# Page 3
-
-",
     "source": {
       "content": "# Page 3",
       "end": 2,
@@ -843,38 +874,19 @@ srcSequence: ./sub/pages3-4.md
       "start": 0,
       "title": "Page 3",
     },
-    "start": 0,
     "title": "Page 3",
   },
   {
-    "content": "
-# Page 4
+    "content": "# Page 4
 
-<Tweet />
-",
-    "end": 10,
+<Tweet />",
     "frontmatter": {
       "background": "https://sli.dev/demo-cover.png#34",
       "layout": "cover",
-      "srcSequence": "./sub/pages3-4.md",
     },
-    "frontmatterRaw": "layout: cover
-",
-    "frontmatterStyle": "frontmatter",
     "index": 3,
     "level": 1,
     "note": undefined,
-    "raw": "---
-layout: cover
-background: https://sli.dev/demo-cover.png#34
-srcSequence: ./sub/pages3-4.md
----
-
-# Page 4
-
-<Tweet />
-
-",
     "source": {
       "content": "# Page 4
 
@@ -900,52 +912,16 @@ layout: cover
       "start": 2,
       "title": "Page 4",
     },
-    "start": 2,
     "title": "Page 4",
   },
   {
-    "content": "
-# Page 1
-",
-    "end": 2,
+    "content": "# Page 1",
     "frontmatter": {
       "background": "https://sli.dev/demo-cover.png#14",
-      "srcSequence": "sub/nested1-4.md,/sub/page1.md",
     },
-    "frontmatterRaw": undefined,
-    "frontmatterStyle": undefined,
     "index": 4,
-    "inline": {
-      "content": "",
-      "end": 19,
-      "frontmatter": {
-        "background": "https://sli.dev/demo-cover.png#14",
-      },
-      "frontmatterRaw": "src: sub/nested1-4.md
-background: https://sli.dev/demo-cover.png#14
-",
-      "frontmatterStyle": "frontmatter",
-      "index": 3,
-      "level": undefined,
-      "note": undefined,
-      "raw": "---
-src: sub/nested1-4.md
-background: https://sli.dev/demo-cover.png#14
----
-",
-      "start": 14,
-      "title": undefined,
-    },
     "level": 1,
     "note": undefined,
-    "raw": "---
-background: https://sli.dev/demo-cover.png#14
-srcSequence: sub/nested1-4.md,/sub/page1.md
----
-
-# Page 1
-
-",
     "source": {
       "content": "# Page 1",
       "end": 2,
@@ -960,38 +936,19 @@ srcSequence: sub/nested1-4.md,/sub/page1.md
       "start": 0,
       "title": "Page 1",
     },
-    "start": 0,
     "title": "Page 1",
   },
   {
-    "content": "
-# Page 2
+    "content": "# Page 2
 
-<Tweet />
-",
-    "end": 8,
+<Tweet />",
     "frontmatter": {
       "background": "https://sli.dev/demo-cover.png#14",
       "layout": "cover",
-      "srcSequence": "sub/nested1-4.md,page2.md",
     },
-    "frontmatterRaw": "layout: cover
-",
-    "frontmatterStyle": "frontmatter",
     "index": 5,
     "level": 1,
     "note": undefined,
-    "raw": "---
-layout: cover
-background: https://sli.dev/demo-cover.png#14
-srcSequence: sub/nested1-4.md,page2.md
----
-
-# Page 2
-
-<Tweet />
-
-",
     "source": {
       "content": "# Page 2
 
@@ -1017,31 +974,16 @@ layout: cover
       "start": 0,
       "title": "Page 2",
     },
-    "start": 0,
     "title": "Page 2",
   },
   {
-    "content": "
-# Page 3
-",
-    "end": 2,
+    "content": "# Page 3",
     "frontmatter": {
       "background": "https://sli.dev/demo-cover.png#14",
-      "srcSequence": "sub/nested1-4.md,../sub/pages3-4.md",
     },
-    "frontmatterRaw": undefined,
-    "frontmatterStyle": undefined,
     "index": 6,
     "level": 1,
     "note": undefined,
-    "raw": "---
-background: https://sli.dev/demo-cover.png#14
-srcSequence: sub/nested1-4.md,../sub/pages3-4.md
----
-
-# Page 3
-
-",
     "source": {
       "content": "# Page 3",
       "end": 2,
@@ -1056,38 +998,19 @@ srcSequence: sub/nested1-4.md,../sub/pages3-4.md
       "start": 0,
       "title": "Page 3",
     },
-    "start": 0,
     "title": "Page 3",
   },
   {
-    "content": "
-# Page 4
+    "content": "# Page 4
 
-<Tweet />
-",
-    "end": 10,
+<Tweet />",
     "frontmatter": {
       "background": "https://sli.dev/demo-cover.png#14",
       "layout": "cover",
-      "srcSequence": "sub/nested1-4.md,../sub/pages3-4.md",
     },
-    "frontmatterRaw": "layout: cover
-",
-    "frontmatterStyle": "frontmatter",
     "index": 7,
     "level": 1,
     "note": undefined,
-    "raw": "---
-layout: cover
-background: https://sli.dev/demo-cover.png#14
-srcSequence: sub/nested1-4.md,../sub/pages3-4.md
----
-
-# Page 4
-
-<Tweet />
-
-",
     "source": {
       "content": "# Page 4
 
@@ -1113,29 +1036,38 @@ layout: cover
       "start": 2,
       "title": "Page 4",
     },
-    "start": 2,
     "title": "Page 4",
   },
   {
-    "content": "
-# Inline Page
+    "content": "# Inline Page
 
-$x+2$
-",
-    "end": 25,
+$x+2$",
     "frontmatter": {},
-    "frontmatterRaw": undefined,
-    "frontmatterStyle": undefined,
     "index": 8,
     "level": 1,
     "note": undefined,
-    "raw": "
+    "source": {
+      "content": "
+# Inline Page
+
+$x+2$
+",
+      "end": 25,
+      "frontmatter": {},
+      "frontmatterRaw": undefined,
+      "frontmatterStyle": undefined,
+      "index": 4,
+      "level": 1,
+      "note": undefined,
+      "raw": "
 # Inline Page
 
 $x+2$
 
 ",
-    "start": 20,
+      "start": 20,
+      "title": "Inline Page",
+    },
     "title": "Inline Page",
   },
 ]

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -15,18 +15,19 @@ function configDiff(v: SlidevConfig) {
 }
 
 describe('md parser', () => {
+  const userRoot = resolve(__dirname, 'fixtures/markdown')
   const files = fg.sync('*.md', {
-    cwd: resolve(__dirname, 'fixtures/markdown'),
+    cwd: userRoot,
     absolute: true,
   })
 
   for (const file of files) {
     it(basename(file), async () => {
-      const data = await load(file)
+      const data = await load(userRoot, file)
 
-      expect(stringify(data).trim()).toEqual(data.raw.trim())
+      expect(stringify(data.entry).trim()).toEqual(data.entry.raw.trim())
 
-      prettify(data)
+      prettify(data.entry)
 
       for (const slide of data.slides) {
         if (slide.source?.filepath)
@@ -65,7 +66,7 @@ e
 
 f
 
-`)
+`, 'file.md')
     expect(data.slides.map(i => i.content.trim()))
       .toEqual(Array.from('abcdef'))
     expect(data.slides[2].frontmatter)
@@ -95,7 +96,7 @@ e
 
 f
 
-`)
+`, 'file.md')
     expect(data.slides.map(i => i.content.trim()))
       .toEqual(Array.from('abcdef'))
     expect(data.slides[2].frontmatter)
@@ -112,10 +113,8 @@ f
   ) {
     return await parse(
       src,
-      undefined,
-      undefined,
-      [],
-      async () => [{ transformRawLines, ...more }, ...moreExts] as any,
+      'file.md',
+      [{ transformRawLines, ...more }, ...moreExts] as any,
     )
   }
 

--- a/test/transform.test.ts
+++ b/test/transform.test.ts
@@ -153,7 +153,7 @@ Alice <- Bob : Hello, too!
         slides: [
           {} as any,
         ],
-        entries: [],
+        watchFiles: [],
       },
     } as any, `/@slidev/slides/1.md`)).toMatchSnapshot()
   })


### PR DESCRIPTION
This PR refactors the data structures for parsed and loaded data.

- Every markdown source file is represented by a `SlidevMarkdown` object, including the entry markdown file:
    ```ts
    export interface SlidevMarkdown {
      filepath: string
      raw: string
      slides: SourceSlideInfo[]  // all the slides in this Markdown file
    }
    ```

- The previous `SlidevMarkdown` is renamed to `SlidevData`:
    ```ts
    export interface SlidevData {
      slides: SlideInfo[]  // the actually displayed slides (disabled slides excluded)
      entry: SlidevMarkdown
      config: SlidevConfig
      headmatter: Record<string, unknown>
      features: SlidevFeatureFlags
      themeMeta?: SlidevThemeMeta
      markdownFiles: Record<string, SlidevMarkdown>
      watchFiles: string[]
    }
    ```

There should be only one `SlidevData`, and at least one `SlidevMarkdown`.

### Advantages

- Fixes (unreported) problems about nested `src` usage.
- Avoid potential bugs caused by forced type conventions, implicit object references, and other ambiguities.
- Resolves #1219 (use `src: ./pages/sub-slides.md#2,5-7` to embed page `2,5,6,7` in `sub-slides.md`).
- A little bit of performance improvement (by avoiding duplicate scans and loads).
- Not resolve config and load any data in the `parse` method, so that the parser's function is more concentrated and its logic can be reused more easily.

### Todos

- [ ] `frontmatter.hide`. I don't know what's the difference between `hide` and `disabled`. (https://sli.dev/custom/#per-slide-configuration)
- [x] Test HMR
- [x] Test slide and note editor
- [x] Update unit tests
- [x] Test export and build