### PR TITLE
refactor!: separating nav.ts for better scoping

### DIFF
--- a/packages/client/builtin/Toc.vue
+++ b/packages/client/builtin/Toc.vue
@@ -74,7 +74,7 @@ function filterOnlySiblings(tree: TocItem[]): TocItem[] {
 }
 
 const toc = computed(() => {
-  const tree = $slidev?.nav.tree
+  const tree = $slidev?.nav.tocTree
   if (!tree)
     return []
   let tocTree = filterTreeDepth(tree)

--- a/packages/client/composables/useContext.ts
+++ b/packages/client/composables/useContext.ts
@@ -5,7 +5,7 @@ import * as nav from '../logic/nav'
 
 export function useContext(): SlidevContext {
   return {
-    nav: { ...nav },
+    nav: { ...nav }, // Convert the module to a plain object
     configs,
     themeConfigs: computed(() => configs.themeConfig),
   }

--- a/packages/client/composables/useContext.ts
+++ b/packages/client/composables/useContext.ts
@@ -5,7 +5,7 @@ import * as nav from '../logic/nav'
 
 export function useContext(): SlidevContext {
   return {
-    nav: { ...nav }, //
+    nav: { ...nav },
     configs,
     themeConfigs: computed(() => configs.themeConfig),
   }

--- a/packages/client/composables/useSwipeControls.ts
+++ b/packages/client/composables/useSwipeControls.ts
@@ -1,0 +1,40 @@
+import type { Ref } from 'vue'
+import { ref } from 'vue'
+import { timestamp, usePointerSwipe } from '@vueuse/core'
+import { isDrawing } from '../logic/drawings'
+import { next, nextSlide, prev, prevSlide } from '../logic/nav'
+
+export function useSwipeControls(root: Ref<HTMLElement | undefined>) {
+  const swipeBegin = ref(0)
+  const { direction, distanceX, distanceY } = usePointerSwipe(root, {
+    pointerTypes: ['touch'],
+    onSwipeStart() {
+      if (isDrawing.value)
+        return
+      swipeBegin.value = timestamp()
+    },
+    onSwipeEnd() {
+      if (!swipeBegin.value)
+        return
+      if (isDrawing.value)
+        return
+
+      const x = Math.abs(distanceX.value)
+      const y = Math.abs(distanceY.value)
+      if (x / window.innerWidth > 0.3 || x > 75) {
+        if (direction.value === 'left')
+          next()
+
+        else
+          prev()
+      }
+      else if (y / window.innerHeight > 0.4 || y > 200) {
+        if (direction.value === 'down')
+          prevSlide()
+
+        else
+          nextSlide()
+      }
+    },
+  })
+}

--- a/packages/client/composables/useTocTree.ts
+++ b/packages/client/composables/useTocTree.ts
@@ -1,0 +1,63 @@
+import type { SlideRoute, TocItem } from '@slidev/types'
+import type { ComputedRef, Ref } from 'vue'
+import { computed } from 'vue'
+import { currentSlideNo, currentSlideRoute, getSlidePath } from '../logic/nav'
+
+function addToTree(tree: TocItem[], route: SlideRoute, level = 1) {
+  const titleLevel = route.meta?.slide?.level
+  if (titleLevel && titleLevel > level && tree.length > 0) {
+    addToTree(tree[tree.length - 1].children, route, level + 1)
+  }
+  else {
+    tree.push({
+      no: route.no,
+      children: [],
+      level,
+      path: getSlidePath(route.meta.slide?.frontmatter?.routeAlias ?? route.no),
+      hideInToc: Boolean(route.meta?.slide?.frontmatter?.hideInToc),
+      title: route.meta?.slide?.title,
+    })
+  }
+}
+
+function getTreeWithActiveStatuses(
+  tree: TocItem[],
+  currentRoute?: SlideRoute,
+  hasActiveParent = false,
+  parent?: TocItem,
+): TocItem[] {
+  return tree.map((item: TocItem) => {
+    const clone = {
+      ...item,
+      active: item.no === currentSlideNo.value,
+      hasActiveParent,
+    }
+    if (clone.children.length > 0)
+      clone.children = getTreeWithActiveStatuses(clone.children, currentRoute, clone.active || clone.hasActiveParent, clone)
+    if (parent && (clone.active || clone.activeParent))
+      parent.activeParent = true
+    return clone
+  })
+}
+
+function filterTree(tree: TocItem[], level = 1): TocItem[] {
+  return tree
+    .filter((item: TocItem) => !item.hideInToc)
+    .map((item: TocItem) => ({
+      ...item,
+      children: filterTree(item.children, level + 1),
+    }))
+}
+
+export function useTocTree(slides: Ref<SlideRoute[]>): ComputedRef<TocItem[]> {
+  const rawTree = computed(() => slides.value
+    .filter((route: SlideRoute) => route.meta?.slide?.title)
+    .reduce((acc: TocItem[], route: SlideRoute) => {
+      addToTree(acc, route)
+      return acc
+    }, []))
+
+  const treeWithActiveStatuses = computed(() => getTreeWithActiveStatuses(rawTree.value, currentSlideRoute.value))
+
+  return computed(() => filterTree(treeWithActiveStatuses.value))
+}

--- a/packages/client/internals/NavControls.vue
+++ b/packages/client/internals/NavControls.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import { computed, ref, shallowRef } from 'vue'
 import { isColorSchemaConfigured, isDark, toggleDark } from '../logic/dark'
-import { currentSlideNo, downloadPDF, getSlidePath, hasNext, hasPrev, isEmbedded, isPresenter, next, presenterPassword, prev, showPresenter, total } from '../logic/nav'
+import { downloadPDF } from '../utils'
+import { currentRoute, currentSlideNo, getSlidePath, hasNext, hasPrev, isEmbedded, isPresenter, isPresenterAvailable, next, prev, total } from '../logic/nav'
 import { activeElement, breakpoints, fullscreen, presenterLayout, showEditor, showInfoDialog, showPresenterCursor, toggleOverview, togglePresenterLayout } from '../state'
 import { brush, drawingEnabled } from '../logic/drawings'
 import { configs } from '../env'
@@ -21,6 +22,7 @@ const props = defineProps({
 const md = breakpoints.smaller('md')
 const { isFullscreen, toggle: toggleFullscreen } = fullscreen
 
+const presenterPassword = computed(() => currentRoute.value.query.password)
 const query = computed(() => presenterPassword.value ? `?password=${presenterPassword.value}` : '')
 const presenterLink = computed(() => `${getSlidePath(currentSlideNo.value, true)}${query.value}`)
 const nonPresenterLink = computed(() => `${getSlidePath(currentSlideNo.value, false)}${query.value}`)
@@ -107,7 +109,7 @@ if (__SLIDEV_FEATURE_DRAWINGS__)
         <RouterLink v-if="isPresenter" :to="nonPresenterLink" class="slidev-icon-btn" title="Play Mode">
           <carbon:presentation-file />
         </RouterLink>
-        <RouterLink v-if="__SLIDEV_FEATURE_PRESENTER__ && showPresenter" :to="presenterLink" class="slidev-icon-btn" title="Presenter Mode">
+        <RouterLink v-if="__SLIDEV_FEATURE_PRESENTER__ && isPresenterAvailable" :to="presenterLink" class="slidev-icon-btn" title="Presenter Mode">
           <carbon:user-speaker />
         </RouterLink>
 

--- a/packages/client/internals/PrintContainer.vue
+++ b/packages/client/internals/PrintContainer.vue
@@ -4,7 +4,7 @@ import { computed } from 'vue'
 import { provideLocal } from '@vueuse/core'
 import { configs, slideAspect, slideWidth } from '../env'
 import { injectionSlideScale } from '../constants'
-import { route as currentRoute, slides } from '../logic/nav'
+import { currentRoute, slides } from '../logic/nav'
 import PrintSlide from './PrintSlide.vue'
 
 const props = defineProps<{

--- a/packages/client/internals/PrintSlideClick.vue
+++ b/packages/client/internals/PrintSlideClick.vue
@@ -4,7 +4,7 @@ import { provideLocal } from '@vueuse/core'
 import { injectionSlidevContext } from '../constants'
 import { configs, slideHeight, slideWidth } from '../env'
 import { getSlideClass } from '../utils'
-import type { SlidevContextNav } from '../modules/context'
+import type { SlidevContextNav } from '../composables/useNav'
 import SlideWrapper from './SlideWrapper'
 
 import GlobalTop from '#slidev/global-components/top'

--- a/packages/client/internals/SlidesShow.vue
+++ b/packages/client/internals/SlidesShow.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { TransitionGroup, computed, shallowRef, watch } from 'vue'
-import { currentSlideRoute, isPresenter, nextRoute, slides, transition } from '../logic/nav'
+import { currentSlideRoute, currentTransition, isPresenter, nextRoute, slides } from '../logic/nav'
 import { getSlideClass } from '../utils'
 import { useViewTransition } from '../composables/useViewTransition'
 import { skipTransition } from '../composables/hmr'
@@ -45,7 +45,7 @@ function onAfterLeave() {
   <!-- Slides -->
   <component
     :is="hasViewTransition ? 'div' : TransitionGroup"
-    v-bind="skipTransition ? {} : transition"
+    v-bind="skipTransition ? {} : currentTransition"
     id="slideshow"
     tag="div"
     @after-leave="onAfterLeave"

--- a/packages/client/logic/nav-state.ts
+++ b/packages/client/logic/nav-state.ts
@@ -1,0 +1,20 @@
+import { computed } from 'vue'
+import { logicOr } from '@vueuse/math'
+import { configs } from '../env'
+import { router } from '../routes'
+import { getSlide, slides } from './slides'
+
+export const currentRoute = computed(() => router.currentRoute.value)
+
+export const isPrintMode = computed(() => currentRoute.value.query.print !== undefined)
+export const isPrintWithClicks = computed(() => currentRoute.value.query.print === 'clicks')
+export const isEmbedded = computed(() => currentRoute.value.query.embedded !== undefined)
+export const isPlaying = computed(() => currentRoute.value.name === 'play')
+export const isPresenter = computed(() => currentRoute.value.name === 'presenter')
+export const isNotesViewer = computed(() => currentRoute.value.name === 'notes')
+export const isPresenterAvailable = computed(() => !isPresenter.value && (!configs.remote || currentRoute.value.query.password === configs.remote))
+
+export const hasPrimarySlide = logicOr(isPlaying, isPresenter)
+
+export const currentSlideNo = computed(() => hasPrimarySlide.value ? getSlide(currentRoute.value.params.no as string)?.no ?? 1 : 1)
+export const currentSlideRoute = computed(() => slides.value[currentSlideNo.value - 1])

--- a/packages/client/logic/nav.ts
+++ b/packages/client/logic/nav.ts
@@ -30,7 +30,7 @@ export const queryClicks = computed({
 export const {
   slides,
   total,
-  path,
+  currentPath,
   currentSlideNo,
   currentPage,
   currentLayout,

--- a/packages/client/logic/nav.ts
+++ b/packages/client/logic/nav.ts
@@ -59,8 +59,8 @@ export const {
   router,
 )
 
-watch([total, currentSlideNo], async () => {
-  if (hasPrimarySlide.value && !getSlide(currentSlideNo.value)) {
+watch([total, route], async () => {
+  if (hasPrimarySlide.value && !getSlide(route.value.params.no as string)) {
     // The current slide may has been removed. Redirect to the last slide.
     await goLast()
   }

--- a/packages/client/logic/nav.ts
+++ b/packages/client/logic/nav.ts
@@ -1,53 +1,16 @@
-import type { Ref, TransitionGroupProps } from 'vue'
-import { computed, ref, watch } from 'vue'
-import type { SlideRoute, TocItem } from '@slidev/types'
-import { timestamp, usePointerSwipe } from '@vueuse/core'
-import { logicOr } from '@vueuse/math'
+import { computed, watch } from 'vue'
 import { router } from '../routes'
-import { configs } from '../env'
-import { skipTransition } from '../composables/hmr'
 import { usePrimaryClicks } from '../composables/useClicks'
 import { CLICKS_MAX } from '../constants'
 import { useNavBase } from '../composables/useNav'
 import { useRouteQuery } from './route'
-import { isDrawing } from './drawings'
-import { slides } from '#slidev/slides'
+import { currentSlideRoute, hasPrimarySlide } from './nav-state'
+import { getSlide } from './slides'
 
-export { slides, router }
+export * from './slides'
+export * from './nav-state'
 
-export const route = computed(() => router.currentRoute.value)
-
-export const isPrintMode = computed(() => route.value.query.print !== undefined)
-export const isPrintWithClicks = computed(() => route.value.query.print === 'clicks')
-export const isEmbedded = computed(() => route.value.query.embedded !== undefined)
-export const isPlaying = computed(() => route.value.name === 'play')
-export const isPresenter = computed(() => route.value.name === 'presenter')
-export const isNotesViewer = computed(() => route.value.name === 'notes')
-export const presenterPassword = computed(() => route.value.query.password)
-export const showPresenter = computed(() => !isPresenter.value && (!configs.remote || presenterPassword.value === configs.remote))
-export const hasPrimarySlide = logicOr(isPlaying, isPresenter)
-
-export const currentSlideNo = computed(() => hasPrimarySlide.value ? getSlide(route.value.params.no as string)?.no ?? 1 : 1)
-export const currentSlideRoute = computed(() => slides.value[currentSlideNo.value - 1])
 export const clicksContext = computed(() => usePrimaryClicks(currentSlideRoute.value))
-
-export const {
-  total,
-  path,
-  currentPage,
-  currentLayout,
-  nextRoute,
-  prevRoute,
-  clicks,
-  clicksTotal,
-  hasNext,
-  hasPrev,
-  downloadPDF,
-  openInEditor,
-} = useNavBase(currentSlideRoute, clicksContext)
-
-export const navDirection = ref(0)
-export const clicksDirection = ref(0)
 
 const queryClicksRaw = useRouteQuery('clicks', '0')
 export const queryClicks = computed({
@@ -64,206 +27,41 @@ export const queryClicks = computed({
   },
 })
 
-export const rawTree = computed(() => slides.value
-  .filter((route: SlideRoute) => route.meta?.slide?.title)
-  .reduce((acc: TocItem[], route: SlideRoute) => {
-    addToTree(acc, route)
-    return acc
-  }, []))
-export const treeWithActiveStatuses = computed(() => getTreeWithActiveStatuses(rawTree.value, currentSlideRoute.value))
-export const tree = computed(() => filterTree(treeWithActiveStatuses.value))
+export const {
+  slides,
+  total,
+  path,
+  currentSlideNo,
+  currentPage,
+  currentLayout,
+  currentTransition,
+  clicksDirection,
+  nextRoute,
+  prevRoute,
+  clicks,
+  clicksTotal,
+  hasNext,
+  hasPrev,
+  tocTree,
+  navDirection,
+  openInEditor,
+  next,
+  prev,
+  go,
+  goLast,
+  goFirst,
+  nextSlide,
+  prevSlide,
+} = useNavBase(
+  currentSlideRoute,
+  clicksContext,
+  queryClicks,
+  router,
+)
 
-export const transition = computed(() => getCurrentTransition(navDirection.value, currentSlideRoute.value, prevRoute.value))
-
-watch(currentSlideRoute, (next, prev) => {
-  navDirection.value = next.no - prev.no
-})
-
-watch([total, route], async () => {
-  if (hasPrimarySlide.value && !getSlide(route.value.params.no as string)) {
+watch([total, currentSlideNo], async () => {
+  if (hasPrimarySlide.value && !getSlide(currentSlideNo.value)) {
     // The current slide may has been removed. Redirect to the last slide.
     await goLast()
   }
 }, { flush: 'post', immediate: true })
-
-export async function next() {
-  clicksDirection.value = 1
-  if (clicksTotal.value <= queryClicks.value)
-    await nextSlide()
-  else
-    queryClicks.value += 1
-}
-
-export async function prev() {
-  clicksDirection.value = -1
-  if (queryClicks.value <= 0)
-    await prevSlide()
-  else
-    queryClicks.value -= 1
-}
-
-export function getSlide(no: number | string) {
-  return slides.value.find(
-    s => (s.no === +no || s.meta.slide?.frontmatter.routeAlias === no),
-  )
-}
-
-export function getSlidePath(route: SlideRoute | number | string, presenter = isPresenter.value) {
-  if (typeof route === 'number' || typeof route === 'string')
-    route = getSlide(route)!
-  const no = route.meta.slide?.frontmatter.routeAlias ?? route.no
-  return presenter ? `/presenter/${no}` : `/${no}`
-}
-
-export async function nextSlide() {
-  clicksDirection.value = 1
-  if (currentSlideNo.value < slides.value.length)
-    await go(currentSlideNo.value + 1)
-}
-
-export async function prevSlide(lastClicks = true) {
-  clicksDirection.value = -1
-  const next = Math.max(1, currentSlideNo.value - 1)
-  await go(next)
-  if (lastClicks && clicksTotal.value)
-    router.replace({ query: { ...route.value.query, clicks: clicksTotal.value } })
-}
-
-export function goFirst() {
-  return go(1)
-}
-
-export function goLast() {
-  return go(total.value)
-}
-
-export function go(page: number | string, clicks?: number) {
-  skipTransition.value = false
-  return router.push({ path: getSlidePath(page), query: { ...route.value.query, clicks } })
-}
-
-export function useSwipeControls(root: Ref<HTMLElement | undefined>) {
-  const swipeBegin = ref(0)
-  const { direction, distanceX, distanceY } = usePointerSwipe(root, {
-    pointerTypes: ['touch'],
-    onSwipeStart() {
-      if (isDrawing.value)
-        return
-      swipeBegin.value = timestamp()
-    },
-    onSwipeEnd() {
-      if (!swipeBegin.value)
-        return
-      if (isDrawing.value)
-        return
-
-      const x = Math.abs(distanceX.value)
-      const y = Math.abs(distanceY.value)
-      if (x / window.innerWidth > 0.3 || x > 75) {
-        if (direction.value === 'left')
-          next()
-        else
-          prev()
-      }
-      else if (y / window.innerHeight > 0.4 || y > 200) {
-        if (direction.value === 'down')
-          prevSlide()
-        else
-          nextSlide()
-      }
-    },
-  })
-}
-
-export function addToTree(tree: TocItem[], route: SlideRoute, level = 1) {
-  const titleLevel = route.meta?.slide?.level
-  if (titleLevel && titleLevel > level && tree.length > 0) {
-    addToTree(tree[tree.length - 1].children, route, level + 1)
-  }
-  else {
-    tree.push({
-      no: route.no,
-      children: [],
-      level,
-      path: getSlidePath(route.meta.slide?.frontmatter?.routeAlias ?? route.no),
-      hideInToc: Boolean(route.meta?.slide?.frontmatter?.hideInToc),
-      title: route.meta?.slide?.title,
-    })
-  }
-}
-
-export function getTreeWithActiveStatuses(
-  tree: TocItem[],
-  currentRoute?: SlideRoute,
-  hasActiveParent = false,
-  parent?: TocItem,
-): TocItem[] {
-  return tree.map((item: TocItem) => {
-    const clone = {
-      ...item,
-      active: item.no === currentSlideNo.value,
-      hasActiveParent,
-    }
-    if (clone.children.length > 0)
-      clone.children = getTreeWithActiveStatuses(clone.children, currentRoute, clone.active || clone.hasActiveParent, clone)
-    if (parent && (clone.active || clone.activeParent))
-      parent.activeParent = true
-    return clone
-  })
-}
-
-export function filterTree(tree: TocItem[], level = 1): TocItem[] {
-  return tree
-    .filter((item: TocItem) => !item.hideInToc)
-    .map((item: TocItem) => ({
-      ...item,
-      children: filterTree(item.children, level + 1),
-    }))
-}
-
-const transitionResolveMap: Record<string, string | undefined> = {
-  'slide-left': 'slide-left | slide-right',
-  'slide-right': 'slide-right | slide-left',
-  'slide-up': 'slide-up | slide-down',
-  'slide-down': 'slide-down | slide-up',
-}
-
-export function resolveTransition(transition?: string | TransitionGroupProps, isBackward = false): TransitionGroupProps | undefined {
-  if (!transition)
-    return undefined
-  if (typeof transition === 'string') {
-    transition = {
-      name: transition,
-    }
-  }
-
-  if (!transition.name)
-    return undefined
-
-  let name = transition.name.includes('|')
-    ? transition.name
-    : (transitionResolveMap[transition.name] || transition.name)
-
-  if (name.includes('|')) {
-    const [forward, backward] = name.split('|').map(i => i.trim())
-    name = isBackward ? backward : forward
-  }
-
-  if (!name)
-    return undefined
-
-  return {
-    ...transition,
-    name,
-  }
-}
-
-export function getCurrentTransition(direction: number, currentRoute?: SlideRoute, prevRoute?: SlideRoute) {
-  let transition = direction > 0
-    ? prevRoute?.meta?.transition
-    : currentRoute?.meta?.transition
-  if (!transition)
-    transition = configs.transition
-
-  return resolveTransition(transition, direction < 0)
-}

--- a/packages/client/logic/nav.ts
+++ b/packages/client/logic/nav.ts
@@ -4,7 +4,7 @@ import { usePrimaryClicks } from '../composables/useClicks'
 import { CLICKS_MAX } from '../constants'
 import { useNavBase } from '../composables/useNav'
 import { useRouteQuery } from './route'
-import { currentSlideRoute, hasPrimarySlide } from './nav-state'
+import { currentRoute, currentSlideRoute, hasPrimarySlide } from './nav-state'
 import { getSlide } from './slides'
 
 export * from './slides'
@@ -59,9 +59,13 @@ export const {
   router,
 )
 
-watch([total, route], async () => {
-  if (hasPrimarySlide.value && !getSlide(route.value.params.no as string)) {
-    // The current slide may has been removed. Redirect to the last slide.
-    await goLast()
-  }
-}, { flush: 'post', immediate: true })
+watch(
+  [total, currentRoute],
+  async () => {
+    if (hasPrimarySlide.value && !getSlide(currentRoute.value.params.no as string)) {
+      // The current slide may has been removed. Redirect to the last slide.
+      await goLast()
+    }
+  },
+  { flush: 'post', immediate: true },
+)

--- a/packages/client/logic/slides.ts
+++ b/packages/client/logic/slides.ts
@@ -1,0 +1,19 @@
+import type { SlideRoute } from '@slidev/types'
+import { router } from '../routes'
+import { isPresenter } from './nav-state'
+import { slides } from '#slidev/slides'
+
+export { slides, router }
+
+export function getSlide(no: number | string) {
+  return slides.value.find(
+    s => (s.no === +no || s.meta.slide?.frontmatter.routeAlias === no),
+  )
+}
+
+export function getSlidePath(route: SlideRoute | number | string, presenter = isPresenter.value) {
+  if (typeof route === 'number' || typeof route === 'string')
+    route = getSlide(route)!
+  const no = route.meta.slide?.frontmatter.routeAlias ?? route.no
+  return presenter ? `/presenter/${no}` : `/${no}`
+}

--- a/packages/client/logic/transition.ts
+++ b/packages/client/logic/transition.ts
@@ -1,0 +1,50 @@
+import type { SlideRoute } from '@slidev/types'
+import type { TransitionGroupProps } from 'vue'
+import { configs } from '../env'
+
+const transitionResolveMap: Record<string, string | undefined> = {
+  'slide-left': 'slide-left | slide-right',
+  'slide-right': 'slide-right | slide-left',
+  'slide-up': 'slide-up | slide-down',
+  'slide-down': 'slide-down | slide-up',
+}
+
+export function resolveTransition(transition?: string | TransitionGroupProps, isBackward = false): TransitionGroupProps | undefined {
+  if (!transition)
+    return undefined
+  if (typeof transition === 'string') {
+    transition = {
+      name: transition,
+    }
+  }
+
+  if (!transition.name)
+    return undefined
+
+  let name = transition.name.includes('|')
+    ? transition.name
+    : (transitionResolveMap[transition.name] || transition.name)
+
+  if (name.includes('|')) {
+    const [forward, backward] = name.split('|').map(i => i.trim())
+    name = isBackward ? backward : forward
+  }
+
+  if (!name)
+    return undefined
+
+  return {
+    ...transition,
+    name,
+  }
+}
+
+export function getCurrentTransition(direction: number, currentRoute?: SlideRoute, prevRoute?: SlideRoute) {
+  let transition = direction > 0
+    ? prevRoute?.meta?.transition
+    : currentRoute?.meta?.transition
+  if (!transition)
+    transition = configs.transition
+
+  return resolveTransition(transition, direction < 0)
+}

--- a/packages/client/modules/context.ts
+++ b/packages/client/modules/context.ts
@@ -6,36 +6,7 @@ import * as nav from '../logic/nav'
 import { isDark } from '../logic/dark'
 import { injectionCurrentPage, injectionRenderContext, injectionSlidevContext } from '../constants'
 import { useContext } from '../composables/useContext'
-
-export type SlidevContextNavKey =
-  | 'slides'
-  | 'total'
-  | 'path'
-  | 'currentSlideNo'
-  | 'currentPage'
-  | 'currentSlideRoute'
-  | 'currentLayout'
-  | 'nextRoute'
-  | 'prevRoute'
-  | 'clicksContext'
-  | 'clicks'
-  | 'clicksTotal'
-  | 'hasNext'
-  | 'hasPrev'
-  | 'rawTree'
-  | 'treeWithActiveStatuses'
-  | 'tree'
-  | 'next'
-  | 'prev'
-  | 'nextSlide'
-  | 'prevSlide'
-  | 'goFirst'
-  | 'goLast'
-  | 'go'
-  | 'downloadPDF'
-  | 'openInEditor'
-
-export type SlidevContextNav = Pick<typeof nav, SlidevContextNavKey>
+import type { SlidevContextNav } from '../composables/useNav'
 
 export interface SlidevContext {
   nav: SlidevContextNav

--- a/packages/client/pages/play.vue
+++ b/packages/client/pages/play.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import { computed, ref, shallowRef } from 'vue'
 import { isEditorVertical, isScreenVertical, showEditor, slideScale, windowSize } from '../state'
-import { isEmbedded, isPrintMode, next, prev, useSwipeControls } from '../logic/nav'
+import { isEmbedded, isPrintMode, next, prev } from '../logic/nav'
+import { useSwipeControls } from '../composables/useSwipeControls'
 import { isDrawing } from '../logic/drawings'
 import { registerShortcuts } from '../logic/shortcuts'
 import { configs } from '../env'

--- a/packages/client/pages/presenter.vue
+++ b/packages/client/pages/presenter.vue
@@ -286,4 +286,4 @@ onMounted(() => {
 .grid-section.bottom {
   grid-area: bottom;
 }
-</style>../composables/useSwipeControls
+</style>

--- a/packages/client/pages/presenter.vue
+++ b/packages/client/pages/presenter.vue
@@ -2,7 +2,8 @@
 import { useHead } from '@unhead/vue'
 import { computed, onMounted, reactive, ref, shallowRef, watch } from 'vue'
 import { useMouse, useWindowFocus } from '@vueuse/core'
-import { clicksContext, currentSlideNo, currentSlideRoute, hasNext, nextRoute, queryClicks, slides, total, useSwipeControls } from '../logic/nav'
+import { clicksContext, currentSlideNo, currentSlideRoute, hasNext, nextRoute, queryClicks, slides, total } from '../logic/nav'
+import { useSwipeControls } from '../composables/useSwipeControls'
 import { decreasePresenterFontSize, increasePresenterFontSize, presenterLayout, presenterNotesFontSize, showEditor, showOverview, showPresenterCursor } from '../state'
 import { configs } from '../env'
 import { sharedState } from '../state/shared'
@@ -285,4 +286,4 @@ onMounted(() => {
 .grid-section.bottom {
   grid-area: bottom;
 }
-</style>
+</style>../composables/useSwipeControls

--- a/packages/client/setup/root.ts
+++ b/packages/client/setup/root.ts
@@ -57,7 +57,6 @@ export default function setupRoot() {
   onPatch((state) => {
     if (!hasPrimarySlide.value)
       return
-    console.warn('patch', state.lastUpdate?.type)
     if (state.lastUpdate?.type === 'presenter' && (+state.page !== +currentSlideNo.value || +clicksContext.value.current !== +state.clicks)) {
       skipTransition.value = false
       router.replace({

--- a/packages/client/setup/shortcuts.ts
+++ b/packages/client/setup/shortcuts.ts
@@ -1,7 +1,8 @@
 /* __imports__ */
 import { and, not, or } from '@vueuse/math'
 import type { NavOperations, ShortcutOptions } from '@slidev/types'
-import { downloadPDF, go, goFirst, goLast, next, nextSlide, prev, prevSlide } from '../logic/nav'
+import { downloadPDF } from '../utils'
+import { go, goFirst, goLast, next, nextSlide, prev, prevSlide } from '../logic/nav'
 import { toggleDark } from '../logic/dark'
 import { magicKeys, showGotoDialog, showOverview, toggleOverview } from '../state'
 import { drawingEnabled } from '../logic/drawings'

--- a/packages/client/utils.ts
+++ b/packages/client/utils.ts
@@ -1,4 +1,5 @@
 import type { SlideRoute } from '@slidev/types'
+import { configs } from './env'
 
 export function getSlideClass(route?: SlideRoute, extra = '') {
   const classes = ['slidev-page', extra]
@@ -8,4 +9,16 @@ export function getSlideClass(route?: SlideRoute, extra = '') {
     classes.push(`slidev-page-${no}`)
 
   return classes.filter(Boolean).join(' ')
+}
+
+export async function downloadPDF() {
+  const { saveAs } = await import('file-saver')
+  saveAs(
+    typeof configs.download === 'string'
+      ? configs.download
+      : configs.exportFilename
+        ? `${configs.exportFilename}.pdf`
+        : `${import.meta.env.BASE_URL}slidev-exported.pdf`,
+    `${configs.title}.pdf`,
+  )
 }

--- a/shim.d.ts
+++ b/shim.d.ts
@@ -11,7 +11,7 @@ declare global {
   const __SLIDEV_HAS_SERVER__: boolean
 }
 
-declare module 'vue' {
+declare module '@vue/runtime-core' {
   interface ComponentCustomProperties {
     __DEV__: boolean
     __SLIDEV_HASH_ROUTE__: boolean


### PR DESCRIPTION
Move most of the logics out of `logic/nav.ts` with became a bit bloated overtime. This would help better maintainability in the long term

This can be a breaking change if you are relying on the exported props from `nav.ts` - basically renaming things, please refer to the types to migrate