### PR TITLE
fix: navigating on the first and last click

### DIFF
--- a/packages/client/composables/useNav.ts
+++ b/packages/client/composables/useNav.ts
@@ -156,18 +156,22 @@ export function useNavBase(
 
   async function nextSlide(lastClicks = false) {
     clicksDirection.value = 1
-    await go(
-      Math.min(currentSlideNo.value + 1, slides.value.length),
-      lastClicks && !isPrint.value ? CLICKS_MAX : undefined,
-    )
+    if (currentSlideNo.value < slides.value.length) {
+      await go(
+        currentSlideNo.value + 1,
+        lastClicks && !isPrint.value ? CLICKS_MAX : undefined,
+      )
+    }
   }
 
   async function prevSlide(lastClicks = false) {
     clicksDirection.value = -1
-    await go(
-      Math.max(1, currentSlideNo.value - 1),
-      lastClicks && !isPrint.value ? CLICKS_MAX : undefined,
-    )
+    if (currentSlideNo.value > 1) {
+      await go(
+        currentSlideNo.value - 1,
+        lastClicks && !isPrint.value ? CLICKS_MAX : undefined,
+      )
+    }
   }
 
   function goFirst() {


### PR DESCRIPTION
This is a regression caused by #1557: pressing right arrow key on the last click of the last slide will set clicks to 0, and pressing left arrow key on the first click of the first slide will set clicks to CLICKS_MAX