### PR TITLE
docs(hosting): use GitHub action variable to set base url

### DIFF
--- a/docs/guide/hosting.md
+++ b/docs/guide/hosting.md
@@ -145,7 +145,7 @@ Then go to your Vercel dashboard and create a new site with the repository.
 To deploy your slides on GitHub Pages:
 
 - upload all the files of the project in your repo (i.e. named `name_of_repo`)
-- create `.github/workflows/deploy.yml` with the following content to deploy your slides to GitHub Pages via GitHub Actions. In this file, replace `<name_of_repo>` with `name_of_repo`. Make sure to leave the leading and trailing slashes in place.
+- create `.github/workflows/deploy.yml` with the following content to deploy your slides to GitHub Pages via GitHub Actions.
 
 ```yaml
 name: Deploy pages
@@ -180,7 +180,7 @@ jobs:
         run: npm install
 
       - name: Build
-        run: npm run build -- --base /<name_of_repo>/
+        run: npm run build -- --base /${{github.event.repository.name}}/
 
       - uses: actions/configure-pages@v4
 


### PR DESCRIPTION
In the docs, there is the following : `In this file, replace <name_of_repo> with name_of_repo`. This is used to set the base path to the name of the repo on build. But this value set manually by the user can be retrieved from Github Actions variables.

You can find an example here : https://github.com/damienfern/talk_creer_son_twitch_personnel/