### PR TITLE
fix: black background when exporting to PDF

### DIFF
--- a/packages/client/internals/PrintContainer.vue
+++ b/packages/client/internals/PrintContainer.vue
@@ -50,6 +50,6 @@ provideLocal(injectionSlideScale, scale)
 }
 
 .print-slide-container {
-  @apply relative overflow-hidden break-after-page;
+  @apply relative overflow-hidden break-after-page translate-0;
 }
 </style>


### PR DESCRIPTION
fix https://github.com/slidevjs/slidev/issues/1207

https://github.com/slidevjs/slidev/issues/1207 is caused by [_stacking context_](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_positioned_layout/Understanding_z-index/Stacking_context#description)