### PR TITLE
fix: remove empty export from transpiled ts file

### DIFF
--- a/packages/client/setup/code-runners.ts
+++ b/packages/client/setup/code-runners.ts
@@ -144,9 +144,13 @@ export async function runJavaScript(code: string): Promise<CodeRunnerOutputs> {
     return textRep
   }
 
-  // The reflect-metadata runtime is available, so allow that to go through
   function sanitizeJS(code: string) {
-    return code.replace(`import "reflect-metadata"`, '').replace(`require("reflect-metadata")`, '')
+    // The reflect-metadata runtime is available, so allow that to go through
+    code = code.replace(`import "reflect-metadata"`, '').replace(`require("reflect-metadata")`, '')
+    // Transpiled typescript sometimes contains an empty export, remove it.
+    code = code.replace('export {};', '')
+
+    return code
   }
 
   return allLogs


### PR DESCRIPTION
When doing an import, the typescript compiler automatically decides ["well this file must be a module".](https://stackoverflow.com/questions/65553572/typescript-adds-plain-export-statement)

https://github.com/slidevjs/slidev/blob/f04f2ebb4783f8bd5df70bf82aaaa9343c87215d/packages/client/setup/code-runners.ts#L158-L163

`import type {UnionToIntersection} from 'type-fest'` -> `export {};` 

However, since the compiled TS code getts embedded in a function, the empty export code doesn't fit into the body of a function.

https://github.com/slidevjs/slidev/blob/f04f2ebb4783f8bd5df70bf82aaaa9343c87215d/packages/client/setup/code-runners.ts#L73-L76

Instead you get  `ERROR: SyntaxError: Unexpected token 'export'`

See https://stackblitz.com/edit/github-qj6z8s?file=slides.md



This PR sanitizes the JS before running by removing the empty export {}; produced by typescript.


