### PR TITLE
fix: `VClicks` component

### DIFF
--- a/packages/client/builtin/VClicks.ts
+++ b/packages/client/builtin/VClicks.ts
@@ -96,7 +96,7 @@ export default defineComponent({
         if (depth < +this.depth && Array.isArray(i.children))
           vNode = h(i, {}, mapSubList(i.children, depth))
         else
-          vNode = i
+          vNode = h(i)
 
         const delta = thisShowIdx - execIdx
         execIdx = thisShowIdx


### PR DESCRIPTION
fixes #1320

Partially reverts aa0cab441fe068419bb34ab75a29453d584a7c33.

#1320 is caused by that one same `li` in `<v-clicks>` is applyed two `v-click` directives. Once in the main view, and once in the slides overview.
