### PR TITLE
fix: should render title correctly in `index.html`

### DIFF
--- a/packages/client/env.ts
+++ b/packages/client/env.ts
@@ -17,4 +17,4 @@ export const themeVars = computed(() => {
   return objectMap(configs.themeConfig || {}, (k, v) => [`--slidev-theme-${k}`, v])
 })
 
-export const slidesTitle = configs.titleTemplate.replace('%s', configs.title || 'Slidev')
+export const slidesTitle = configs.slidesTitle

--- a/packages/parser/src/fs.ts
+++ b/packages/parser/src/fs.ts
@@ -96,10 +96,9 @@ export async function load(userRoot: string, filepath: string, content?: string,
 
   const entry = await loadMarkdown(slash(filepath))
 
-  const headmatter = {
-    title: slides[0]?.title,
-    ...entry.slides[0]?.frontmatter,
-  }
+  const headmatter = { ...entry.slides[0]?.frontmatter }
+  if (slides[0]?.title)
+    headmatter.title = slides[0].title
 
   return {
     slides,

--- a/packages/slidev/node/commands/shared.ts
+++ b/packages/slidev/node/commands/shared.ts
@@ -3,7 +3,6 @@ import { join } from 'node:path'
 import { loadConfigFromFile, mergeConfig, resolveConfig } from 'vite'
 import type { ConfigEnv, InlineConfig } from 'vite'
 import type { ResolvedSlidevOptions, SlidevData } from '@slidev/types'
-import { isString } from 'unocss'
 import MarkdownIt from 'markdown-it'
 import { slash } from '@antfu/utils'
 import markdownItLink from '../syntax/markdown-it/markdown-it-link'
@@ -14,12 +13,11 @@ import { version } from '../../package.json'
 export const sharedMd = MarkdownIt({ html: true })
 sharedMd.use(markdownItLink)
 
-export function getTitle(data: SlidevData) {
-  if (isString(data.config.title)) {
-    const tokens = sharedMd.parseInline(data.config.title, {})
-    return stringifyMarkdownTokens(tokens)
-  }
-  return data.config.title
+export function getSlideTitle(data: SlidevData) {
+  const tokens = sharedMd.parseInline(data.config.title, {})
+  const title = stringifyMarkdownTokens(tokens)
+  const slideTitle = data.config.titleTemplate.replace('%s', title)
+  return slideTitle === 'Slidev - Slidev' ? 'Slidev' : slideTitle
 }
 
 function escapeHtml(unsafe: unknown) {
@@ -43,7 +41,7 @@ export async function getIndexHtml({ entry, clientRoot, roots, data }: ResolvedS
     `<meta name="slidev:version" content="${version}">`,
     `<meta charset="slidev:entry" content="${slash(entry)}">`,
     `<link rel="icon" href="${data.config.favicon}">`,
-    `<title>${getTitle(data)}</title>`,
+    `<title>${getSlideTitle(data)}</title>`,
     info && `<meta name="description" content=${escapeHtml(info)}>`,
     author && `<meta name="author" content=${escapeHtml(author)}>`,
     keywords && `<meta name="keywords" content=${escapeHtml(Array.isArray(keywords) ? keywords.join(', ') : keywords)}>`,

--- a/packages/slidev/node/virtual/configs.ts
+++ b/packages/slidev/node/virtual/configs.ts
@@ -1,22 +1,14 @@
 import { isString } from '@antfu/utils'
-import { stringifyMarkdownTokens } from '../utils'
+import { getSlideTitle } from '../commands/shared'
 import type { VirtualModuleTemplate } from './types'
 
 export const templateConfigs: VirtualModuleTemplate = {
   id: '/@slidev/configs',
   getContent: async ({ data, remote }, { md }) => {
-    function getTitle() {
-      if (isString(data.config.title)) {
-        const tokens = md.parseInline(data.config.title, {})
-        return stringifyMarkdownTokens(tokens)
-      }
-      return data.config.title
-    }
-
     const config = {
       ...data.config,
       remote,
-      title: getTitle(),
+      slidesTitle: getSlideTitle(data),
     }
 
     if (isString(config.info))

--- a/packages/types/client.d.ts
+++ b/packages/types/client.d.ts
@@ -4,7 +4,7 @@
 declare module '#slidev/configs' {
   import type { SlidevConfig } from '@slidev/types'
 
-  const configs: SlidevConfig
+  const configs: SlidevConfig & { slidesTitle: string }
   export default configs
 }
 


### PR DESCRIPTION
Previously, the `getTitle` returns undefined, because the logic in itself is incorrect, and the `load` function in `parser/fs.ts` returns `headmatter: {title: undefined}` which prevents the default value (`"Slidev"`) of `title` from taking effect.