### PR TITLE
ci: fix production smoke test

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -66,16 +66,12 @@ jobs:
         if: ${{ ! matrix.hoist }}
 
       - name: Install project (npm, pnpm)
-        run: |
-          ${{ matrix.pm }} i
-          ${{ matrix.pm }} i ../slidev-pkgs/cli.tgz playwright-chromium
+        run: ${{ matrix.pm }} i ../slidev-pkgs/cli.tgz playwright-chromium
         working-directory: ../temp/slidev-project
         if: ${{ matrix.pm != 'yarn' }}
 
       - name: Install project (yarn)
-        run: |
-          yarn
-          yarn add ../slidev-pkgs/cli.tgz playwright-chromium
+        run: yarn add ../slidev-pkgs/cli.tgz playwright-chromium
         working-directory: ../temp/slidev-project
         if: ${{ matrix.pm == 'yarn' }}
 


### PR DESCRIPTION
Previously, the smoke test CI would fail when the current version hasn't been published yet.