### PR TITLE
fix: code block styles

### DIFF
--- a/packages/client/builtin/ShikiMagicMove.vue
+++ b/packages/client/builtin/ShikiMagicMove.vue
@@ -93,7 +93,7 @@ onMounted(() => {
 <template>
   <div ref="container" class="slidev-code-wrapper slidev-code-magic-move relative">
     <ShikiMagicMovePrecompiled
-      class="slidev-code relative shiki overflow-visible"
+      class="slidev-code relative shiki overflow-y-clip overflow-x-auto"
       :steps="steps"
       :step="stepIndex"
       :animate="!isPrintMode"

--- a/packages/client/styles/code.css
+++ b/packages/client/styles/code.css
@@ -42,6 +42,7 @@ html:not(.dark) .shiki span {
   border-radius: var(--slidev-code-radius) !important;
   background: var(--slidev-code-background);
   overflow: auto;
+  scrollbar-width: thin;
 }
 
 .slidev-code .slidev-code-highlighted {


### PR DESCRIPTION
This PR:

1. Set scroll bar in code block to `thin`

2. Fix #1531. But also makes the overflow part of code invisible during the magic move animation.

According to https://stackoverflow.com/questions/60832837/set-overflow-y-visible-while-overflow-x-is-auto-so-that-content-can-vertically-o :

> If either overflow-x or overflow-y property is neither visible nor clip, then visible/clip is calculated as auto/hidden, respectively.
>
> That is, if you specify overflow-x: auto;, overflow-y property will also be auto (because the default value is visible).

So `overflow-x-auto overflow-y-visible` will become `overflow-x-auto overflow-y-auto`, which will display a y scroll bar while animating. So we have to use `overflow-x-auto overflow-y-clip`.

Not sure if there is a better solution
