### PR TITLE
fix: filter frontmatter (#1303)

### DIFF
--- a/packages/client/constants.ts
+++ b/packages/client/constants.ts
@@ -1,6 +1,7 @@
 import type { ComputedRef, InjectionKey, Ref, UnwrapNestedRefs } from 'vue'
 import type { RouteRecordRaw } from 'vue-router'
 import type { ClicksContext, RenderContext } from '@slidev/types'
+import { objectOmit } from '@vueuse/core'
 import type { SlidevContext } from './modules/context'
 
 export const injectionClicksContext: InjectionKey<Ref<ClicksContext>> = Symbol('slidev-clicks-context')
@@ -24,3 +25,55 @@ export const TRUST_ORIGINS = [
   'localhost',
   '127.0.0.1',
 ]
+
+const FRONTMATTER_FIELDS = [
+  'clicks',
+  'disabled',
+  'hide',
+  'hideInToc',
+  'layout',
+  'level',
+  'preload',
+  'routeAlias',
+  'src',
+  'title',
+  'transition',
+]
+
+const HEADMATTER_FIELDS = [
+  ...FRONTMATTER_FIELDS,
+  'theme',
+  'titleTemplate',
+  'info',
+  'author',
+  'keywords',
+  'presenter',
+  'download',
+  'exportFilename',
+  'export',
+  'highlighter',
+  'lineNumbers',
+  'monaco',
+  'remoteAssets',
+  'selectable',
+  'record',
+  'colorSchema',
+  'routerMode',
+  'aspectRatio',
+  'canvasWidth',
+  'themeConfig',
+  'favicon',
+  'plantUmlServer',
+  'fonts',
+  'defaults',
+  'drawings',
+  'htmlAttrs',
+  'mdc',
+]
+
+export function filterFrontmatter(frontmatter: Record<string, any>, pageNo: number) {
+  return {
+    ...objectOmit(frontmatter, pageNo === 0 ? HEADMATTER_FIELDS : FRONTMATTER_FIELDS),
+    frontmatter,
+  }
+}

--- a/packages/slidev/node/plugins/loaders.ts
+++ b/packages/slidev/node/plugins/loaders.ts
@@ -27,6 +27,7 @@ const vueContextImports = [
     injectionCurrentPage as _injectionCurrentPage,
     injectionRenderContext as _injectionRenderContext,
     injectionFrontmatter as _injectionFrontmatter,
+    filterFrontmatter as _filterFrontmatter,
   } from "@slidev/client/constants.ts"`.replace(/\n\s+/g, '\n'),
   'const $slidev = _vueInject(_injectionSlidevContext)',
   'const $nav = _vueToRef($slidev, "nav")',
@@ -487,7 +488,7 @@ export function createSlidesLoader(
     let body = code.slice(injectA, injectB).trim()
     if (body.startsWith('<div>') && body.endsWith('</div>'))
       body = body.slice(5, -6)
-    code = `${code.slice(0, injectA)}\n<InjectedLayout v-bind="frontmatter">\n${body}\n</InjectedLayout>\n${code.slice(injectB)}`
+    code = `${code.slice(0, injectA)}\n<InjectedLayout v-bind="_filterFrontmatter(frontmatter,${pageNo})">\n${body}\n</InjectedLayout>\n${code.slice(injectB)}`
 
     return code
   }


### PR DESCRIPTION
fixes #1303.

This PR added a filter to remove unwanted fields from frontmatter to pass to the layout component. And pass the full frontmatter as `frontmatter` prop. (https://github.com/slidevjs/slidev/issues/1303#issuecomment-1952309397).

Current behavior on the first slide of the demo:
![image](https://github.com/slidevjs/slidev/assets/63178754/465d9146-256c-4375-8361-b9cbe74cac9a)
Not the best, but much better than before.