### PR TITLE
docs: flesh out RenderWhen's contexts

### DIFF
--- a/docs/builtin/components.md
+++ b/docs/builtin/components.md
@@ -132,6 +132,14 @@ Context type: `'main' | 'visible' | 'print' | 'slide' | 'overview' | 'presenter'
 Parameters:
 
 - `context` (`Context | Context[]`): a context or array of contexts you want to check for
+  - `'main'`: Render in slides and presenter view (equivalent to ['slide', 'presenter']),
+  - `'visible'`: Render the content if it is visible
+  - `'print'`: Render in print mode
+  - `'slide'`: Render in slides
+  - `'overview'`: Render in overview
+  - `'presenter'`: Render in presenter view
+  - `'previewNext'`: Render in presenter's next slide view
+  - `'previewPrevious'`: Render in presenter's previous slide view
 
 Slots:
 


### PR DESCRIPTION
It wasn't obvious to me what each `RenderWhen`'s context targeted. I took the liberty to update the code based on what I understood of the source code.