### PR TITLE
fix: install slidev cli in .github/workflows/deploy.yml

### DIFF
--- a/docs/guide/hosting.md
+++ b/docs/guide/hosting.md
@@ -179,6 +179,9 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      - name: Install slidev
+        run:  npm i -g @slidev/cli
+
       - name: Build
         run: npm run build -- --base /<name_of_repo>/
 


### PR DESCRIPTION
`npm run build -- --base /<repo-name>/` fails as slidev is not installed