### PR TITLE
feat: Add guide to adding svg images

### DIFF
--- a/docs/guide/syntax.md
+++ b/docs/guide/syntax.md
@@ -365,6 +365,12 @@ For local assets, put them into the [`public` folder](/custom/directory-structur
 ![Local Image](/pic.png)
 ```
 
+In the case want to include an **SVG image** you need to add `?skipsvgo` to the image path.
+
+```md
+![Local Image](/pic.svg?skipsvgo)
+```
+
 If you want to apply custom sizes or styles, you can convert them to the `<img>` tag
 
 ```html


### PR DESCRIPTION
Continues: https://github.com/slidevjs/docs/pull/172

Sorry I hadn't seen your response 3 weeks ago

> Slidev does not even have vite-svg-loader installed - how is this relevant?

I checked that you are right `pnpm why vite-svg-loader`, however the issue is still the same

I created a stackblitz demonstarting the issue

https://stackblitz.com/edit/slidev-azbcjy?file=slides.md,public%2Ftux.svg

If you try to `pnpm build` this it will fail.

If you apply the suggested fix it builds.
