### PR TITLE
fix: disable code interop in inline code, fix #1540

### DIFF
--- a/packages/slidev/node/vite/markdown.ts
+++ b/packages/slidev/node/vite/markdown.ts
@@ -103,6 +103,7 @@ export async function createMarkdownPlugin(
     wrapperClasses: '',
     headEnabled: false,
     frontmatter: false,
+    escapeCodeTagInterpolation: false,
     markdownItOptions: {
       quotes: '""\'\'',
       html: true,
@@ -119,6 +120,7 @@ export async function createMarkdownPlugin(
         },
       })
 
+      md.use(MarkdownItEscapeInlineCode)
       md.use(MarkdownItFootnote)
       md.use(MarkdownItTaskList, { enabled: true, lineNumber: true, label: true })
       md.use(MarkdownItKatex, KatexOptions)
@@ -165,4 +167,12 @@ export async function createMarkdownPlugin(
       },
     },
   }) as Plugin
+}
+
+function MarkdownItEscapeInlineCode(md: MarkdownIt) {
+  const codeInline = md.renderer.rules.code_inline!
+  md.renderer.rules.code_inline = (tokens, idx, options, env, self) => {
+    const result = codeInline(tokens, idx, options, env, self)
+    return result.replace(/^<code/, '<code v-pre')
+  }
 }

--- a/packages/slidev/node/vite/markdown.ts
+++ b/packages/slidev/node/vite/markdown.ts
@@ -103,7 +103,6 @@ export async function createMarkdownPlugin(
     wrapperClasses: '',
     headEnabled: false,
     frontmatter: false,
-    escapeCodeTagInterpolation: false,
     markdownItOptions: {
       quotes: '""\'\'',
       html: true,


### PR DESCRIPTION
I am not sure why it was disabled before. But I think it would make sense to have it as the better default.