### PR TITLE
fix: routing and view transition

### DIFF
--- a/cypress/e2e/examples/basic.spec.ts
+++ b/cypress/e2e/examples/basic.spec.ts
@@ -9,7 +9,7 @@ declare global {
 }
 
 Cypress.Commands.add('rightArrow', (n = 1) => {
-  cy.get('body').wait(200).type('{rightarrow}'.repeat(n)).wait(200)
+  cy.get('body').wait(500).type('{rightarrow}'.repeat(n)).wait(500)
 })
 
 const BASE = 'http://localhost:3041'

--- a/cypress/e2e/examples/basic.spec.ts
+++ b/cypress/e2e/examples/basic.spec.ts
@@ -9,7 +9,9 @@ declare global {
 }
 
 Cypress.Commands.add('rightArrow', (n = 1) => {
-  cy.get('body').wait(500).type('{rightarrow}'.repeat(n)).wait(500)
+  const body = cy.get('body').wait(200)
+  for (let i = 0; i < n; i++)
+    body.type('{rightarrow}').wait(200)
 })
 
 const BASE = 'http://localhost:3041'

--- a/cypress/e2e/examples/basic.spec.ts
+++ b/cypress/e2e/examples/basic.spec.ts
@@ -9,9 +9,7 @@ declare global {
 }
 
 Cypress.Commands.add('rightArrow', (n = 1) => {
-  const body = cy.get('body').wait(200)
-  for (let i = 0; i < n; i++)
-    body.type('{rightarrow}').wait(200)
+  cy.get('body').wait(500).type('{rightarrow}'.repeat(n)).wait(500)
 })
 
 const BASE = 'http://localhost:3041'
@@ -76,7 +74,7 @@ context('Basic', () => {
       .should('eq', `${BASE}/6?clicks=1`)
 
     cy.get('body')
-      .rightArrow(6)
+      .type('{RightArrow}{RightArrow}{RightArrow}{RightArrow}{RightArrow}{RightArrow}')
       .url().should('eq', `${BASE}/7`)
 
     cy.get('body')
@@ -235,7 +233,7 @@ context('Basic', () => {
       .should('eq', `${BASE}/12`)
 
     cy.get('body')
-      .rightArrow(6)
+      .type('{RightArrow}{RightArrow}{RightArrow}{RightArrow}{RightArrow}{RightArrow}')
       .url()
       .should('eq', `${BASE}/12?clicks=6`) // we should still be on page 12
 

--- a/cypress/e2e/examples/basic.spec.ts
+++ b/cypress/e2e/examples/basic.spec.ts
@@ -9,7 +9,7 @@ declare global {
 }
 
 Cypress.Commands.add('rightArrow', (n = 1) => {
-  cy.get('body').wait(500).type('{rightarrow}'.repeat(n)).wait(500)
+  cy.get('body').wait(200).type('{rightarrow}'.repeat(n)).wait(200)
 })
 
 const BASE = 'http://localhost:3041'
@@ -74,7 +74,7 @@ context('Basic', () => {
       .should('eq', `${BASE}/6?clicks=1`)
 
     cy.get('body')
-      .type('{RightArrow}{RightArrow}{RightArrow}{RightArrow}{RightArrow}{RightArrow}')
+      .rightArrow(6)
       .url().should('eq', `${BASE}/7`)
 
     cy.get('body')
@@ -233,7 +233,7 @@ context('Basic', () => {
       .should('eq', `${BASE}/12`)
 
     cy.get('body')
-      .type('{RightArrow}{RightArrow}{RightArrow}{RightArrow}{RightArrow}{RightArrow}')
+      .rightArrow(6)
       .url()
       .should('eq', `${BASE}/12?clicks=6`) // we should still be on page 12
 

--- a/packages/client/composables/useNav.ts
+++ b/packages/client/composables/useNav.ts
@@ -170,15 +170,19 @@ export function useNavBase(
     return go(total.value)
   }
 
-  async function go(page: number | string, clicks?: number) {
+  async function go(page: number | string, clicks: number = 0) {
     skipTransition.value = false
-    await router?.push({
-      path: getSlidePath(page, isPresenter.value),
-      query: {
-        ...router.currentRoute.value.query,
-        clicks: clicks || undefined,
-      },
-    })
+    const pageChanged = currentSlideNo.value !== page
+    const clicksChanged = clicks !== queryClicks.value
+    if (pageChanged || clicksChanged) {
+      await router?.push({
+        path: getSlidePath(page, isPresenter.value),
+        query: {
+          ...router.currentRoute.value.query,
+          clicks: clicks === 0 ? undefined : clicks.toString(),
+        },
+      })
+    }
   }
 
   return {

--- a/packages/client/composables/useViewTransition.ts
+++ b/packages/client/composables/useViewTransition.ts
@@ -33,7 +33,6 @@ export function useViewTransition() {
       return
     }
 
-    const becomeViewTransition = !isViewTransition.value
     isViewTransition.value = true
     const promise = new Promise<void>((resolve, reject) => {
       viewTransitionFinish = resolve
@@ -43,7 +42,8 @@ export function useViewTransition() {
     let changeRoute: () => void
     const ready = new Promise<void>(resolve => (changeRoute = resolve))
 
-    const startViewTransition = () => {
+    // Wait for `TransitionGroup` to become normal `div`
+    setTimeout(() => {
       // @ts-expect-error missing types
       const transition = document.startViewTransition(() => {
         changeRoute()
@@ -53,15 +53,7 @@ export function useViewTransition() {
         viewTransitionAbort = undefined
         viewTransitionFinish = undefined
       })
-    }
-
-    if (becomeViewTransition) {
-      // Wait for `TransitionGroup` to become normal `div`
-      setTimeout(startViewTransition, 50)
-    }
-    else {
-      startViewTransition()
-    }
+    }, 50)
 
     return ready
   })

--- a/packages/client/composables/useViewTransition.ts
+++ b/packages/client/composables/useViewTransition.ts
@@ -1,7 +1,6 @@
 import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { getSlide } from '../logic/slides'
-import { configs } from '../env'
 
 export function useViewTransition() {
   const router = useRouter()
@@ -18,10 +17,12 @@ export function useViewTransition() {
     const fromNo = fromMeta?.slide?.no
     const toNo = toMeta?.slide?.no
     if (
-      !fromNo || !toNo
-      || (configs.transition !== 'view-transition'
-      && ((fromNo < toNo && fromMeta?.transition === 'view-transition')
-      || (toNo < fromNo && toMeta?.transition === 'view-transition')))
+      !(
+        fromNo !== undefined && toNo !== undefined && (
+          (fromMeta?.transition === 'view-transition' && fromNo < toNo)
+          || (toMeta?.transition === 'view-transition' && toNo < fromNo)
+        )
+      )
     ) {
       isViewTransition.value = false
       return

--- a/packages/client/composables/useViewTransition.ts
+++ b/packages/client/composables/useViewTransition.ts
@@ -1,6 +1,7 @@
 import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { getSlide } from '../logic/slides'
+import { configs } from '../env'
 
 export function useViewTransition() {
   const router = useRouter()
@@ -17,12 +18,10 @@ export function useViewTransition() {
     const fromNo = fromMeta?.slide?.no
     const toNo = toMeta?.slide?.no
     if (
-      !(
-        fromNo !== undefined && toNo !== undefined && (
-          (fromMeta?.transition === 'view-transition' && fromNo < toNo)
-          || (toMeta?.transition === 'view-transition' && toNo < fromNo)
-        )
-      )
+      !fromNo || !toNo
+      || (configs.transition !== 'view-transition'
+      && ((fromNo < toNo && fromMeta?.transition === 'view-transition')
+      || (toNo < fromNo && toMeta?.transition === 'view-transition')))
     ) {
       isViewTransition.value = false
       return

--- a/packages/client/composables/useViewTransition.ts
+++ b/packages/client/composables/useViewTransition.ts
@@ -33,6 +33,7 @@ export function useViewTransition() {
       return
     }
 
+    const becomeViewTransition = !isViewTransition.value
     isViewTransition.value = true
     const promise = new Promise<void>((resolve, reject) => {
       viewTransitionFinish = resolve
@@ -42,8 +43,7 @@ export function useViewTransition() {
     let changeRoute: () => void
     const ready = new Promise<void>(resolve => (changeRoute = resolve))
 
-    // Wait for `TransitionGroup` to become normal `div`
-    setTimeout(() => {
+    const startViewTransition = () => {
       // @ts-expect-error missing types
       const transition = document.startViewTransition(() => {
         changeRoute()
@@ -53,7 +53,15 @@ export function useViewTransition() {
         viewTransitionAbort = undefined
         viewTransitionFinish = undefined
       })
-    }, 50)
+    }
+
+    if (becomeViewTransition) {
+      // Wait for `TransitionGroup` to become normal `div`
+      setTimeout(startViewTransition, 50)
+    }
+    else {
+      startViewTransition()
+    }
 
     return ready
   })

--- a/packages/client/composables/useViewTransition.ts
+++ b/packages/client/composables/useViewTransition.ts
@@ -43,17 +43,19 @@ export function useViewTransition() {
     let changeRoute: () => void
     const ready = new Promise<void>(resolve => (changeRoute = resolve))
 
-    // eslint-disable-next-line ts/ban-ts-comment
-    // @ts-expect-error
-    const transition = document.startViewTransition(() => {
-      changeRoute()
-      return promise
-    })
+    // Wait for `TransitionGroup` to become normal `div`
+    setTimeout(() => {
+      // @ts-expect-error missing types
+      const transition = document.startViewTransition(() => {
+        changeRoute()
+        return promise
+      })
+      transition.finished.then(() => {
+        viewTransitionAbort = undefined
+        viewTransitionFinish = undefined
+      })
+    }, 50)
 
-    transition.finished.then(() => {
-      viewTransitionAbort = undefined
-      viewTransitionFinish = undefined
-    })
     return ready
   })
 

--- a/packages/client/composables/useViewTransition.ts
+++ b/packages/client/composables/useViewTransition.ts
@@ -1,6 +1,7 @@
 import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { getSlide } from '../logic/slides'
+import { configs } from '../env'
 
 export function useViewTransition() {
   const router = useRouter()
@@ -16,14 +17,9 @@ export function useViewTransition() {
     const toMeta = getSlide(to.params.no as string)?.meta
     const fromNo = fromMeta?.slide?.no
     const toNo = toMeta?.slide?.no
-    if (
-      !(
-        fromNo !== undefined && toNo !== undefined && (
-          (fromMeta?.transition === 'view-transition' && fromNo < toNo)
-          || (toMeta?.transition === 'view-transition' && toNo < fromNo)
-        )
-      )
-    ) {
+    const transitionType = fromNo != null && toNo != null
+      && ((fromNo < toNo ? fromMeta?.transition : toMeta?.transition) ?? configs.transition)
+    if (transitionType !== 'view-transition') {
       isViewTransition.value = false
       return
     }

--- a/packages/client/logic/route.ts
+++ b/packages/client/logic/route.ts
@@ -22,6 +22,9 @@ export function useRouteQuery<T extends string | string[]>(
     },
     set(v) {
       nextTick(() => {
+        const oldValue = router.currentRoute.value.query[name]
+        if ((oldValue ?? defaultValue?.toString()) === v.toString())
+          return
         router[unref(mode) as 'replace' | 'push']({
           query: {
             ...router.currentRoute.value.query,
@@ -30,7 +33,7 @@ export function useRouteQuery<T extends string | string[]>(
         })
       })
     },
-  }) as any
+  })
 }
 
 // force update collected elements when the route is fully resolved

--- a/packages/client/logic/transition.ts
+++ b/packages/client/logic/transition.ts
@@ -9,7 +9,7 @@ const transitionResolveMap: Record<string, string | undefined> = {
   'slide-down': 'slide-down | slide-up',
 }
 
-export function resolveTransition(transition?: string | TransitionGroupProps, isBackward = false): TransitionGroupProps | undefined {
+function resolveTransition(transition?: string | TransitionGroupProps, isBackward = false): TransitionGroupProps | undefined {
   if (!transition)
     return undefined
   if (typeof transition === 'string') {


### PR DESCRIPTION
fix #1408

This PR fixes routing and view transition.

Previously, a navigation operation would make more than one route changes, which overrides themselves, resulting in #1408.

And when navigating from a non-view-transition (i.e. `TransitionGroup`) slide to a view-transition slide, we need to first wait for `TransitionGroup` element to become a normal `div` element. Otherwise when the route changes, view-transition will not play because it was still a `TransitionGroup` element. Currently a `setTimeout(50)` is added (`nextTick` not working for some unknown reason), but the root fix will be adding an `enabled` prop to `TransitionGroup` by Vue (I will open an issue in Vue for this later).

However, before and in this PR, if you switch slides very quickly, the displayed slide will mismatch the path. And after waiting for about 3s, the displayed slide will be updated to the correct one. I checked the DOM tree and found the DOM tree is correctly updated and always matches the path. So the problem is only about view-transition. I will open a new issue for this (update: #1415).