### PR TITLE
feat: allow preparsers to access the run mode (dev,export,build)

### DIFF
--- a/packages/parser/src/fs.ts
+++ b/packages/parser/src/fs.ts
@@ -19,7 +19,7 @@ export function injectPreparserExtensionLoader(fn: PreparserExtensionLoader) {
  */
 export type LoadedSlidevData = Omit<SlidevData, 'config' | 'themeMeta'>
 
-export async function load(userRoot: string, filepath: string, content?: string): Promise<LoadedSlidevData> {
+export async function load(userRoot: string, filepath: string, content?: string, mode?: string): Promise<LoadedSlidevData> {
   const markdown = content ?? await fs.readFile(filepath, 'utf-8')
 
   let extensions: SlidevPreparserExtension[] | undefined
@@ -36,7 +36,7 @@ export async function load(userRoot: string, filepath: string, content?: string)
       hm = lines.slice(1, hEnd).join('\n')
     }
     const o = YAML.load(hm) as Record<string, unknown> ?? {}
-    extensions = await preparserExtensionLoader(o, filepath)
+    extensions = await preparserExtensionLoader(o, filepath, mode)
   }
 
   const markdownFiles: Record<string, SlidevMarkdown> = {}

--- a/packages/slidev/node/cli.ts
+++ b/packages/slidev/node/cli.ts
@@ -38,7 +38,7 @@ const CONFIG_RESTART_FIELDS: (keyof SlidevConfig)[] = [
   'theme',
 ]
 
-injectPreparserExtensionLoader(async (headmatter?: Record<string, unknown>, filepath?: string) => {
+injectPreparserExtensionLoader(async (headmatter?: Record<string, unknown>, filepath?: string, mode?: string) => {
   const addons = headmatter?.addons as string[] ?? []
   const { clientRoot, userRoot } = await getRoots()
   const roots = uniq([
@@ -47,7 +47,7 @@ injectPreparserExtensionLoader(async (headmatter?: Record<string, unknown>, file
     ...await resolveAddons(addons),
   ])
   const mergeArrays = (a: SlidevPreparserExtension[], b: SlidevPreparserExtension[]) => a.concat(b)
-  return await loadSetups(clientRoot, roots, 'preparser.ts', { filepath, headmatter }, [], mergeArrays)
+  return await loadSetups(clientRoot, roots, 'preparser.ts', { filepath, headmatter, mode }, [], mergeArrays)
 })
 
 const cli = yargs(process.argv.slice(2))
@@ -144,7 +144,7 @@ cli.command(
         {
           async loadData() {
             const { data: oldData, entry } = options
-            const loaded = await parser.load(options.userRoot, entry)
+            const loaded = await parser.load(options.userRoot, entry, undefined, 'dev')
 
             const themeRaw = theme || loaded.headmatter.theme as string || 'default'
             if (options.themeRaw !== themeRaw) {

--- a/packages/slidev/node/options.ts
+++ b/packages/slidev/node/options.ts
@@ -82,7 +82,7 @@ export async function resolveOptions(
 ): Promise<ResolvedSlidevOptions> {
   const rootsInfo = await getRoots()
   const entry = await resolveEntry(options.entry || 'slides.md', rootsInfo)
-  const loaded = await parser.load(rootsInfo.userRoot, entry)
+  const loaded = await parser.load(rootsInfo.userRoot, entry, undefined, mode)
 
   // Load theme data first, because it may affect the config
   const themeRaw = options.theme || loaded.headmatter.theme as string || 'default'

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -92,7 +92,7 @@ export interface SlidevPreparserExtension {
   transformSlide?: (content: string, frontmatter: any) => Promise<string | undefined>
 }
 
-export type PreparserExtensionLoader = (headmatter?: Record<string, unknown>, filepath?: string) => Promise<SlidevPreparserExtension[]>
+export type PreparserExtensionLoader = (headmatter?: Record<string, unknown>, filepath?: string, mode?: string) => Promise<SlidevPreparserExtension[]>
 
 export type RenderContext = 'none' | 'slide' | 'overview' | 'presenter' | 'previewNext'
 


### PR DESCRIPTION
While trying to make a preparser dependent on whether we are exporting slides or not, one user tried to naturally import nav as in:

```ts
import { definePreparserSetup } from "@slidev/types";
import { isPrintMode } from "@slidev/client/logic/nav.ts";

function removeSlidesWithHidePrint(lines) {...}

export default definePreparserSetup(() => {
  return [
    {
      transformRawLines(lines) {
        if (isPrintMode) {
          removeSlidesWithHidePrint(lines);
        }
      },
    },
  ];
});
```

But `nav` includes `routes` which includes some `Play.vue` file which gives an error.

My understanding is that the reason is the following: the parsing code is not running in the client side, so most of these (routes, vue loader, etc) are not (supposed to be) available.

This PR passes the running "mode" (dev|build|export) to the preparser.
NB:
- I initially wanted to pass as much of the options as possible but it happen that the mode was already available at the call site, while other options were not. I thus ended up passing only the mode. 
- I passed the mode as a string to avoid moving all the `interface ResolvedSlidevOptions` (and dependencies) into the `types` package.


