### PR TITLE
fix: Twoslash popover displayed in wrong place

### DIFF
--- a/packages/client/internals/SlidesShow.vue
+++ b/packages/client/internals/SlidesShow.vue
@@ -81,8 +81,6 @@ function onAfterLeave() {
 
   <DragControl v-if="activeDragElement" :data="activeDragElement" />
 
-  <div id="twoslash-container" />
-
   <!-- Global Top -->
   <GlobalTop />
 

--- a/packages/client/pages/play.vue
+++ b/packages/client/pages/play.vue
@@ -73,4 +73,5 @@ if (__DEV__ && __SLIDEV_FEATURE_EDITOR__)
     <SideEditor v-if="SideEditor && showEditor" :resize="true" />
   </div>
   <Controls v-if="!isPrintMode" />
+  <div id="twoslash-container" />
 </template>

--- a/packages/client/styles/index.css
+++ b/packages/client/styles/index.css
@@ -124,3 +124,8 @@ html {
 #twoslash-container {
   position: fixed;
 }
+
+#twoslash-container .v-popper__wrapper {
+  transform: scale(calc(1 * var(--slidev-slide-scale)));
+  transform-origin: 30px top;
+}


### PR DESCRIPTION
fix #1593.

This is only a simple workaround. The root fix may requires a rewrite/fork of the Twoslash renderer, which will also make #1414 fixed).

Also tested in print mode.