### PR TITLE
fix: slide exporter

### DIFF
--- a/packages/client/index.html
+++ b/packages/client/index.html
@@ -8,6 +8,7 @@
 <body>
   <div id="app"></div>
   <script type="module" src="__ENTRY__"></script>
+  <div id="mermaid-rendering-container"></div>
   <!-- body -->
 </body>
 </html>

--- a/packages/client/internals/SlideLoading.vue
+++ b/packages/client/internals/SlideLoading.vue
@@ -10,7 +10,7 @@ onMounted(() => {
 </script>
 
 <template>
-  <div class="h-full w-full flex items-center justify-center gap-2">
+  <div class="h-full w-full flex items-center justify-center gap-2 slidev-slide-loading">
     <template v-if="timeout">
       <div class="i-svg-spinners-90-ring-with-bg text-xl" />
       <div>Loading slide...</div>

--- a/packages/client/modules/mermaid.ts
+++ b/packages/client/modules/mermaid.ts
@@ -8,8 +8,10 @@ mermaid.startOnLoad = false
 mermaid.initialize({ startOnLoad: false })
 
 const cache = new Map<string, string>()
+let containerElement: Element | undefined
 
 export async function renderMermaid(lzEncoded: string, options: any) {
+  containerElement ??= document.getElementById('mermaid-rendering-container')!
   const key = lzEncoded + JSON.stringify(options)
   const _cache = cache.get(key)
   if (_cache)
@@ -22,7 +24,7 @@ export async function renderMermaid(lzEncoded: string, options: any) {
   })
   const code = lz.decompressFromBase64(lzEncoded)
   const id = makeId()
-  const { svg } = await mermaid.render(id, code)
+  const { svg } = await mermaid.render(id, code, containerElement)
   cache.set(key, svg)
   return svg
 }


### PR DESCRIPTION
This PR fixes:
- Wait for slides to be all loaded before printing to PDF.
- Wait for mermaid charts to be all loaded
- Hide Monaco's aria container to avoid the empty page at the end of the PDF.