### PR TITLE
fix: id should not contain numbers

### DIFF
--- a/packages/client/logic/utils.ts
+++ b/packages/client/logic/utils.ts
@@ -26,7 +26,7 @@ export function useTimer() {
 
 export function makeId(length = 5) {
   const result = []
-  const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
+  const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'
   const charactersLength = characters.length
   for (let i = 0; i < length; i++)
     result.push(characters.charAt(Math.floor(Math.random() * charactersLength)))


### PR DESCRIPTION
in the Mermaid render, we use `makeId` to generate the DOM element's id, which cannot start with numbers. As a simpler fix, this PR removes numbers in id.