### PR TITLE
fix: `VClick` component with `table` element

### DIFF
--- a/packages/client/builtin/VClick.ts
+++ b/packages/client/builtin/VClick.ts
@@ -36,6 +36,7 @@ export default defineComponent({
         at: this.at,
         hide: this.hide,
         fade: this.fade,
+        handleSpecialElements: false,
       },
       {
         default: () =>

--- a/packages/client/builtin/VClicks.ts
+++ b/packages/client/builtin/VClicks.ts
@@ -34,6 +34,10 @@ export default defineComponent({
       type: Boolean,
       default: false,
     },
+    handleSpecialElements: {
+      type: Boolean,
+      default: true,
+    },
   },
   render() {
     const every = +this.every
@@ -120,21 +124,23 @@ export default defineComponent({
       size: +at + Math.ceil((globalIdx - 1) / every) - 1 - execIdx,
     })
 
-    // handle ul, ol list
-    if (elements.length === 1 && listTags.includes(elements[0].type as string) && Array.isArray(elements[0].children))
-      return h(elements[0], {}, [...mapChildren(elements[0].children), lastGap()])
+    if (this.handleSpecialElements) {
+      // handle ul, ol list
+      if (elements.length === 1 && listTags.includes(elements[0].type as string) && Array.isArray(elements[0].children))
+        return h(elements[0], {}, [...mapChildren(elements[0].children), lastGap()])
 
-    if (elements.length === 1 && elements[0].type as string === 'table') {
-      const tableNode = elements[0]
-      if (Array.isArray(tableNode.children)) {
-        return h(tableNode, {}, tableNode.children.map((i) => {
-          if (!isVNode(i))
-            return i
-          else if (i.type === 'tbody' && Array.isArray(i.children))
-            return h(i, {}, [...mapChildren(i.children), lastGap()])
-          else
-            return h(i)
-        }))
+      if (elements.length === 1 && elements[0].type as string === 'table') {
+        const tableNode = elements[0]
+        if (Array.isArray(tableNode.children)) {
+          return h(tableNode, {}, tableNode.children.map((i) => {
+            if (!isVNode(i))
+              return i
+            else if (i.type === 'tbody' && Array.isArray(i.children))
+              return h(i, {}, [...mapChildren(i.children), lastGap()])
+            else
+              return h(i)
+          }))
+        }
       }
     }
 


### PR DESCRIPTION
Because `VClick` is a wrapper of `VClicks` component, and `VClicks` has special handling for `table` element, previously, the header of the table was shown before it should be, like this:

![image](https://github.com/slidevjs/slidev/assets/63178754/8063541b-7a9b-489a-b3b6-67f610c00801)

This PR fixes this via a new `handleSpecialElements` prop in `VClicks` element to disable the special handling