### PR TITLE
fix: reset CodeMirror history when route changes

### DIFF
--- a/packages/client/internals/Editor.vue
+++ b/packages/client/internals/Editor.vue
@@ -102,6 +102,11 @@ onMounted(async () => {
         noteEditor.refresh()
     })
   })
+
+  watch(currentSlideId, () => {
+    contentEditor.clearHistory()
+    noteEditor.clearHistory()
+  }, { flush: 'post' })
 })
 
 const handlerDown = ref(false)


### PR DESCRIPTION
Reset the history of editors when route (i.e. slide) changes. Thus too many `ctrl+z`s will not set the content of the slide to the previous slide.