### PR TITLE
docs: fix `v-click` example

### DIFF
--- a/docs/guide/animations.md
+++ b/docs/guide/animations.md
@@ -16,8 +16,7 @@ To apply "click animations" for elements, you can use the `v-click` directive or
 ```md
 <!-- Component usage:
      this will be invisible until you press "next" -->
-
-<v-click> Hello **World** </v-click>
+<v-click> Hello World! </v-click>
 
 <!-- Directive usage:
      this will be invisible until you press "next" the second time -->

--- a/docs/guide/animations.md
+++ b/docs/guide/animations.md
@@ -13,6 +13,8 @@ outline: deep
 
 To apply "click animations" for elements, you can use the `v-click` directive or `<v-click>` components
 
+<!-- eslint-skip -->
+
 ```md
 <!-- Component usage:
      this will be invisible until you press "next" -->


### PR DESCRIPTION
It seems that `<div> a **b** </div>` doesn't have the bold font now. (If I remember correctly, it had bold font at that time)