### PR TITLE
fix: hide scroll bar in Shiki magic move

### DIFF
--- a/packages/client/builtin/ShikiMagicMove.vue
+++ b/packages/client/builtin/ShikiMagicMove.vue
@@ -41,7 +41,7 @@ onMounted(() => {
 <template>
   <div class="slidev-code-wrapper slidev-code-magic-move">
     <ShikiMagicMovePrecompiled
-      class="slidev-code relative shiki"
+      class="slidev-code relative shiki overflow-visible"
       :steps="steps"
       :step="index"
       :options="{ globalScale: scale }"


### PR DESCRIPTION
Previously, there was a white scroll bar shown when magic moving, and hidden when animation finished. This PR hides this white scroll bar.