### PR TITLE
fix: escape `{{` in code (#1316)

### DIFF
--- a/packages/slidev/node/plugins/markdown.ts
+++ b/packages/slidev/node/plugins/markdown.ts
@@ -260,10 +260,10 @@ export function transformPlantUml(md: string, server: string): string {
 }
 
 /**
- * Escape `{{}}` in code block to prevent Vue interpret it, #99
+ * Escape `{{` in code block to prevent Vue interpret it, #99, #1316
  */
 export function escapeVueInCode(md: string) {
-  return md.replace(/{{(.*?)}}/g, '&lbrace;&lbrace;$1&rbrace;&rbrace;')
+  return md.replace(/{{/g, '&lbrace;&lbrace;')
 }
 
 export async function loadShikiSetups(


### PR DESCRIPTION
fixes #1316.

Previously, only "full" mustache syntax (`{{...}}`) is escaped. However, Vue regards `{{` as the start of mustache syntax, no matter what the following code is.

This PR escapes all `{{` in Shiki-rendered HTML. I think it is only 99.999% safe, but I can't find a better solution.

In Vitepress, only `{{...}}` is replaced:
https://github.com/vuejs/vitepress/blob/28989df83446923a9e7c8ada345b0778119ed66f/src/node/markdown/plugins/highlight.ts#L127-L134