### PR TITLE
fix: increase contrast for presenter cursor

### DIFF
--- a/packages/client/internals/PresenterMouse.vue
+++ b/packages/client/internals/PresenterMouse.vue
@@ -8,8 +8,12 @@ import { sharedState } from '../state/shared'
     class="absolute top-0 left-0 right-0 bottom-0 pointer-events-none text-xl"
   >
     <ph-cursor-fill
-      class="absolute"
-      :style="{ left: `${sharedState.cursor.x}%`, top: `${sharedState.cursor.y}%` }"
+      class="absolute stroke-white dark:stroke-black"
+      :style="{
+        left: `${sharedState.cursor.x}%`,
+        top: `${sharedState.cursor.y}%`,
+        strokeWidth: 16,
+      }"
     />
   </div>
 </template>


### PR DESCRIPTION
The cursor being a solid fill color doesn't show up well against a dark background in light mode (when the cursor is black) or a light background in dark mode (when the cursor is white).

This adds a contrasting stroke emulating a native cursor look.

Fixes #1477.