### PR TITLE
fix: refresh CodeMirror editror when size changed

### DIFF
--- a/packages/client/internals/SideEditor.vue
+++ b/packages/client/internals/SideEditor.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import { throttledWatch, useEventListener } from '@vueuse/core'
+import { throttledWatch, useEventListener, watchThrottled } from '@vueuse/core'
 import { computed, nextTick, onMounted, ref, watch } from 'vue'
-import { activeElement, editorHeight, editorWidth, isInputting, showEditor, isEditorVertical as vertical } from '../state'
+import { activeElement, editorHeight, editorWidth, isEditorVertical, isInputting, showEditor, isEditorVertical as vertical } from '../state'
 import { useCodeMirror } from '../modules/codemirror'
 import { useNav } from '../composables/useNav'
 import { useDynamicSlideInfo } from '../composables/useSlideInfo'
@@ -96,14 +96,21 @@ onMounted(async () => {
     },
   )
 
-  watch([tab, vertical], () => {
-    nextTick(() => {
-      if (tab.value === 'content')
-        contentEditor.refresh()
-      else
-        noteEditor.refresh()
-    })
-  })
+  watchThrottled(
+    [tab, vertical, isEditorVertical, editorWidth, editorHeight],
+    () => {
+      nextTick(() => {
+        if (tab.value === 'content')
+          contentEditor.refresh()
+        else
+          noteEditor.refresh()
+      })
+    },
+    {
+      throttle: 100,
+      flush: 'post',
+    },
+  )
 
   watch(currentSlideNo, () => {
     contentEditor.clearHistory()


### PR DESCRIPTION
When the size of CodeMirror editor changes, we have to call `editor.refresh()` manually. (CodeMirror itself only listens to window size changes).