### PR TITLE
refactor: extract `useSlideInfo`

### DIFF
--- a/packages/client/composables/useSlideInfo.ts
+++ b/packages/client/composables/useSlideInfo.ts
@@ -9,14 +9,14 @@ export interface UseSlideInfo {
   update: (data: SlidePatch) => Promise<SlideInfo | void>
 }
 
-export function useSlideInfo(id: number | undefined): UseSlideInfo {
-  if (id == null) {
+export function useSlideInfo(no: number): UseSlideInfo {
+  if (no == null) {
     return {
       info: ref() as Ref<SlideInfo | undefined>,
       update: async () => {},
     }
   }
-  const url = `/@slidev/slide/${id}.json`
+  const url = `/@slidev/slide/${no}.json`
   const { data: info, execute } = useFetch(url).json().get()
 
   execute()
@@ -37,11 +37,11 @@ export function useSlideInfo(id: number | undefined): UseSlideInfo {
 
   if (__DEV__) {
     import.meta.hot?.on('slidev:update-slide', (payload) => {
-      if (payload.id === id)
+      if (payload.no === no)
         info.value = payload.data
     })
     import.meta.hot?.on('slidev:update-note', (payload) => {
-      if (payload.id === id && info.value.note?.trim() !== payload.note?.trim())
+      if (payload.no === no && info.value.note?.trim() !== payload.note?.trim())
         info.value = { ...info.value, ...payload }
     })
   }
@@ -52,20 +52,17 @@ export function useSlideInfo(id: number | undefined): UseSlideInfo {
   }
 }
 
-const map: Record<string, UseSlideInfo> = {}
+const map: Record<number, UseSlideInfo> = {}
 
-export function useDynamicSlideInfo(id: MaybeRef<number | undefined>) {
-  function get(id: number | undefined) {
-    const i = `${id}`
-    if (!map[i])
-      map[i] = useSlideInfo(id)
-    return map[i]
+export function useDynamicSlideInfo(no: MaybeRef<number>) {
+  function get(no: number) {
+    return map[no] ??= useSlideInfo(no)
   }
 
   return {
-    info: computed(() => get(unref(id)).info.value),
+    info: computed(() => get(unref(no)).info.value),
     update: async (data: SlidePatch, newId?: number) => {
-      const info = get(newId ?? unref(id))
+      const info = get(newId ?? unref(no))
       const newData = await info.update(data)
       if (newData)
         info.info.value = newData

--- a/packages/client/internals/NoteEditable.vue
+++ b/packages/client/internals/NoteEditable.vue
@@ -1,14 +1,15 @@
 <script setup lang="ts">
 import type { PropType } from 'vue'
-import { nextTick, ref, watch, watchEffect } from 'vue'
+import { nextTick, ref, toRef, watch, watchEffect } from 'vue'
 import { ignorableWatch, onClickOutside, useVModel } from '@vueuse/core'
 import type { ClicksContext } from '@slidev/types'
-import { useDynamicSlideInfo } from '../logic/note'
+import { useDynamicSlideInfo } from '../composables/useSlideInfo'
 import NoteDisplay from './NoteDisplay.vue'
 
 const props = defineProps({
   no: {
     type: Number,
+    required: true,
   },
   class: {
     default: '',
@@ -38,7 +39,7 @@ const emit = defineEmits<{
 
 const editing = useVModel(props, 'editing', emit, { passive: true })
 
-const { info, update } = useDynamicSlideInfo(props.no)
+const { info, update } = useDynamicSlideInfo(toRef(props, 'no'))
 
 const note = ref('')
 let timer: any

--- a/packages/client/internals/NoteStatic.vue
+++ b/packages/client/internals/NoteStatic.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import type { ClicksContext } from '@slidev/types'
-import { useSlideInfo } from '../logic/note'
+import { useSlideInfo } from '../composables/useSlideInfo'
 import NoteDisplay from './NoteDisplay.vue'
 
 const props = defineProps<{
-  no?: number
+  no: number
   class?: string
   clicksContext?: ClicksContext
 }>()

--- a/packages/client/internals/SideEditor.vue
+++ b/packages/client/internals/SideEditor.vue
@@ -4,7 +4,7 @@ import { computed, nextTick, onMounted, ref, watch } from 'vue'
 import { activeElement, editorHeight, editorWidth, isInputting, showEditor, isEditorVertical as vertical } from '../state'
 import { useCodeMirror } from '../setup/codemirror'
 import { currentSlideNo, openInEditor } from '../logic/nav'
-import { useDynamicSlideInfo } from '../logic/note'
+import { useDynamicSlideInfo } from '../composables/useSlideInfo'
 import IconButton from './IconButton.vue'
 
 const props = defineProps<{

--- a/packages/slidev/node/plugins/loaders.ts
+++ b/packages/slidev/node/plugins/loaders.ts
@@ -179,7 +179,8 @@ export function createSlidesLoader(
           const b = newData.slides[i]
 
           if (
-            a.content.trim() === b.content.trim()
+            !hmrPages.has(i)
+            && a.content.trim() === b.content.trim()
             && a.title?.trim() === b.title?.trim()
             && equal(a.frontmatter, b.frontmatter)
             && Object.entries(a.snippetsUsed ?? {}).every(([file, oldContent]) => {
@@ -196,7 +197,7 @@ export function createSlidesLoader(
               ctx.server.hot.send(
                 'slidev:update-note',
                 {
-                  id: i,
+                  no: i + 1,
                   note: b!.note || '',
                   noteHTML: renderNote(b!.note || ''),
                 },
@@ -208,7 +209,7 @@ export function createSlidesLoader(
           ctx.server.hot.send(
             'slidev:update-slide',
             {
-              id: i,
+              no: i + 1,
               data: withRenderedNote(newData.slides[i]),
             },
           )

--- a/packages/types/src/hmr.ts
+++ b/packages/types/src/hmr.ts
@@ -3,11 +3,11 @@ import type { SlideInfo } from './types'
 declare module 'vite' {
   interface CustomEventMap {
     'slidev:update-slide': {
-      id: number
+      no: number
       data: SlideInfo
     }
     'slidev:update-note': {
-      id: number
+      no: number
       note: string
       noteHTML: string
     }


### PR DESCRIPTION
This PR contains a small refactor of `useSlideInfo`:

- move `useSlideInfo` and `useDynamicSlideInfo` to `composables` directory.
- always use `no` instead of `id` in `useSlideInfo`.
- skip unnecessary checks in `handleHotUpdate`. 