### PR TITLE
docs: clarify leading slash in `syntax.md`

### DIFF
--- a/docs/custom/vue-context.md
+++ b/docs/custom/vue-context.md
@@ -119,9 +119,9 @@ If you want to get the context programmatically (also type-safely), you can impo
 
 ```vue
 <script setup>
-import { useDarkMode, useNav, useSlidevContext } from '@slidev/client'
+import { useDarkMode, useNav, useSlideContext } from '@slidev/client'
 
-const { $slidev } = useSlidevContext()
+const { $slidev } = useSlideContext()
 const { currentSlideRoute } = useNav()
 const { isDark } = useDarkMode()
 // ...

--- a/docs/custom/vue-context.md
+++ b/docs/custom/vue-context.md
@@ -77,7 +77,7 @@ For more properties available, refer to the [`SlidevContextNav` interface](https
 
 ### `$slidev.configs`
 
-A reactive object holding the parsed [configurations in the first frontmatter](/custom/#frontmatter-configures) of your `slides.md`. For example
+A reactive object holding the parsed [configurations in the first frontmatter](/custom/#frontmatter-configures) of your `slides.md`. For example:
 
 ```yaml
 ---
@@ -115,6 +115,8 @@ A shorthand of `$slidev.nav`.
 
 > Available since v0.48.0
 
+### Context
+
 If you want to get the context programmatically (also type-safely), you can import composables from `@slidev/client`:
 
 ```vue
@@ -122,7 +124,7 @@ If you want to get the context programmatically (also type-safely), you can impo
 import { useDarkMode, useNav, useSlideContext } from '@slidev/client'
 
 const { $slidev } = useSlideContext()
-const { currentSlideRoute } = useNav()
+const { currentPage, currentLayout, currentSlideRoute } = useNav()
 const { isDark } = useDarkMode()
 // ...
 </script>
@@ -130,3 +132,17 @@ const { isDark } = useDarkMode()
 
 > [!NOTE]
 > Previously, you might see the usage of importing nested modules like `import { isDark } from '@slidev/client/logic/dark.ts'`, this is **NOT RECOMMENDED** as they are internal implementation details and might be broken in the future. Try always to use the public API from `@slidev/client` whenever possible.
+
+### Types
+
+If you want to get a type programmatically, you can import types like `TocItem` from `@slidev/types`:
+
+```vue
+<script setup>
+import type { TocItem } from "@slidev/types";
+
+function tocFunc(tree: TocItem[]): TocItem[] {
+  // ...
+}
+</script>
+```

--- a/docs/guide/syntax.md
+++ b/docs/guide/syntax.md
@@ -359,13 +359,13 @@ For remote assets, the built-in [`vite-plugin-remote-assets`](https://github.com
 ![Remote Image](https://sli.dev/favicon.png)
 ```
 
-For local assets, put them into the [`public` folder](/custom/directory-structure.html#public) and reference them with a **leading slash**.
+For local assets, put them into the [`public` folder](/custom/directory-structure.html#public) and reference them with a **leading slash** (i.e., `/pic.png`, NOT `./pic.png`, which is relative to the working file).
 
 ```md
 ![Local Image](/pic.png)
 ```
 
-If you want to apply custom sizes or styles, you can convert them to the `<img>` tag
+If you want to apply custom sizes or styles, you can convert them to the `<img>` tag:
 
 ```html
 <img src="/pic.png" class="m-40 h-40 rounded shadow" />


### PR DESCRIPTION
Clarifies note about static asset paths, to prevent others from making the same error I did in #1488. (This also includes the changes I suggested in #1484 / #1483 - not sure if this is ok)