### PR TITLE
fix: revert `overflow-hidden` for `SlideWrapper`

### DIFF
--- a/packages/client/internals/SlidesShow.vue
+++ b/packages/client/internals/SlidesShow.vue
@@ -76,7 +76,6 @@ function onAfterLeave() {
         :class="getSlideClass(route)"
         :route="route"
         :render-context="renderContext"
-        class="overflow-hidden"
       />
     </div>
   </component>


### PR DESCRIPTION
Hi, thanks a lot for this project! Slidev's my go-to tooling these days. Big fan of the project!

This PR:
- Allow overflow to be visible to enable negative margins for styling

I like to style my slides with negative margins (especially when using `two-cols`, etc.) but with the change introduced in https://github.com/slidevjs/slidev/commit/c820e23b10581191a42bbf51c04bfd2caa49077a, it was hard to customize it to my liking.

Not sure there are any other side effects to this change, but it took me some time to fix it so I figured I'd open a PR :)

My current workaround was to include in `styles/main.css`:

```css
.slidev-page {
  /* https://github.com/slidevjs/slidev/commit/c820e23b10581191a42bbf51c04bfd2caa49077a */
  overflow: visible !important;
}
```