### PR TITLE
fix: `defineEmits` caused warnings

### DIFF
--- a/packages/client/internals/InfoDialog.vue
+++ b/packages/client/internals/InfoDialog.vue
@@ -10,7 +10,7 @@ const props = defineProps({
   },
 })
 
-const emit = defineEmits<{ (name: 'modelValue', v: boolean): void }>()
+const emit = defineEmits(['update:modelValue'])
 const value = useVModel(props, 'modelValue', emit)
 const hasInfo = computed(() => typeof configs.info === 'string')
 </script>

--- a/packages/client/internals/Modal.vue
+++ b/packages/client/internals/Modal.vue
@@ -10,7 +10,7 @@ const props = defineProps({
   },
 })
 
-const emit = defineEmits<{ (name: 'modelValue', v: boolean): void }>()
+const emit = defineEmits(['update:modelValue'])
 const value = useVModel(props, 'modelValue', emit)
 
 function onClick() {

--- a/packages/client/internals/SlidesOverview.vue
+++ b/packages/client/internals/SlidesOverview.vue
@@ -14,7 +14,7 @@ import IconButton from './IconButton.vue'
 
 const props = defineProps<{ modelValue: boolean }>()
 
-const emit = defineEmits([])
+const emit = defineEmits(['update:modelValue'])
 const value = useVModel(props, 'modelValue', emit)
 
 function close() {


### PR DESCRIPTION
This PR fixes three warnings about `update:modelValue` is not defined in `defineEmits`.