### PR TITLE
fix: slide route meta

### DIFF
--- a/packages/client/logic/nav.ts
+++ b/packages/client/logic/nav.ts
@@ -177,7 +177,7 @@ export async function downloadPDF() {
 export async function openInEditor(url?: string) {
   if (url == null) {
     const slide = currentRoute.value?.meta?.slide
-    if (!slide?.filepath)
+    if (!slide)
       return false
     url = `${slide.filepath}:${slide.start}`
   }

--- a/packages/client/routes.ts
+++ b/packages/client/routes.ts
@@ -1,7 +1,7 @@
 import type { RouteLocationNormalized, RouteRecordRaw } from 'vue-router'
 import { createRouter, createWebHashHistory, createWebHistory } from 'vue-router'
 import type { TransitionGroupProps } from 'vue'
-import type { ClicksContext } from '@slidev/types'
+import type { ClicksContext, SlideInfo } from '@slidev/types'
 
 // @ts-expect-error missing types
 import _rawRoutes, { redirects } from '/@slidev/routes'
@@ -84,19 +84,12 @@ declare module 'vue-router' {
     preload?: boolean
 
     // slide info
-    slide?: {
+    slide?: Omit<SlideInfo, 'source'> & {
+      noteHTML: string
+      filepath: string
       start: number
-      end: number
-      note?: string
-      noteHTML?: string
       id: number
       no: number
-      filepath: string
-      title?: string
-      level?: number
-      raw: string
-      content: string
-      frontmatter: Record<string, any>
     }
 
     // private fields

--- a/packages/parser/src/fs.ts
+++ b/packages/parser/src/fs.ts
@@ -51,7 +51,7 @@ export async function load(userRoot: string, filepath: string, themeMeta?: Slide
   }
 
   async function loadSlide(slide: SourceSlideInfo, frontmatterOverride?: Record<string, unknown>) {
-    if (slide.frontmatter.disabled)
+    if (slide.frontmatter.disabled || slide.frontmatter.hide)
       return
     if (slide.frontmatter.src) {
       const [rawPath, rangeRaw] = slide.frontmatter.src.split('#')

--- a/packages/slidev/node/plugins/loaders.ts
+++ b/packages/slidev/node/plugins/loaders.ts
@@ -305,6 +305,7 @@ export function createSlidesLoader(
               const slideBase = {
                 ...renderNoteHTML(slide),
                 frontmatter: undefined,
+                source: undefined,
                 // remove raw content in build, optimize the bundle size
                 ...(mode === 'build' ? { raw: '', content: '', note: '' } : {}),
               }
@@ -325,7 +326,8 @@ export function createSlidesLoader(
                     slide: {
                       ...(${JSON.stringify(slideBase)}),
                       frontmatter,
-                      filepath: ${JSON.stringify(slide.source?.filepath || entry)},
+                      filepath: ${JSON.stringify(slide.source.filepath)},
+                      start: ${JSON.stringify(slide.source.start)},
                       id: ${pageNo},
                       no: ${no},
                     },


### PR DESCRIPTION
This PR fixes the route meta of slides. So that the open-in-editor function is fixed and the total size of data is reduced.