### PR TITLE
fix: print mode

### DIFF
--- a/packages/client/composables/useClicks.ts
+++ b/packages/client/composables/useClicks.ts
@@ -68,6 +68,7 @@ export function createClicksContextBase(
 export function createFixedClicks(
   route?: SlideRoute | undefined,
   currentInit = 0,
+  isDisabled?: () => boolean,
 ): ClicksContext {
-  return createClicksContextBase(ref(currentInit), route?.meta?.clicks)
+  return createClicksContextBase(ref(currentInit), route?.meta?.clicks, isDisabled)
 }

--- a/packages/client/internals/PrintSlide.vue
+++ b/packages/client/internals/PrintSlide.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
 import type { SlideRoute } from '@slidev/types'
-import { useFixedNav } from '../composables/useNav'
+import { useFixedNav, useNav } from '../composables/useNav'
 import { createFixedClicks } from '../composables/useClicks'
 import PrintSlideClick from './PrintSlideClick.vue'
 
 const { route } = defineProps<{ route: SlideRoute }>()
-const clicks0 = createFixedClicks(route, 0)
+const { isPrintWithClicks } = useNav()
+const clicks0 = createFixedClicks(route, 0, () => !isPrintWithClicks.value)
 </script>
 
 <template>

--- a/packages/client/modules/v-mark.ts
+++ b/packages/client/modules/v-mark.ts
@@ -116,7 +116,8 @@ export function createVMarkDirective() {
 
           const resolvedClick = resolveClick(el, binding, options.value.at)
           if (!resolvedClick) {
-            console.error('[Slidev] Invalid value for v-mark:', options.value.at)
+            // No click animation, just show the mark
+            annotation.show()
             return
           }
 
@@ -130,19 +131,14 @@ export function createVMarkDirective() {
 
             const at = options.value.at
 
-            if (at === true) {
+            if (at === true)
               shouldShow = true
-            }
-            else if (at === false) {
+
+            else if (at === false)
               shouldShow = false
-            }
-            else if (resolvedClick) {
+
+            else
               shouldShow = resolvedClick.isActive.value
-            }
-            else {
-              console.error('[Slidev] Invalid value for v-mark:', at)
-              return
-            }
 
             if (shouldShow == null)
               return

--- a/packages/client/modules/v-mark.ts
+++ b/packages/client/modules/v-mark.ts
@@ -133,10 +133,8 @@ export function createVMarkDirective() {
 
             if (at === true)
               shouldShow = true
-
             else if (at === false)
               shouldShow = false
-
             else
               shouldShow = resolvedClick.isActive.value
 


### PR DESCRIPTION
fix #1416. close #1418.

This PR:
- Fix print without per clicks (#1416)

- Show rough notation in print mode
  Previously rough notation is not shown in print mode because click animation is disabled. In this PR the rough notation will always be shown when the click animation is not working, aligning with the behavior of `v-click`.