### PR TITLE
fix: slide patching

### DIFF
--- a/packages/client/logic/note.ts
+++ b/packages/client/logic/note.ts
@@ -2,11 +2,11 @@ import type { MaybeRef } from '@vueuse/core'
 import { useFetch } from '@vueuse/core'
 import type { Ref } from 'vue'
 import { computed, ref, unref } from 'vue'
-import type { SlideInfo } from '@slidev/types'
+import type { SlideInfo, SlidePatch } from '@slidev/types'
 
 export interface UseSlideInfo {
   info: Ref<SlideInfo | undefined>
-  update: (data: Partial<SlideInfo>) => Promise<SlideInfo | void>
+  update: (data: SlidePatch) => Promise<SlideInfo | void>
 }
 
 export function useSlideInfo(id: number | undefined): UseSlideInfo {
@@ -21,7 +21,7 @@ export function useSlideInfo(id: number | undefined): UseSlideInfo {
 
   execute()
 
-  const update = async (data: Partial<SlideInfo>) => {
+  const update = async (data: SlidePatch) => {
     return await fetch(
       url,
       {
@@ -64,7 +64,7 @@ export function useDynamicSlideInfo(id: MaybeRef<number | undefined>) {
 
   return {
     info: computed(() => get(unref(id)).info.value),
-    update: async (data: Partial<SlideInfo>, newId?: number) => {
+    update: async (data: SlidePatch, newId?: number) => {
       const info = get(newId ?? unref(id))
       const newData = await info.update(data)
       if (newData)

--- a/packages/slidev/node/plugins/loaders.ts
+++ b/packages/slidev/node/plugins/loaders.ts
@@ -8,7 +8,7 @@ import { bold, gray, red, yellow } from 'kolorist'
 
 // @ts-expect-error missing types
 import mila from 'markdown-it-link-attributes'
-import type { SlideInfo } from '@slidev/types'
+import type { SlideInfo, SlidePatch } from '@slidev/types'
 import * as parser from '@slidev/parser/fs'
 import equal from 'fast-deep-equal'
 
@@ -106,12 +106,10 @@ export function createSlidesLoader(
             return res.end()
           }
           if (type === 'json' && req.method === 'POST') {
-            const body = await getBodyJson(req)
+            const body: SlidePatch = await getBodyJson(req)
             const slide = data.slides[idx]
 
-            const onlyNoteChanged = Object.keys(body).length === 2
-              && 'note' in body && body.raw === null
-            if (!onlyNoteChanged)
+            if (body.content && body.content !== slide.source.content)
               hmrPages.add(idx)
 
             Object.assign(slide.source, body)

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -41,6 +41,11 @@ export interface SlideInfo extends SlideInfoBase {
 }
 
 /**
+ * Editable fields for a slide
+ */
+export type SlidePatch = Partial<Pick<SlideInfoBase, 'content' | 'note'>>
+
+/**
  * Metadata for "slidev" field in themes' package.json
  */
 export interface SlidevThemeMeta {


### PR DESCRIPTION
This PR adds a new type:
```ts
/**
 * Editable fields for a slide
 */
export type SlidePatch = Partial<Pick<SlideInfoBase, 'content' | 'note'>>
```

And fixes slide patching, e.g. editing notes.