### PR TITLE
feat: preserve comments in frontmatter

### DIFF
--- a/packages/client/composables/useDragElements.ts
+++ b/packages/client/composables/useDragElements.ts
@@ -52,7 +52,7 @@ export function useDragElementsUpdater(no: number) {
         return
       frontmatter.dragPos[id] = posStr
       newPatch = {
-        frontmatter,
+        dragPos: frontmatter.dragPos,
       }
     }
     else {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -48,7 +48,6 @@
     "file-saver": "^2.0.5",
     "floating-vue": "^5.2.2",
     "fuse.js": "^7.0.0",
-    "js-yaml": "^4.1.0",
     "katex": "^0.16.10",
     "lz-string": "^1.5.0",
     "mermaid": "^10.9.0",
@@ -61,7 +60,8 @@
     "unocss": "^0.59.0",
     "vue": "^3.4.21",
     "vue-demi": "^0.14.7",
-    "vue-router": "^4.3.0"
+    "vue-router": "^4.3.0",
+    "yaml": "^2.4.1"
   },
   "devDependencies": {
     "vite": "^5.2.8"

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -45,6 +45,6 @@
   },
   "dependencies": {
     "@slidev/types": "workspace:*",
-    "js-yaml": "^4.1.0"
+    "yaml": "^2.4.1"
   }
 }

--- a/packages/parser/src/fs.ts
+++ b/packages/parser/src/fs.ts
@@ -1,6 +1,6 @@
 import { promises as fs } from 'node:fs'
 import { dirname, resolve } from 'node:path'
-import YAML from 'js-yaml'
+import YAML from 'yaml'
 import { slash } from '@antfu/utils'
 import type { PreparserExtensionLoader, SlideInfo, SlidevData, SlidevMarkdown, SlidevPreparserExtension, SourceSlideInfo } from '@slidev/types'
 import { detectFeatures, parse, parseRangeString, stringify } from './core'
@@ -35,7 +35,7 @@ export async function load(userRoot: string, filepath: string, content?: string,
         hEnd++
       hm = lines.slice(1, hEnd).join('\n')
     }
-    const o = YAML.load(hm) as Record<string, unknown> ?? {}
+    const o = YAML.parse(hm) as Record<string, unknown> ?? {}
     extensions = await preparserExtensionLoader(o, filepath, mode)
   }
 

--- a/packages/slidev/node/utils.ts
+++ b/packages/slidev/node/utils.ts
@@ -1,5 +1,6 @@
 import type { Token } from 'markdown-it'
-import type { ResolvedFontOptions } from '@slidev/types'
+import type { ResolvedFontOptions, SlideInfo } from '@slidev/types'
+import YAML from 'yaml'
 
 export function stringifyMarkdownTokens(tokens: Token[]) {
   return tokens.map(token => token.children
@@ -20,4 +21,32 @@ export function generateGoogleFontsUrl(options: ResolvedFontOptions) {
     .join('&')
 
   return `https://fonts.googleapis.com/css2?${fonts}&display=swap`
+}
+
+export function updateDragPos(slide: SlideInfo, dragPos: Record<string, string>) {
+  const source = slide.source
+  slide.frontmatter.dragPos = source.frontmatter.dragPos = dragPos
+  let doc = source.frontmatterDoc
+  if (!doc) {
+    source.frontmatterStyle = 'frontmatter'
+    source.frontmatterDoc = doc = new YAML.Document({})
+  }
+  const valueNode = doc.createNode(dragPos)
+  let found = false
+  YAML.visit(doc.contents, {
+    Pair(_key, node, path) {
+      if (path.length === 1 && YAML.isScalar(node.key) && node.key.value === 'dragPos') {
+        node.value = valueNode
+        found = true
+        return YAML.visit.BREAK
+      }
+    },
+  })
+  if (!found) {
+    if (!YAML.isMap(doc.contents))
+      doc.contents = doc.createNode({})
+    doc.contents.add(
+      doc.createPair('dragPos', valueNode),
+    )
+  }
 }

--- a/packages/slidev/node/vite/loaders.ts
+++ b/packages/slidev/node/vite/loaders.ts
@@ -4,7 +4,6 @@ import { isString, isTruthy, notNullish, range } from '@antfu/utils'
 import fg from 'fast-glob'
 import fs from 'fs-extra'
 import Markdown from 'markdown-it'
-import YAML from 'js-yaml'
 import { bold, gray, red, yellow } from 'kolorist'
 
 // @ts-expect-error missing types
@@ -14,7 +13,7 @@ import * as parser from '@slidev/parser/fs'
 import equal from 'fast-deep-equal'
 
 import type { LoadResult } from 'rollup'
-import { stringifyMarkdownTokens } from '../utils'
+import { stringifyMarkdownTokens, updateDragPos } from '../utils'
 import { toAtFS } from '../resolver'
 import { templates } from '../virtual'
 import type { VirtualModuleTempalteContext } from '../virtual/types'
@@ -168,10 +167,8 @@ export function createSlidesLoader(
               slide.content = slide.source.content = body.content
             if (body.note)
               slide.note = slide.source.note = body.note
-            if (body.frontmatter) {
-              Object.assign(slide.frontmatter, body.frontmatter)
-              slide.source.frontmatterRaw = YAML.dump(slide.frontmatter)
-            }
+            if (body.dragPos)
+              updateDragPos(slide, body.dragPos)
 
             parser.prettifySlide(slide.source)
             const fileContent = await parser.save(data.markdownFiles[slide.source.filepath])
@@ -183,7 +180,7 @@ export function createSlidesLoader(
               server?.moduleGraph.invalidateModule(
                 server.moduleGraph.getModuleById(`${VIRTUAL_SLIDE_PREFIX}${no}.md`)!,
               )
-              if (body.frontmatter) {
+              if (body.dragPos) {
                 server?.moduleGraph.invalidateModule(
                   server.moduleGraph.getModuleById(`${VIRTUAL_SLIDE_PREFIX}${no}.frontmatter`)!,
                 )

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -1,5 +1,6 @@
 import type { ComputedRef } from 'vue'
 import type { RouteComponent, RouteMeta } from 'vue-router'
+import type YAML from 'yaml'
 import type { SlidevConfig } from './config'
 
 export type FrontmatterStyle = 'frontmatter' | 'yaml'
@@ -28,6 +29,7 @@ export interface SourceSlideInfo extends SlideInfoBase {
   end: number
   raw: string
   frontmatterRaw?: string
+  frontmatterDoc?: YAML.Document
   frontmatterStyle?: FrontmatterStyle
 }
 
@@ -44,8 +46,9 @@ export interface SlideInfo extends SlideInfoBase {
 /**
  * Editable fields for a slide
  */
-export type SlidePatch = Partial<Pick<SlideInfoBase, 'content' | 'note' | 'frontmatter'>> & {
+export type SlidePatch = Partial<Pick<SlideInfoBase, 'content' | 'note'>> & {
   skipHmr?: boolean
+  dragPos?: Record<string, string>
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -362,9 +362,6 @@ importers:
       fuse.js:
         specifier: ^7.0.0
         version: 7.0.0
-      js-yaml:
-        specifier: ^4.1.0
-        version: 4.1.0
       katex:
         specifier: ^0.16.10
         version: 0.16.10
@@ -404,6 +401,9 @@ importers:
       vue-router:
         specifier: ^4.3.0
         version: 4.3.0(vue@3.4.21)
+      yaml:
+        specifier: ^2.4.1
+        version: 2.4.1
     devDependencies:
       vite:
         specifier: ^5.2.8
@@ -441,9 +441,9 @@ importers:
       '@slidev/types':
         specifier: workspace:*
         version: link:../types
-      js-yaml:
-        specifier: ^4.1.0
-        version: 4.1.0
+      yaml:
+        specifier: ^2.4.1
+        version: 2.4.1
 
   packages/slidev:
     dependencies:
@@ -509,7 +509,7 @@ importers:
         version: 3.7.0
       debug:
         specifier: ^4.3.4
-        version: 4.3.4(supports-color@8.1.1)
+        version: 4.3.4(supports-color@5.5.0)
       fast-deep-equal:
         specifier: ^3.1.3
         version: 3.1.3
@@ -993,7 +993,7 @@ packages:
       '@babel/traverse': 7.24.1
       '@babel/types': 7.24.0
       convert-source-map: 2.0.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -1241,7 +1241,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/parser': 7.24.4
       '@babel/types': 7.24.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -1815,7 +1815,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.1
@@ -1832,7 +1832,7 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       espree: 10.0.1
       globals: 14.0.0
       ignore: 5.3.1
@@ -1883,7 +1883,7 @@ packages:
     engines: {node: '>=10.10.0'}
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -1948,7 +1948,7 @@ packages:
       '@antfu/install-pkg': 0.1.1
       '@antfu/utils': 0.5.2
       '@iconify/types': 1.1.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       kolorist: 1.8.0
       local-pkg: 0.4.3
     transitivePeerDependencies:
@@ -1961,7 +1961,7 @@ packages:
       '@antfu/install-pkg': 0.1.1
       '@antfu/utils': 0.7.7
       '@iconify/types': 2.0.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       kolorist: 1.8.0
       local-pkg: 0.5.0
       mlly: 1.6.1
@@ -2924,7 +2924,7 @@ packages:
       '@typescript-eslint/type-utils': 7.6.0(eslint@9.0.0)(typescript@5.4.4)
       '@typescript-eslint/utils': 7.6.0(eslint@9.0.0)(typescript@5.4.4)
       '@typescript-eslint/visitor-keys': 7.6.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       eslint: 9.0.0
       graphemer: 1.4.0
       ignore: 5.3.1
@@ -2950,7 +2950,7 @@ packages:
       '@typescript-eslint/types': 7.6.0
       '@typescript-eslint/typescript-estree': 7.6.0(typescript@5.4.4)
       '@typescript-eslint/visitor-keys': 7.6.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       eslint: 9.0.0
       typescript: 5.4.4
     transitivePeerDependencies:
@@ -2985,7 +2985,7 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 7.6.0(typescript@5.4.4)
       '@typescript-eslint/utils': 7.6.0(eslint@9.0.0)(typescript@5.4.4)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       eslint: 9.0.0
       ts-api-utils: 1.3.0(typescript@5.4.4)
       typescript: 5.4.4
@@ -3014,7 +3014,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.3
@@ -3036,7 +3036,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 7.6.0
       '@typescript-eslint/visitor-keys': 7.6.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.4
@@ -3112,7 +3112,7 @@ packages:
   /@typescript/vfs@1.5.0:
     resolution: {integrity: sha512-AJS307bPgbsZZ9ggCT3wwpg3VbTKMFNHfaY/uF0ahSkYYrPF2dSSKDNIDIQAHm9qJqbLvCsSJH7yN4Vs/CsMMg==}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -3926,7 +3926,7 @@ packages:
   /@windicss/config@1.9.3:
     resolution: {integrity: sha512-u8GUjsfC9r5X1AGYhzb1lX3zZj8wqk6SH1DYex8XUGmZ1M2UpvnUPOFi63XFViduspQ6l2xTX84QtG+lUzhEoQ==}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       jiti: 1.21.0
       windicss: 3.5.6
     transitivePeerDependencies:
@@ -3938,7 +3938,7 @@ packages:
     dependencies:
       '@antfu/utils': 0.7.7
       '@windicss/config': 1.9.3
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       fast-glob: 3.3.2
       magic-string: 0.30.9
       micromatch: 4.0.5
@@ -3994,7 +3994,7 @@ packages:
     resolution: {integrity: sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==}
     engines: {node: '>= 14'}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -5070,7 +5070,6 @@ packages:
     dependencies:
       ms: 2.1.2
       supports-color: 5.5.0
-    dev: true
 
   /debug@4.3.4(supports-color@8.1.1):
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
@@ -5083,6 +5082,7 @@ packages:
     dependencies:
       ms: 2.1.2
       supports-color: 8.1.1
+    dev: true
 
   /decode-named-character-reference@1.0.2:
     resolution: {integrity: sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==}
@@ -5770,7 +5770,7 @@ packages:
       eslint: ^8.56.0 || ^9.0.0-0
     dependencies:
       '@typescript-eslint/utils': 7.6.0(eslint@9.0.0)(typescript@5.4.4)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       doctrine: 3.0.0
       eslint: 9.0.0
       eslint-import-resolver-node: 0.3.9
@@ -5792,7 +5792,7 @@ packages:
       '@es-joy/jsdoccomment': 0.42.0
       are-docs-informative: 0.0.2
       comment-parser: 1.4.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       escape-string-regexp: 4.0.0
       eslint: 9.0.0
       esquery: 1.5.0
@@ -5887,7 +5887,7 @@ packages:
     peerDependencies:
       eslint: '>=6.0.0'
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       eslint: 9.0.0
       eslint-compat-utils: 0.5.0(eslint@9.0.0)
       lodash: 4.17.21
@@ -5985,7 +5985,7 @@ packages:
     peerDependencies:
       eslint: '>=6.0.0'
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       eslint: 9.0.0
       eslint-compat-utils: 0.5.0(eslint@9.0.0)
       lodash: 4.17.21
@@ -6051,7 +6051,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       escape-string-regexp: 4.0.0
       eslint-scope: 8.0.1
       eslint-visitor-keys: 4.0.0
@@ -6378,7 +6378,7 @@ packages:
       debug:
         optional: true
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
     dev: false
 
   /foreground-child@3.1.1:
@@ -6700,6 +6700,7 @@ packages:
   /has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+    dev: true
 
   /has-property-descriptors@1.0.1:
     resolution: {integrity: sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==}
@@ -6778,7 +6779,7 @@ packages:
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6805,7 +6806,7 @@ packages:
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -7291,7 +7292,7 @@ packages:
     dependencies:
       chalk: 5.3.0
       commander: 11.1.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       execa: 8.0.1
       lilconfig: 3.0.0
       listr2: 8.0.1
@@ -8011,7 +8012,7 @@ packages:
   /micromark@2.11.4:
     resolution: {integrity: sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       parse-entities: 2.0.0
     transitivePeerDependencies:
       - supports-color
@@ -8021,7 +8022,7 @@ packages:
     resolution: {integrity: sha512-uD66tJj54JLYq0De10AhWycZWGQNUvDI55xPgk2sQM5kn1JYlhbCMTtEeT27+vAhW2FBQxLlOmS3pmA7/2z4aA==}
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       decode-named-character-reference: 1.0.2
       micromark-core-commonmark: 1.1.0
       micromark-factory-space: 1.1.0
@@ -8044,7 +8045,7 @@ packages:
     resolution: {integrity: sha512-o/sd0nMof8kYff+TqcDx3VSrgBTcZpSvYcAHIfHhv5VAuNmisCxjhx6YmxS8PFEpb9z5WKWKPdzf0jM23ro3RQ==}
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       decode-named-character-reference: 1.0.2
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.0
@@ -8857,7 +8858,7 @@ packages:
         optional: true
     dependencies:
       lilconfig: 3.0.0
-      yaml: 2.3.4
+      yaml: 2.4.1
     dev: true
 
   /postcss-nested@6.0.1(postcss@8.4.38):
@@ -9471,7 +9472,7 @@ packages:
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       socks: 2.7.1
     transitivePeerDependencies:
       - supports-color
@@ -9697,6 +9698,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       has-flag: 4.0.0
+    dev: true
 
   /supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
@@ -9915,7 +9917,7 @@ packages:
       bundle-require: 4.0.2(esbuild@0.19.12)
       cac: 6.7.14
       chokidar: 3.6.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       esbuild: 0.19.12
       execa: 5.1.1
       globby: 11.1.0
@@ -9948,7 +9950,7 @@ packages:
     engines: {node: ^16.14.0 || >=18.0.0}
     dependencies:
       '@tufjs/models': 2.0.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       make-fetch-happen: 13.0.0
     transitivePeerDependencies:
       - supports-color
@@ -10314,7 +10316,7 @@ packages:
       '@antfu/utils': 0.7.7
       '@iconify/utils': 2.1.22
       '@vue/compiler-sfc': 3.4.21
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       kolorist: 1.8.0
       local-pkg: 0.5.0
       unplugin: 1.6.0
@@ -10337,7 +10339,7 @@ packages:
       '@antfu/utils': 0.7.7
       '@rollup/pluginutils': 5.1.0
       chokidar: 3.6.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       fast-glob: 3.3.2
       local-pkg: 0.4.3
       magic-string: 0.30.9
@@ -10501,7 +10503,7 @@ packages:
     hasBin: true
     dependencies:
       cac: 6.7.14
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       pathe: 1.1.2
       picocolors: 1.0.0
       vite: 5.2.8(@types/node@20.12.7)
@@ -10528,7 +10530,7 @@ packages:
     dependencies:
       '@antfu/utils': 0.7.7
       '@rollup/pluginutils': 5.1.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       error-stack-parser-es: 0.1.1
       fs-extra: 11.2.0
       open: 10.1.0
@@ -10553,7 +10555,7 @@ packages:
     dependencies:
       '@antfu/utils': 0.7.7
       '@rollup/pluginutils': 5.1.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       error-stack-parser-es: 0.1.1
       fs-extra: 11.2.0
       open: 10.1.0
@@ -10574,7 +10576,7 @@ packages:
       '@antfu/utils': 0.7.7
       axios: 1.6.5(debug@4.3.4)
       blueimp-md5: 2.19.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       fs-extra: 11.2.0
       magic-string: 0.30.9
       vite: 5.2.8(@types/node@20.12.7)
@@ -10602,7 +10604,7 @@ packages:
       vue: ^3.0.0
     dependencies:
       '@antfu/utils': 0.7.7
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       klona: 2.0.6
       mlly: 1.6.1
       ufo: 1.5.3
@@ -10618,7 +10620,7 @@ packages:
       vite: ^2.0.1 || ^3.0.0 || ^4.0.0 || ^5.0.0
     dependencies:
       '@windicss/plugin-utils': 1.9.3
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       kolorist: 1.8.0
       vite: 3.2.8(@types/node@20.12.7)
       windicss: 3.5.6
@@ -10795,7 +10797,7 @@ packages:
       '@vitest/utils': 1.4.0
       acorn-walk: 8.3.2
       chai: 4.4.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       execa: 8.0.1
       local-pkg: 0.5.0
       magic-string: 0.30.9
@@ -10838,7 +10840,7 @@ packages:
     peerDependencies:
       eslint: '>=6.0.0'
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       eslint: 9.0.0
       eslint-scope: 7.2.2
       eslint-visitor-keys: 3.4.3
@@ -11024,13 +11026,18 @@ packages:
     dependencies:
       eslint-visitor-keys: 3.4.3
       lodash: 4.17.21
-      yaml: 2.3.4
+      yaml: 2.4.1
     dev: true
 
   /yaml@2.3.4:
     resolution: {integrity: sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==}
     engines: {node: '>= 14'}
     dev: true
+
+  /yaml@2.4.1:
+    resolution: {integrity: sha512-pIXzoImaqmfOrL7teGUBt/T7ZDnyeGBWyXQBvOVhLkWLN37GXv8NMLK406UY6dS51JfcQHsmcW5cJ441bHg6Lg==}
+    engines: {node: '>= 14'}
+    hasBin: true
 
   /yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}

--- a/test/__snapshots__/parser.test.ts.snap
+++ b/test/__snapshots__/parser.test.ts.snap
@@ -104,6 +104,14 @@ exports[`md parser > frontmatter.md > slides 1`] = `
         },
         "layout": "cover",
       },
+      "frontmatterDoc": {
+        "fonts": {
+          "mono": "Fira Code",
+          "sans": "Roboto, Lato",
+          "serif": "Mate SC",
+        },
+        "layout": "cover",
+      },
       "frontmatterRaw": "layout: cover
 fonts:
   sans: Roboto, Lato
@@ -153,6 +161,13 @@ fonts:
           "title": "FooBar",
         },
       },
+      "frontmatterDoc": {
+        "layout": "center",
+        "meta": {
+          "duration": 12,
+          "title": "FooBar",
+        },
+      },
       "frontmatterRaw": "meta:
   title: FooBar
   duration: 12
@@ -192,6 +207,7 @@ This is note
 ",
       "end": 27,
       "frontmatter": {},
+      "frontmatterDoc": null,
       "frontmatterRaw": undefined,
       "frontmatterStyle": undefined,
       "index": 2,
@@ -221,6 +237,9 @@ Hey
 ",
       "end": 38,
       "frontmatter": {
+        "layout": "text",
+      },
+      "frontmatterDoc": {
         "layout": "text",
       },
       "frontmatterRaw": "layout: text
@@ -273,6 +292,7 @@ Also part of the code block
 ",
       "end": 50,
       "frontmatter": {},
+      "frontmatterDoc": null,
       "frontmatterRaw": undefined,
       "frontmatterStyle": undefined,
       "index": 4,
@@ -308,6 +328,9 @@ Content 1
 ",
       "end": 59,
       "frontmatter": {
+        "layout": "from yaml",
+      },
+      "frontmatterDoc": {
         "layout": "from yaml",
       },
       "frontmatterRaw": "
@@ -354,6 +377,9 @@ Content 2
 ",
       "end": 70,
       "frontmatter": {
+        "layout": "cover",
+      },
+      "frontmatterDoc": {
         "layout": "cover",
       },
       "frontmatterRaw": "layout: cover
@@ -404,6 +430,7 @@ Content 3
 ",
       "end": 81,
       "frontmatter": {},
+      "frontmatterDoc": null,
       "frontmatterRaw": undefined,
       "frontmatterStyle": undefined,
       "index": 7,
@@ -514,6 +541,9 @@ exports[`md parser > mdc.md > slides 1`] = `
 ",
       "end": 8,
       "frontmatter": {
+        "mdc": true,
+      },
+      "frontmatterDoc": {
         "mdc": true,
       },
       "frontmatterRaw": "mdc: true
@@ -634,6 +664,7 @@ console.log('Hello World')
 ",
       "end": 10,
       "frontmatter": {},
+      "frontmatterDoc": null,
       "frontmatterRaw": undefined,
       "frontmatterStyle": undefined,
       "index": 0,
@@ -677,6 +708,7 @@ console.log('Hello World')
 ",
       "end": 19,
       "frontmatter": {},
+      "frontmatterDoc": null,
       "frontmatterRaw": undefined,
       "frontmatterStyle": undefined,
       "index": 1,
@@ -707,6 +739,7 @@ Nice to meet you
 ",
       "end": 23,
       "frontmatter": {},
+      "frontmatterDoc": null,
       "frontmatterRaw": undefined,
       "frontmatterStyle": undefined,
       "index": 2,
@@ -802,6 +835,7 @@ exports[`md parser > multi-entries.md > slides 1`] = `
       "content": "# Page 1",
       "end": 2,
       "frontmatter": {},
+      "frontmatterDoc": null,
       "frontmatterRaw": undefined,
       "frontmatterStyle": undefined,
       "index": 0,
@@ -831,6 +865,9 @@ exports[`md parser > multi-entries.md > slides 1`] = `
 <Tweet />",
       "end": 8,
       "frontmatter": {
+        "layout": "cover",
+      },
+      "frontmatterDoc": {
         "layout": "cover",
       },
       "frontmatterRaw": "layout: cover
@@ -864,6 +901,7 @@ layout: cover
       "content": "# Page 3",
       "end": 2,
       "frontmatter": {},
+      "frontmatterDoc": null,
       "frontmatterRaw": undefined,
       "frontmatterStyle": undefined,
       "index": 0,
@@ -893,6 +931,9 @@ layout: cover
 <Tweet />",
       "end": 10,
       "frontmatter": {
+        "layout": "cover",
+      },
+      "frontmatterDoc": {
         "layout": "cover",
       },
       "frontmatterRaw": "layout: cover
@@ -926,6 +967,7 @@ layout: cover
       "content": "# Page 1",
       "end": 2,
       "frontmatter": {},
+      "frontmatterDoc": null,
       "frontmatterRaw": undefined,
       "frontmatterStyle": undefined,
       "index": 0,
@@ -955,6 +997,9 @@ layout: cover
 <Tweet />",
       "end": 8,
       "frontmatter": {
+        "layout": "cover",
+      },
+      "frontmatterDoc": {
         "layout": "cover",
       },
       "frontmatterRaw": "layout: cover
@@ -988,6 +1033,7 @@ layout: cover
       "content": "# Page 3",
       "end": 2,
       "frontmatter": {},
+      "frontmatterDoc": null,
       "frontmatterRaw": undefined,
       "frontmatterStyle": undefined,
       "index": 0,
@@ -1017,6 +1063,9 @@ layout: cover
 <Tweet />",
       "end": 10,
       "frontmatter": {
+        "layout": "cover",
+      },
+      "frontmatterDoc": {
         "layout": "cover",
       },
       "frontmatterRaw": "layout: cover
@@ -1054,6 +1103,7 @@ $x+2$
 ",
       "end": 25,
       "frontmatter": {},
+      "frontmatterDoc": null,
       "frontmatterRaw": undefined,
       "frontmatterStyle": undefined,
       "index": 4,


### PR DESCRIPTION
This PR migrates `js-yaml` to `yaml`, because `yaml` can preserve the comments inside the frontmatter.

Usage:
- updating `dragPos`
- updating `contextmenu` (#1475)
- now `prettifySlide` will "format" the frontmatter (removing redundant spaces, etc.)
