### PR TITLE
fix: HTML head tags injection

### DIFF
--- a/packages/slidev/node/commands/shared.ts
+++ b/packages/slidev/node/commands/shared.ts
@@ -2,16 +2,48 @@ import { existsSync, promises as fs } from 'node:fs'
 import { join } from 'node:path'
 import { loadConfigFromFile, mergeConfig, resolveConfig } from 'vite'
 import type { ConfigEnv, InlineConfig } from 'vite'
-import type { ResolvedSlidevOptions } from '@slidev/types'
-import { generateGoogleFontsUrl } from '../utils'
+import type { ResolvedSlidevOptions, SlidevData } from '@slidev/types'
+import { isString } from 'unocss'
+import MarkdownIt from 'markdown-it'
+import markdownItLink from '../syntax/markdown-it/markdown-it-link'
+import { generateGoogleFontsUrl, stringifyMarkdownTokens } from '../utils'
 import { toAtFS } from '../resolver'
+
+export const sharedMd = MarkdownIt({ html: true })
+sharedMd.use(markdownItLink)
+
+export function getTitle(data: SlidevData) {
+  if (isString(data.config.title)) {
+    const tokens = sharedMd.parseInline(data.config.title, {})
+    return stringifyMarkdownTokens(tokens)
+  }
+  return data.config.title
+}
+
+function escapeHtml(unsafe: unknown) {
+  return JSON.stringify(
+    String(unsafe)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#039;'),
+  )
+}
 
 export async function getIndexHtml({ clientRoot, roots, data }: ResolvedSlidevOptions): Promise<string> {
   let main = await fs.readFile(join(clientRoot, 'index.html'), 'utf-8')
   let head = ''
   let body = ''
 
-  head += `<link rel="icon" href="${data.config.favicon}">`
+  const { info, author, keywords } = data.headmatter
+  head += [
+    `<link rel="icon" href="${data.config.favicon}">`,
+    `<title>${getTitle(data)}</title>`,
+    info && `<meta name="description" content=${escapeHtml(info)}>`,
+    author && `<meta name="author" content=${escapeHtml(author)}>`,
+    keywords && `<meta name="keywords" content=${escapeHtml(Array.isArray(keywords) ? keywords.join(', ') : keywords)}>`,
+  ].filter(Boolean).join('\n')
 
   for (const root of roots) {
     const path = join(root, 'index.html')


### PR DESCRIPTION
In #1301 the `transformIndexHtml` hook was used to inject tags to HTML head. But the tags are not injected in fact because Slidev overrides the server's logic on `index.html` and the hook was not called.