### PR TITLE
feat: add `zoom` option in page frontmatter

### DIFF
--- a/packages/client/constants.ts
+++ b/packages/client/constants.ts
@@ -38,6 +38,7 @@ const FRONTMATTER_FIELDS = [
   'src',
   'title',
   'transition',
+  'zoom',
 ]
 
 const HEADMATTER_FIELDS = [

--- a/packages/client/internals/SlideWrapper.ts
+++ b/packages/client/internals/SlideWrapper.ts
@@ -1,6 +1,7 @@
-import { defineComponent, h, provide, ref, toRef } from 'vue'
+import { computed, defineComponent, h, provide, ref, toRef } from 'vue'
 import type { PropType } from 'vue'
 import type { ClicksContext, RenderContext } from '@slidev/types'
+import type { RouteRecordRaw } from 'vue-router'
 import { injectionActive, injectionClicksContext, injectionCurrentPage, injectionRenderContext, injectionRoute } from '../constants'
 
 export default defineComponent({
@@ -20,23 +21,37 @@ export default defineComponent({
     },
     is: {
       type: Object,
-      default: undefined,
+      required: true,
     },
     route: {
-      type: Object,
-      default: undefined,
+      type: Object as PropType<RouteRecordRaw>,
+      required: true,
     },
   },
   setup(props) {
-    provide(injectionRoute, props.route as any)
-    provide(injectionCurrentPage, ref(+props.route?.path))
+    provide(injectionRoute, props.route)
+    provide(injectionCurrentPage, ref(+props.route.path))
     provide(injectionRenderContext, ref(props.renderContext as RenderContext))
     provide(injectionActive, toRef(props, 'active'))
     provide(injectionClicksContext, toRef(props, 'clicksContext'))
+
+    const style = computed(() => {
+      const zoom = props.route.meta?.slide?.frontmatter.zoom ?? 1
+      return zoom === 1
+        ? undefined
+        : {
+            width: `${100 / zoom}%`,
+            height: `${100 / zoom}%`,
+            transformOrigin: 'top left',
+            transform: `scale(${zoom})`,
+          }
+    })
+
+    return {
+      style,
+    }
   },
   render() {
-    if (this.$props.is)
-      return h(this.$props.is)
-    return this.$slots?.default?.()
+    return h(this.$props.is, { style: this.style })
   },
 })


### PR DESCRIPTION
This PR adds a `zoom` option in **every page**'s frontmatter to scale each slide **separately**.

| `zoom: 0.3` | `zoom: 1` (default) | `zoom: 3` |
| - | - | - |
| <img width="1280" alt="image" src="https://github.com/slidevjs/slidev/assets/63178754/ab6145d0-e71f-44ed-832b-f8b98d43ed18"> | <img width="1280" alt="image" src="https://github.com/slidevjs/slidev/assets/63178754/6bada295-d4ef-4806-b36b-614b76ea7f52"> | <img width="1280" alt="image" src="https://github.com/slidevjs/slidev/assets/63178754/37e44a10-2d62-4b08-b509-98ccea86e7d4"> |

Resolves #1075.

If we want to zoom all the slides, we can use the `canvasWidth` option in the headmatter, which has almost the same effect as applying this `zoom` option to all slides.