### PR TITLE
feat: allow `theme` to be `null`

### DIFF
--- a/packages/slidev/node/cli.ts
+++ b/packages/slidev/node/cli.ts
@@ -413,7 +413,8 @@ cli.command(
           const entry = await resolveEntry(entryRaw)
           const roots = await getRoots(entry)
           const data = await parser.load(roots.userRoot, entry)
-          const themeRaw = themeInput || (data.headmatter.theme as string) || 'default'
+          let themeRaw = themeInput || data.headmatter.theme as string | null | undefined
+          themeRaw = themeRaw === null ? 'none' : (themeRaw || 'default')
           if (themeRaw === 'none') {
             console.error('Cannot eject theme "none"')
             process.exit(1)

--- a/packages/slidev/node/options.ts
+++ b/packages/slidev/node/options.ts
@@ -17,7 +17,8 @@ export async function resolveOptions(
   const loaded = await parser.load(rootsInfo.userRoot, entry, undefined, mode)
 
   // Load theme data first, because it may affect the config
-  const themeRaw = options.theme || loaded.headmatter.theme as string || 'default'
+  let themeRaw = options.theme || loaded.headmatter.theme as string | null | undefined
+  themeRaw = themeRaw === null ? 'none' : (themeRaw || 'default')
   const [theme, themeRoot] = await resolveTheme(themeRaw, entry)
   const themeRoots = themeRoot ? [themeRoot] : []
   const themeMeta = themeRoot ? await getThemeMeta(theme, themeRoot) : undefined


### PR DESCRIPTION
resolve #1412.

Allow `theme` to be `null`. `theme: null` is now equivalent to `theme: none`, while `theme: undefined` is still resolved as `theme: undefined`