### PR TITLE
fix: remove `clickContext.disabled`

### DIFF
--- a/packages/client/builtin/CodeBlockWrapper.vue
+++ b/packages/client/builtin/CodeBlockWrapper.vue
@@ -60,17 +60,13 @@ watchEffect(() => {
 })
 
 onMounted(() => {
-  if (!clicks || clicks.disabled || !props.ranges?.length)
+  if (!clicks || !props.ranges?.length)
     return
 
   const { start, end, delta } = clicks.resolve(props.at, props.ranges.length - 1)
   clicks.register(id, { max: end, delta })
 
-  const index = computed(() => {
-    if (clicks.disabled)
-      return props.ranges.length - 1
-    return Math.max(0, clicks.current - start + 1)
-  })
+  const index = computed(() => Math.max(0, clicks.current - start + 1))
 
   const finallyRange = computed(() => {
     return props.finally === 'last' ? props.ranges.at(-1) : props.finally.toString()

--- a/packages/client/builtin/KaTexBlockWrapper.vue
+++ b/packages/client/builtin/KaTexBlockWrapper.vue
@@ -55,17 +55,13 @@ onUnmounted(() => {
 })
 
 onMounted(() => {
-  if (!clicks || clicks.disabled || !props.ranges?.length)
+  if (!clicks || !props.ranges?.length)
     return
 
   const { start, end, delta } = clicks.resolve(props.at, props.ranges.length - 1)
   clicks.register(id, { max: end, delta })
 
-  const index = computed(() => {
-    if (clicks.disabled)
-      return props.ranges.length - 1
-    return Math.max(0, clicks.current - start + 1)
-  })
+  const index = computed(() => Math.max(0, clicks.current - start + 1))
 
   const finallyRange = computed(() => {
     return props.finally === 'last' ? props.ranges.at(-1) : props.finally.toString()

--- a/packages/client/builtin/ShikiMagicMove.vue
+++ b/packages/client/builtin/ShikiMagicMove.vue
@@ -23,11 +23,11 @@ const container = ref<HTMLElement>()
 const ranges = computed(() => props.stepRanges.map(i => i.length ? i : ['all']))
 
 onUnmounted(() => {
-  clicks!.unregister(id)
+  clicks?.unregister(id)
 })
 
 onMounted(() => {
-  if (!clicks || clicks.disabled)
+  if (!clicks)
     return
 
   if (ranges.value.length !== steps.length)

--- a/packages/client/builtin/SlidevVideo.vue
+++ b/packages/client/builtin/SlidevVideo.vue
@@ -26,7 +26,7 @@ const matchRoute = computed(() => {
 })
 
 const matchClick = computed(() => {
-  if (!video.value || currentContext?.value !== 'slide' || clicks?.disabled || clicks?.current === undefined)
+  if (!video.value || currentContext?.value !== 'slide' || !clicks)
     return false
   return clicks.map.get(video.value)?.isShown?.value ?? true
 })

--- a/packages/client/builtin/VClickGap.vue
+++ b/packages/client/builtin/VClickGap.vue
@@ -14,7 +14,7 @@ const { $clicksContext: clicks } = useSlideContext()
 
 onMounted(() => {
   watchEffect((onCleanup) => {
-    if (!clicks || clicks.disabled)
+    if (!clicks)
       return
 
     let delta = +props.size

--- a/packages/client/composables/useClicks.ts
+++ b/packages/client/composables/useClicks.ts
@@ -8,15 +8,11 @@ import { routeForceRefresh } from '../logic/route'
 export function createClicksContextBase(
   current: Ref<number>,
   clicksOverrides?: number,
-  isDisabled?: () => boolean,
 ): ClicksContext {
   const relativeOffsets: ClicksContext['relativeOffsets'] = new Map()
   const map: ClicksContext['map'] = shallowReactive(new Map())
 
   return {
-    get disabled() {
-      return isDisabled ? isDisabled() : false
-    },
     get current() {
       return +current.value
     },
@@ -25,7 +21,7 @@ export function createClicksContextBase(
     },
     relativeOffsets,
     map,
-    onMounted() {},
+    onMounted() { },
     resolve(at, size = 1) {
       const [isRelative, value] = normalizeAtProp(at)
       if (isRelative) {
@@ -68,7 +64,6 @@ export function createClicksContextBase(
 export function createFixedClicks(
   route?: SlideRoute | undefined,
   currentInit = 0,
-  isDisabled?: () => boolean,
 ): ClicksContext {
-  return createClicksContextBase(ref(currentInit), route?.meta?.clicks, isDisabled)
+  return createClicksContextBase(ref(currentInit), route?.meta?.clicks)
 }

--- a/packages/client/composables/useNav.ts
+++ b/packages/client/composables/useNav.ts
@@ -259,8 +259,6 @@ const useNavState = createSharedComposable((): SlidevContextNavState => {
 
   const queryClicks = computed({
     get() {
-      if (clicksContext.value.disabled)
-        return CLICKS_MAX
       let v = +(queryClicksRaw.value || 0)
       if (Number.isNaN(v))
         v = 0
@@ -281,8 +279,6 @@ const useNavState = createSharedComposable((): SlidevContextNavState => {
     const context = createClicksContextBase(
       computed({
         get() {
-          if (context.disabled)
-            return CLICKS_MAX
           if (currentSlideNo.value === thisNo)
             return +(queryClicksRaw.value || 0) || 0
           else if (currentSlideNo.value > thisNo)
@@ -296,7 +292,6 @@ const useNavState = createSharedComposable((): SlidevContextNavState => {
         },
       }),
       route?.meta?.clicks,
-      () => isPrintMode.value && !isPrintWithClicks.value,
     )
 
     // On slide mounted, make sure the query is not greater than the total

--- a/packages/client/internals/PrintSlide.vue
+++ b/packages/client/internals/PrintSlide.vue
@@ -2,11 +2,12 @@
 import type { SlideRoute } from '@slidev/types'
 import { useFixedNav, useNav } from '../composables/useNav'
 import { createFixedClicks } from '../composables/useClicks'
+import { CLICKS_MAX } from '../constants'
 import PrintSlideClick from './PrintSlideClick.vue'
 
 const { route } = defineProps<{ route: SlideRoute }>()
 const { isPrintWithClicks } = useNav()
-const clicks0 = createFixedClicks(route, 0, () => !isPrintWithClicks.value)
+const clicks0 = createFixedClicks(route, isPrintWithClicks.value ? 0 : CLICKS_MAX)
 </script>
 
 <template>
@@ -14,7 +15,7 @@ const clicks0 = createFixedClicks(route, 0, () => !isPrintWithClicks.value)
     :clicks-context="clicks0"
     :nav="useFixedNav(route, clicks0)"
   />
-  <template v-if="!clicks0.disabled">
+  <template v-if="isPrintWithClicks">
     <PrintSlideClick
       v-for="i of clicks0.total"
       :key="i"

--- a/packages/client/internals/QuickOverview.vue
+++ b/packages/client/internals/QuickOverview.vue
@@ -133,7 +133,6 @@ watchEffect(() => {
             <SlideContainer
               :key="route.no"
               :width="cardWidth"
-              :clicks-disabled="true"
               class="pointer-events-none"
             >
               <SlideWrapper

--- a/packages/client/modules/v-click.ts
+++ b/packages/client/modules/v-click.ts
@@ -132,7 +132,7 @@ function isCurrent(thisClick: number | [number, number], clicks: number) {
 export function resolveClick(el: Element, dir: DirectiveBinding<any>, value: VClickValue, clickAfter = false, flagHide = false): ResolvedClicksInfo | null {
   const ctx = dirInject(dir, injectionClicksContext)?.value
 
-  if (!el || !ctx || ctx.disabled)
+  if (!el || !ctx)
     return null
 
   if (value === false || value === 'false')

--- a/packages/client/pages/overview.vue
+++ b/packages/client/pages/overview.vue
@@ -177,7 +177,6 @@ onMounted(() => {
             <SlideContainer
               :key="route.no"
               :width="cardWidth"
-              :clicks-disabled="true"
               class="pointer-events-none important:[&_*]:select-none"
             >
               <SlideWrapper

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -151,7 +151,6 @@ export type ClicksMap = Map<ClicksElement, ClicksInfo>
 
 export interface ClicksContext {
   current: number
-  readonly disabled: boolean
   readonly relativeOffsets: ClicksRelativeEls
   readonly map: ClicksMap
   resolve: (at: string | number, size?: number) => {


### PR DESCRIPTION
This PR removes `clickContext.disabled`, which was previously used in print mode. So when exporting without clicks, the last click will always be printed. Previously, all animations were just removed, which works almost the same as this PR, but this PR could be more intuitive.