### PR TITLE
fix: multiple Tweet component (#1309)

### DIFF
--- a/packages/client/builtin/Tweet.vue
+++ b/packages/client/builtin/Tweet.vue
@@ -7,9 +7,9 @@ Usage:
 -->
 
 <script setup lang="ts">
-import { useScriptTag } from '@vueuse/core'
 import { getCurrentInstance, onMounted, ref } from 'vue'
 import { isDark } from '../logic/dark'
+import { useTweet } from '../composables/tweet'
 
 const props = defineProps<{
   id: string | number
@@ -41,21 +41,10 @@ async function create() {
 }
 
 // @ts-expect-error global
-if (window?.twttr?.widgets) {
+if (window?.twttr?.widgets)
   onMounted(create)
-}
-else {
-  useScriptTag(
-    'https://platform.twitter.com/widgets.js',
-    () => {
-      if (vm.isMounted)
-        create()
-      else
-        onMounted(create, vm)
-    },
-    { async: true },
-  )
-}
+else
+  useTweet(vm, create)
 </script>
 
 <template>

--- a/packages/client/builtin/Tweet.vue
+++ b/packages/client/builtin/Tweet.vue
@@ -9,7 +9,7 @@ Usage:
 <script setup lang="ts">
 import { getCurrentInstance, onMounted, ref } from 'vue'
 import { isDark } from '../logic/dark'
-import { useTweet } from '../composables/tweet'
+import { useTweetScript } from '../composables/useTweetScript'
 
 const props = defineProps<{
   id: string | number
@@ -44,7 +44,7 @@ async function create() {
 if (window?.twttr?.widgets)
   onMounted(create)
 else
-  useTweet(vm, create)
+  useTweetScript(vm, create)
 </script>
 
 <template>

--- a/packages/client/composables/tweet.ts
+++ b/packages/client/composables/tweet.ts
@@ -1,0 +1,17 @@
+import { createSharedComposable, useScriptTag } from '@vueuse/core'
+import type { ComponentInternalInstance } from 'vue'
+import { onMounted } from 'vue'
+
+export const useTweet = createSharedComposable(
+  (vm: ComponentInternalInstance, create: () => void) =>
+    useScriptTag(
+      'https://platform.twitter.com/widgets.js',
+      () => {
+        if (vm.isMounted)
+          create()
+        else
+          onMounted(create, vm)
+      },
+      { async: true },
+    ),
+)

--- a/packages/client/composables/useTweetScript.ts
+++ b/packages/client/composables/useTweetScript.ts
@@ -2,7 +2,7 @@ import { createSharedComposable, useScriptTag } from '@vueuse/core'
 import type { ComponentInternalInstance } from 'vue'
 import { onMounted } from 'vue'
 
-export const useTweet = createSharedComposable(
+export const useTweetScript = createSharedComposable(
   (vm: ComponentInternalInstance, create: () => void) =>
     useScriptTag(
       'https://platform.twitter.com/widgets.js',


### PR DESCRIPTION
Fixes #1309.

This PR fixes **Firefox-only** issue about multiple `Tweet` components. The cause is very similar to https://github.com/vueuse/vueuse/issues/2027.

This PR wraps `useScriptTag` by `createSharedComposable`. I've tested multiple Tweet components in Firefox119 in Browserling and found this fix works well.