### PR TITLE
fix: double click operation in clicks slider

### DIFF
--- a/packages/client/internals/ClicksSlider.vue
+++ b/packages/client/internals/ClicksSlider.vue
@@ -39,7 +39,7 @@ function onMousedown() {
     </div>
     <div
       relative flex-auto h5 flex="~"
-      @dblclick="current = 999999"
+      @dblclick="current = clicksContext.total"
     >
       <div
         v-for="i of range" :key="i"


### PR DESCRIPTION
This PR reverts a change that is used to debug. I forgot to revert this debug change in #1356