### PR TITLE
fix: allow hyphenated languages for magic move, e.g. angular-ts

### DIFF
--- a/packages/slidev/node/plugins/markdown.ts
+++ b/packages/slidev/node/plugins/markdown.ts
@@ -247,7 +247,7 @@ export function transformSlotSugar(md: string) {
 }
 
 const reMagicMoveBlock = /^````(?:md|markdown) magic-move(?:[ ]*(\{.*?\})?([^\n]*?))?\n([\s\S]+?)^````$/mg
-const reCodeBlock = /^```(\w+?)(?:\s*{([\d\w*,\|-]+)}\s*?({.*?})?(.*?))?\n([\s\S]+?)^```$/mg
+const reCodeBlock = /^```([\w'-]+?)(?:\s*{([\d\w*,\|-]+)}\s*?({.*?})?(.*?))?\n([\s\S]+?)^```$/mg
 
 /**
  * Transform magic-move code blocks

--- a/test/transform-magic-move.test.ts
+++ b/test/transform-magic-move.test.ts
@@ -46,3 +46,45 @@ Some text after
       "
     `)
 })
+
+it('hyphenated code language', async () => {
+  const code = `
+
+Some text before
+
+\`\`\`\`md magic-move
+\`\`\`angular-ts
+console.log('Hello, Angular!')
+\`\`\`
+\`\`\`angular-ts
+console.log('Hello, Angular #2!')
+\`\`\`
+\`\`\`\`
+
+Some text after
+  
+`
+  const shiki = await getHighlighter({
+    themes: ['nord'],
+    langs: ['angular-ts'],
+  })
+
+  expect(transformMagicMove(
+    code,
+    shiki,
+    {
+      theme: 'nord',
+    },
+  ))
+    .toMatchInlineSnapshot(`
+        "
+
+        Some text before
+
+        <ShikiMagicMove v-bind="{}" steps-lz="NobwRAxg9gJgpmAXJKA7AzlANnAdFqAcwAoByACTiwIBoACAQVUIFcsBDAJwEJSBKMDTAALdumFIwABwBeABgBCAMQCcCgMwAtAG6CwAFygBrOBiSgUqfaf2ToGbAiFQAZi/RxbiOUOgFOkgDEACIAHMEAohEqei5o+gDK+gCeOEg+YCbJkrKKqho6ALRyYAC+NOD21laSuHqu7p5IAOy+2FAByIERAMIRSkoALLHxSakI3kJZOfLKalrahQCMZRWW1V5gBIT1bh5eoW3+QaGhPXLBJUJxVmNpk5lw2ci5cwWLAEyrlfE2ksS7RpeJZLI4dIJhSLRAYjW4pe4ZaYvWb5BaFdTfdZ/ZCkQH7JBLD5gzpgbp9AbDa6jeETRFPGZ5eZFYblH5WbFgSjUKD0JisDg8PFNRBLdTEoIMdQKCJnWGJGnpKb05GM96FACsmKqHNxzj2wo+hxQxy6vX6Qzld1pSue0hRTMWADYtb8asgBHqgUgPipxV1IVEVDCqXDxorHrbXqiis0Xey3WAADqoIVedR0yP2tWhMoAXSEACMdl0PnB1INBnI3LFi6SYKF4HAVNWhPphHAALZwABy7C7klQHRgeg4zEk7GYbC4hX06Bd8DsaEwOHwRDIXNojEnArogQ+vA9IjEEmQADUlgwINolgBFAAaAFkc63jKY54gLNqE/Zl04wA18QePxwX9cJA0tBUHiRMBz0va97yfYo4w2WpUxaP1STNCkILDKDlRgi8r1vR9QmWZCOW2NDECNYCSUCU5zkuHCERtSRYKIhDSK+VksQTAFPUAkEMJCMDoSUZjrQjNjCPgkj0XIhNdX/fVgSJY0QMw8kLRDeVcIzaS4OIxCWTWL9Ng3Hkt35Lhd33KjRWEyVpVlHSrXDaD2NkxDNR4szJCUgDhXUUF1LorDtLAG5dJYqSzxkozSOdXzXU2Q9ArTNTaIhUSg3E1zIP0uLDM4wpY2S+NNmTKj1DFWKCOKuSc1KfMwCLIJS3LSsW0i2tAnrRtmxcPQ207Hs+wmMBB04YchFHWsJ2szgZznZqgA" :step-ranges='[[],[]]' />
+
+        Some text after
+          
+        "
+      `)
+})


### PR DESCRIPTION
the code languages 'angular-ts' and 'angular-html' are currently excluded from magic move as the code regexp doesn't handle the "-". This should fix it, also wrote a test for it. Let me know if any adjustments are needed.