### PR TITLE
fix: use bundler version of vue

### DIFF
--- a/packages/slidev/node/vite/extendConfig.ts
+++ b/packages/slidev/node/vite/extendConfig.ts
@@ -73,7 +73,7 @@ export function createConfigPlugin(options: ResolvedSlidevOptions): Plugin {
             },
             {
               find: 'vue',
-              replacement: await resolveImportPath('vue/dist/vue.esm-browser.js', true),
+              replacement: await resolveImportPath('vue/dist/vue.esm-bundler.js', true),
             },
           ],
           dedupe: ['vue'],


### PR DESCRIPTION
fix #1437.
resolve #1410.

Currently, Slidev uses the dev version of Vue both in dev and build mode for a very long time. This PR uses the bundler version of vue instead.