### PR TITLE
fix: monaco types loader

### DIFF
--- a/packages/slidev/node/plugins/loaders.ts
+++ b/packages/slidev/node/plugins/loaders.ts
@@ -657,7 +657,7 @@ defineProps<{ no: number | string }>()`)
     }
 
     // Dependencies
-    const deps = data.config.monacoTypesAdditionalPackages
+    const deps = [...data.config.monacoTypesAdditionalPackages]
     if (data.config.monacoTypesSource === 'local')
       deps.push(...scanMonacoModules(data.slides.map(s => s.source.raw).join()))
 


### PR DESCRIPTION
This bug will silently change the config, which will make the page reload instead of HMR in the very first edit.