### PR TITLE
docs: correct page edit links

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -249,7 +249,7 @@ export default defineConfig({
   themeConfig: {
     logo: '/logo.svg',
     editLink: {
-      pattern: 'https://github.com/slidevjs/docs/edit/main/:path',
+      pattern: 'https://github.com/slidevjs/slidev/edit/main/docs/:path',
       text: 'Suggest changes to this page',
     },
 


### PR DESCRIPTION
Changed the page edit link at the bottom of `docs` webpages. Previously it pointed to the mirrored repo (`slidevjs/docs`) which doesn't accept PRs. Now it points to the `docs` folder in this one.