### PR TITLE
fix: should restart server on feature change

### DIFF
--- a/packages/slidev/node/cli.ts
+++ b/packages/slidev/node/cli.ts
@@ -190,6 +190,13 @@ cli.command(
               restartServer()
               return false
             }
+
+            if ((newData.features.katex && !oldData.features.katex) || (newData.features.monaco && !oldData.features.monaco)) {
+              console.log(yellow('\n  restarting on feature change\n'))
+              restartServer()
+              return false
+            }
+
             return newData
           },
         },

--- a/packages/slidev/node/vite/loaders.ts
+++ b/packages/slidev/node/vite/loaders.ts
@@ -47,22 +47,6 @@ export function getBodyJson(req: Connect.IncomingMessage) {
   })
 }
 
-export function sendHmrReload(server: ViteDevServer, modules: ModuleNode[]) {
-  const timestamp = +Date.now()
-
-  modules.forEach(m => server.moduleGraph.invalidateModule(m))
-
-  server.ws.send({
-    type: 'update',
-    updates: modules.map<Update>(m => ({
-      acceptedPath: m.id || m.file!,
-      path: m.file!,
-      timestamp,
-      type: 'js-update',
-    })),
-  })
-}
-
 function renderNote(text: string = '') {
   let clickCount = 0
   const html = sharedMd.render(text

--- a/packages/slidev/node/vite/loaders.ts
+++ b/packages/slidev/node/vite/loaders.ts
@@ -1,5 +1,5 @@
 import path from 'node:path'
-import type { Connect, ModuleNode, Plugin, Update, ViteDevServer } from 'vite'
+import type { Connect, Plugin, ViteDevServer } from 'vite'
 import { notNullish, range } from '@antfu/utils'
 import fg from 'fast-glob'
 import { bold, gray, red, yellow } from 'kolorist'


### PR DESCRIPTION
Previously, when `data.features` changed, the browser page will get a full reload but the server isn't started. This caused some problems. For example, the Katex CSS is not loaded when user adds the first Katex code block.

This PR restarts the server when the `katex` and `monaco` features become enabled.