### PR TITLE
docs: build demo

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -13,6 +13,16 @@ status = 302
 force = true
 
 [[redirects]]
+from = "/demo/composable-vue/*"
+to = "/demo/composable-vue/index.html"
+status = 200
+
+[[redirects]]
+from = "/demo/starter/*"
+to = "/demo/starter/index.html"
+status = 200
+
+[[redirects]]
 from = "https://slidev.antfu.me/*"
 to = "https://sli.dev/:splat"
 status = 301

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lint:fix": "nr lint --fix",
     "typecheck": "vue-tsc --noEmit",
     "docs": "pnpm -C docs run dev",
-    "docs:build": "pnpm -C docs run build",
+    "docs:build": "pnpm -C docs run build && pnpm demo:build",
     "release": "bumpp package.json packages/*/package.json --all -x \"zx scripts/update-versions.mjs\"",
     "test": "vitest test"
   },

--- a/packages/slidev/node/cli.ts
+++ b/packages/slidev/node/cli.ts
@@ -370,13 +370,17 @@ cli.command(
         options.data.config.download = download
 
       printInfo(options)
-      await build(options, {
-        base,
-        build: {
-          watch: watch ? {} : undefined,
-          outDir: entry.length === 1 ? out : path.join(out, path.basename(entryFile, '.md')),
+      await build(
+        options,
+        {
+          base,
+          build: {
+            watch: watch ? {} : undefined,
+            outDir: entry.length === 1 ? out : path.join(out, path.basename(entryFile, '.md')),
+          },
         },
-      }, { ...args, entry: entryFile })
+        { ...args, entry: entryFile },
+      )
     }
   },
 )

--- a/scripts/demo.mjs
+++ b/scripts/demo.mjs
@@ -3,6 +3,7 @@ import { $, cd, fs, path } from 'zx'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
+const demo = path.resolve(__dirname, '../docs/.vitepress/dist/demo')
 
 await $`npm run build`
 
@@ -11,6 +12,6 @@ if (!fs.existsSync(starterMd))
   await fs.copyFile(path.resolve(__dirname, '../packages/create-app/template/slides.md'), starterMd)
 
 cd(path.resolve(__dirname, '../demo/composable-vue'))
-await $`npx slidev build -d --base /composable-vue/ --out ../../dist/composable-vue`
+await $`npx slidev build -d --base /demo/composable/ --out ${demo}/composable-vue`
 cd(path.resolve(__dirname, '../demo/starter'))
-await $`npx slidev build -d --base /starter/ --out ../../dist/starter`
+await $`npx slidev build -d --base /demo/starter/ --out ${demo}/starter`

--- a/scripts/demo.mjs
+++ b/scripts/demo.mjs
@@ -12,6 +12,6 @@ if (!fs.existsSync(starterMd))
   await fs.copyFile(path.resolve(__dirname, '../packages/create-app/template/slides.md'), starterMd)
 
 cd(path.resolve(__dirname, '../demo/composable-vue'))
-await $`npx slidev build -d --base /demo/composable/ --out ${demo}/composable-vue`
+await $`npx slidev build --base /demo/composable/ --out ${demo}/composable-vue`
 cd(path.resolve(__dirname, '../demo/starter'))
-await $`npx slidev build -d --base /demo/starter/ --out ${demo}/starter`
+await $`npx slidev build --base /demo/starter/ --out ${demo}/starter`


### PR DESCRIPTION
The demo was no longer included in the doc site since https://github.com/slidevjs/slidev/commit/4f5bb6820d47e6eaba8836a8a933ec29a8b3112e

check this out: https://sli.dev/demo/starter/7

And I've added [`PLAYWRIGHT_BROWSERS_PATH=0`](https://playwright.dev/docs/browsers#hermetic-install) env virable on netlify settings to prevent `chromium executable doesn"t exist` error in a cached build. Just mentioning, not sure this project did this before.