### PR TITLE
fix: slide formatter

### DIFF
--- a/packages/parser/src/core.ts
+++ b/packages/parser/src/core.ts
@@ -3,7 +3,7 @@ import { isObject, objectMap } from '@antfu/utils'
 import type { FrontmatterStyle, SlidevFeatureFlags, SlidevMarkdown, SlidevPreparserExtension, SourceSlideInfo } from '@slidev/types'
 
 export function stringify(data: SlidevMarkdown) {
-  return `${data.slides.map(stringifySlide).join('\n').trim()}\n`
+  return `${data.slides.map(stringifySlide).join('').trim()}\n`
 }
 
 export function stringifySlide(data: SourceSlideInfo, idx = 0) {
@@ -13,14 +13,15 @@ export function stringifySlide(data: SourceSlideInfo, idx = 0) {
 }
 
 export function prettifySlide(data: SourceSlideInfo) {
-  data.content = `\n${data.content.trim()}\n`
-  data.raw = Object.keys(data.frontmatter || {}).length
+  const trimed = data.content.trim()
+  data.content = trimed ? `\n${data.content.trim()}\n` : ''
+  data.raw = data.frontmatterRaw
     ? data.frontmatterStyle === 'yaml'
-      ? `\`\`\`yaml\n${YAML.dump(data.frontmatter).trim()}\n\`\`\`\n${data.content}`
-      : `---\n${YAML.dump(data.frontmatter).trim()}\n---\n${data.content}`
+      ? `\`\`\`yaml\n${data.frontmatterRaw.trim()}\n\`\`\`\n${data.content}`
+      : `---\n${data.frontmatterRaw.trim()}\n---\n${data.content}`
     : data.content
   if (data.note)
-    data.raw += `\n<!--\n${data.note.trim()}\n-->\n`
+    data.raw += `\n<!--\n${data.note.trim()}\n-->\n\n`
   else
     data.raw += '\n'
   return data

--- a/packages/parser/src/core.ts
+++ b/packages/parser/src/core.ts
@@ -1,15 +1,15 @@
 import YAML from 'js-yaml'
-import { isObject, objectMap } from '@antfu/utils'
+import { ensurePrefix, isObject, objectMap } from '@antfu/utils'
 import type { FrontmatterStyle, SlidevFeatureFlags, SlidevMarkdown, SlidevPreparserExtension, SourceSlideInfo } from '@slidev/types'
 
 export function stringify(data: SlidevMarkdown) {
-  return `${data.slides.map(stringifySlide).join('').trim()}\n`
+  return `${data.slides.map(stringifySlide).join('\n').trim()}\n`
 }
 
 export function stringifySlide(data: SourceSlideInfo, idx = 0) {
   return (data.raw.startsWith('---') || idx === 0)
     ? data.raw
-    : `---\n${data.raw.startsWith('\n') ? data.raw : `\n${data.raw}`}`
+    : `---\n${ensurePrefix('\n', data.raw)}`
 }
 
 export function prettifySlide(data: SourceSlideInfo) {
@@ -21,9 +21,7 @@ export function prettifySlide(data: SourceSlideInfo) {
       : `---\n${data.frontmatterRaw.trim()}\n---\n${data.content}`
     : data.content
   if (data.note)
-    data.raw += `\n<!--\n${data.note.trim()}\n-->\n\n`
-  else
-    data.raw += '\n'
+    data.raw += `\n<!--\n${data.note.trim()}\n-->\n`
   return data
 }
 


### PR DESCRIPTION
Previously, the built-in slide formatter will remove all the comments in the frontmatter. This PR uses `frontmatterRaw` instead.

The difference between the built-in formatter and the Prettier plugin is that the built-in formatter does nothing to the content of the slide.

Tested:
- Editing slide in the side editor
- `slidev format slides.md`