### PR TITLE
fix: remove `--watch` option in build command

### DIFF
--- a/docs/guide/install.md
+++ b/docs/guide/install.md
@@ -182,7 +182,6 @@ Build hostable SPA.
 
 Options:
 
-- `--watch`, `-w` (`boolean`, default: `false`): build watch.
 - `--out`, `-o` (`string`, default: `dist`): output dir.
 - `--base` (`string`, default: `/`): base URL (see https://cli.vuejs.org/config/#publicpath)
 - `--download` (`boolean`, default: `false`): allow to download the slides as PDF inside the SPA.

--- a/packages/slidev/node/cli.ts
+++ b/packages/slidev/node/cli.ts
@@ -332,11 +332,6 @@ cli.command(
   'build [entry..]',
   'Build hostable SPA',
   args => exportOptions(commonOptions(args))
-    .option('watch', {
-      alias: 'w',
-      default: false,
-      describe: 'build watch',
-    })
     .option('out', {
       alias: 'o',
       type: 'string',
@@ -360,7 +355,7 @@ cli.command(
     .strict()
     .help(),
   async (args) => {
-    const { entry, theme, watch, base, download, out, inspect } = args
+    const { entry, theme, base, download, out, inspect } = args
     const { build } = await import('./commands/build')
 
     for (const entryFile of entry as unknown as string[]) {
@@ -374,7 +369,6 @@ cli.command(
         {
           base,
           build: {
-            watch: watch ? {} : undefined,
             outDir: entry.length === 1 ? out : path.join(out, path.basename(entryFile, '.md')),
           },
         },

--- a/packages/types/src/cli.ts
+++ b/packages/types/src/cli.ts
@@ -18,7 +18,6 @@ export interface ExportArgs extends CommonArgs {
 }
 
 export interface BuildArgs extends ExportArgs {
-  watch: boolean
   out: string
   base?: string
   download?: boolean


### PR DESCRIPTION
As #1597 reported, this option is not working. I don't think there is anyone using it, so it would be fine to just remove it.