### PR TITLE
Remove redundant onMount

### DIFF
--- a/packages/client/composables/useClicks.ts
+++ b/packages/client/composables/useClicks.ts
@@ -21,7 +21,6 @@ export function createClicksContextBase(
     },
     relativeOffsets,
     map,
-    onMounted() { },
     resolve(at, size = 1) {
       const [isRelative, value] = normalizeAtProp(at)
       if (isRelative) {


### PR DESCRIPTION
I have found redundant piece of code with empty `onMount() {}`