### PR TITLE
fix: warning about `TransitionGroup`'s children must be keyed

### DIFF
--- a/packages/client/internals/SlidesShow.vue
+++ b/packages/client/internals/SlidesShow.vue
@@ -75,8 +75,9 @@ function onAfterLeave() {
         class="overflow-hidden"
       />
     </div>
-    <div id="twoslash-container" />
   </component>
+
+  <div id="twoslash-container" />
 
   <!-- Global Top -->
   <GlobalTop />
@@ -92,7 +93,7 @@ function onAfterLeave() {
   height: 100%;
 }
 
-#slideshow > div:not(#twoslash-container) {
+#slideshow > div {
   position: absolute;
   height: 100%;
   width: 100%;


### PR DESCRIPTION
![image](https://github.com/slidevjs/slidev/assets/63178754/d3834ac4-6764-4e57-be8a-17b9e0ae7274)
