### PR TITLE
fix: Slide export without slide per click (#1416)

### DIFF
--- a/packages/client/composables/useClicks.ts
+++ b/packages/client/composables/useClicks.ts
@@ -4,6 +4,7 @@ import type { Ref } from 'vue'
 import { ref, shallowReactive } from 'vue'
 import { normalizeAtProp } from '../logic/utils'
 import { routeForceRefresh } from '../logic/route'
+import { useNav } from './useNav'
 
 export function createClicksContextBase(
   current: Ref<number>,
@@ -69,5 +70,6 @@ export function createFixedClicks(
   route?: SlideRoute | undefined,
   currentInit = 0,
 ): ClicksContext {
-  return createClicksContextBase(ref(currentInit), route?.meta?.clicks)
+  const { isPrintWithClicks, isPrintMode } = useNav()
+  return createClicksContextBase(ref(currentInit), route?.meta?.clicks, () => isPrintMode.value && !isPrintWithClicks.value)
 }


### PR DESCRIPTION
Closes https://github.com/slidevjs/slidev/issues/1416 by disabling clicks when in print mode