### PR TITLE
fix: double click operation in clicks slider

### DIFF
--- a/packages/client/composables/useClicks.ts
+++ b/packages/client/composables/useClicks.ts
@@ -66,7 +66,7 @@ function useClicksContextBase(current: Ref<number>, clicksOverrides?: number): C
 export function usePrimaryClicks(route: RouteRecordRaw | undefined): ClicksContext {
   if (route?.meta?.__clicksContext)
     return route.meta.__clicksContext
-  const thisPath = +(route?.path ?? CLICKS_MAX)
+  const thisPath = +(route?.path ?? Number.NaN)
   const current = computed({
     get() {
       const currentPath = +(currentRoute.value?.path ?? Number.NaN)
@@ -81,8 +81,10 @@ export function usePrimaryClicks(route: RouteRecordRaw | undefined): ClicksConte
     },
     set(v) {
       const currentPath = +(currentRoute.value?.path ?? Number.NaN)
-      if (currentPath === thisPath)
-        queryClicks.value = v
+      if (currentPath === thisPath) {
+        // eslint-disable-next-line ts/no-use-before-define
+        queryClicks.value = Math.min(v, context.total)
+      }
     },
   })
   const context = useClicksContextBase(

--- a/packages/client/internals/ClicksSlider.vue
+++ b/packages/client/internals/ClicksSlider.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import type { ClicksContext } from '@slidev/types'
 import { computed } from 'vue'
-import { CLICKS_MAX } from '../constants'
 
 const props = defineProps<{
   clicksContext: ClicksContext
@@ -34,15 +33,13 @@ function onMousedown() {
   >
     <div class="flex gap-1 items-center min-w-16">
       <carbon:cursor-1 text-sm op50 />
-      <template v-if="current <= total && current >= 0">
-        <span text-primary>{{ current }}</span>
-        <span op50>/</span>
-      </template>
+      <span text-primary>{{ current }}</span>
+      <span op50>/</span>
       <span op50>{{ total }}</span>
     </div>
     <div
       relative flex-auto h5 flex="~"
-      @dblclick="current = CLICKS_MAX"
+      @dblclick="current = 999999"
     >
       <div
         v-for="i of range" :key="i"


### PR DESCRIPTION
Previously, when double-clicking the bar, the URL will become something like `http://localhost:3031/presenter/5?clicks=99999`.

So <kbd>Left</kbd> can only minus the `clicks` num by one, and actually has no effect. Because the new clicks num may be `99998`, which is still a very large num.

This PR sets `clicks` to `total` when double-clicking the clicks bar, and prevents setting `usePrimaryClicks().click` to be greater than `total`.

This PR also prevents the slider to be focused. Otherwise, the <kbd>Right</kbd> will try to add the range input's value, instead of going to the next slide.