### PR TITLE
fix: `.gitignore` template

### DIFF
--- a/packages/create-app/template/_gitignore
+++ b/packages/create-app/template/_gitignore
@@ -2,6 +2,6 @@ node_modules
 .DS_Store
 dist
 *.local
-index.html
+.vite-inspect
 .remote-assets
 components.d.ts

--- a/packages/create-theme/template/_gitignore
+++ b/packages/create-theme/template/_gitignore
@@ -2,7 +2,7 @@ node_modules
 .DS_Store
 dist
 *.local
-index.html
+.vite-inspect
 .remote-assets
 .idea/
 components.d.ts


### PR DESCRIPTION
This PR updates the `.gitignore` file in the templates.

- Removed `index.html`, because users may have something to insert into `<head>` or `<body>` by providing an `index.html`.
- Add `.vite-inspect`. Sometimes `--inspect` option will generate this.
