### PR TITLE
fix: types in shim files

### DIFF
--- a/packages/client/context.ts
+++ b/packages/client/context.ts
@@ -39,6 +39,8 @@ export function useSlideContext() {
   }
 }
 
+export type SlideContext = ReturnType<typeof useSlideContext>
+
 export function provideFrontmatter(frontmatter: Record<string, any>) {
   provideLocal(injectionFrontmatter, frontmatter)
 

--- a/packages/client/shim-vue.d.ts
+++ b/packages/client/shim-vue.d.ts
@@ -1,15 +1,13 @@
 declare module 'vue' {
   import type { UnwrapNestedRefs } from 'vue'
-  import type { SlidevContext } from './modules/context'
 
   interface ComponentCustomProperties {
-    $slidev: UnwrapNestedRefs<SlidevContext>
+    $slidev: UnwrapNestedRefs<import('./modules/context').SlidevContext>
   }
 }
 
 declare module 'vue-router' {
   import type { TransitionGroupProps } from 'vue'
-  import type { ClicksContext, SlideInfo } from '@slidev/types'
 
   interface RouteMeta {
     // inherited from frontmatter
@@ -21,7 +19,7 @@ declare module 'vue-router' {
     preload?: boolean
 
     // slide info
-    slide?: Omit<SlideInfo, 'source'> & {
+    slide?: Omit<import('@slidev/types').SlideInfo, 'source'> & {
       noteHTML: string
       filepath: string
       start: number
@@ -30,7 +28,7 @@ declare module 'vue-router' {
     }
 
     // private fields
-    __clicksContext: null | ClicksContext
+    __clicksContext: null | import('@slidev/types').ClicksContext
     __preloaded?: boolean
   }
 }

--- a/packages/client/shim-vue.d.ts
+++ b/packages/client/shim-vue.d.ts
@@ -1,8 +1,8 @@
 declare module 'vue' {
   import type { UnwrapNestedRefs } from 'vue'
 
-  interface ComponentCustomProperties {
-    $slidev: UnwrapNestedRefs<import('./modules/context').SlidevContext>
+  type SlideContext = import('./context').SlideContext
+  interface ComponentCustomProperties extends SlideContext {
   }
 }
 

--- a/packages/client/shim-vue.d.ts
+++ b/packages/client/shim-vue.d.ts
@@ -1,6 +1,4 @@
 declare module 'vue' {
-  import type { UnwrapNestedRefs } from 'vue'
-
   type SlideContext = import('./context').SlideContext
   interface ComponentCustomProperties extends SlideContext {
   }


### PR DESCRIPTION
For some unknown reason, **some** imports inside the `declare module` block are neither an error nor have any effect.

(As mentioned in https://discord.com/channels/851817370623410197/855378319515582474/1214524756217434166)

This PR fixes this by using dynamic imports instead.

This PR also completes `ComponentCustomProperties`.

However, though `shim-vue.d.ts` looks OK now, I am still wondering how this file takes effect on the user side -- there seems to be nowhere importing this file.