### PR TITLE
feat: two-way arrow and `v-drag-arrow`

### DIFF
--- a/demo/starter/slides.md
+++ b/demo/starter/slides.md
@@ -598,7 +598,11 @@ Double-click on the draggable elements to edit their positions.
 
 ###### Draggable Arrow
 
-<v-drag-arrow two-way pos="71,428,245,56" op70 />
+```md
+<v-drag-arrow two-way />
+```
+
+<v-drag-arrow pos="67,452,253,46" two-way op70 />
 
 ---
 src: ./pages/multiple-entries.md

--- a/demo/starter/slides.md
+++ b/demo/starter/slides.md
@@ -562,7 +562,7 @@ database "MySql" {
 ---
 foo: bar
 dragPos:
-  square: 691,33,167,_,-16
+  square: 691,32,167,_,-16
 ---
 
 # Draggable Elements
@@ -588,13 +588,17 @@ Double-click on the draggable elements to edit their positions.
 </v-drag>
 ```
 
-<v-drag pos="671,205,253,_,-15">
+<v-drag pos="663,206,261,_,-15">
   <div text-center text-3xl border border-main rounded>
     Double-click me!
   </div>
 </v-drag>
 
 <img v-drag="'square'" src="https://sli.dev/logo.png">
+
+###### Draggable Arrow
+
+<v-drag-arrow two-way pos="71,428,245,56" op70 />
 
 ---
 src: ./pages/multiple-entries.md

--- a/docs/builtin/components.md
+++ b/docs/builtin/components.md
@@ -30,6 +30,17 @@ Parameters:
 - `y2` (`string | number`, required): end point x position
 - `width` (`string | number`, default: `2`): line width
 - `color` (`string`, default: `'currentColor'`): line color
+- `two-way` (`boolean`, default: `false`): draw a two-way arrow
+
+### `VDragArrow`
+
+An `Arrow` component that can be dragged.
+
+#### Usage
+
+See https://sli.dev/guide/draggable.html#draggable-arrow
+
+Parameters not related to position are the same as [the `Arrow` component](#arrow).
 
 ### `AutoFitText`
 

--- a/docs/guide/draggable.md
+++ b/docs/guide/draggable.md
@@ -64,3 +64,13 @@ When you first create a draggable element, you don't need to specify the positio
 - You can also use the arrow keys to move the element.
 - Hold `Shift` while dragging to preserve its aspect ratio.
 - Click outside the draggable element to stop dragging it.
+
+## Draggable Arrow
+
+The `<v-drag-arrow>` component creates a draggable arrow element. Simply use it like this:
+
+```md
+<v-drag-arrow />
+```
+
+And you will get a draggable arrow element. Other props are the same as [the `Arrow` component](/builtin/components#arrow).

--- a/packages/client/builtin/Arrow.vue
+++ b/packages/client/builtin/Arrow.vue
@@ -18,9 +18,19 @@ defineProps<{
   y2: number | string
   width?: number | string
   color?: string
+  twoWay?: boolean
 }>()
 
 const id = makeId()
+
+const markerAttrs = {
+  markerUnits: 'strokeWidth',
+  markerWidth: 10,
+  markerHeight: 7,
+  refX: 9,
+  refY: 3.5,
+  orient: 'auto',
+}
 </script>
 
 <template>
@@ -30,26 +40,19 @@ const id = makeId()
     :height="Math.max(+y1, +y2) + 50"
   >
     <defs>
-      <marker
-        :id="id"
-        markerUnits="strokeWidth"
-        :markerWidth="10"
-        :markerHeight="7"
-        refX="9"
-        refY="3.5"
-        orient="auto"
-      >
+      <marker :id="id" v-bind="markerAttrs">
         <polygon points="0 0, 10 3.5, 0 7" :fill="color || 'currentColor'" />
+      </marker>
+      <marker v-if="twoWay" :id="`${id}-rev`" v-bind="markerAttrs">
+        <polygon points="10 0, 0 3.5, 10 7" :fill="color || 'currentColor'" />
       </marker>
     </defs>
     <line
-      :x1="+x1"
-      :y1="+y1"
-      :x2="+x2"
-      :y2="+y2"
+      :x1 :y1 :x2 :y2
       :stroke="color || 'currentColor'"
       :stroke-width="width || 2"
       :marker-end="`url(#${id})`"
+      :marker-start="twoWay ? `url(#${id}-rev)` : 'none'"
     />
   </svg>
 </template>

--- a/packages/client/builtin/Arrow.vue
+++ b/packages/client/builtin/Arrow.vue
@@ -9,6 +9,8 @@ Simple Arrow
 -->
 
 <script setup lang="ts">
+import { ref } from 'vue'
+import { onClickOutside } from '@vueuse/core'
 import { makeId } from '../logic/utils'
 
 defineProps<{
@@ -21,30 +23,33 @@ defineProps<{
   twoWay?: boolean
 }>()
 
+const emit = defineEmits(['dblclick', 'clickOutside'])
+
 const id = makeId()
 
 const markerAttrs = {
   markerUnits: 'strokeWidth',
-  markerWidth: 10,
   markerHeight: 7,
-  refX: 9,
   refY: 3.5,
   orient: 'auto',
 }
+
+const clickArea = ref<HTMLElement>()
+onClickOutside(clickArea, () => emit('clickOutside'))
 </script>
 
 <template>
   <svg
-    class="absolute left-0 top-0 pointer-events-none"
+    class="absolute left-0 top-0"
     :width="Math.max(+x1, +x2) + 50"
     :height="Math.max(+y1, +y2) + 50"
   >
     <defs>
-      <marker :id="id" v-bind="markerAttrs">
-        <polygon points="0 0, 10 3.5, 0 7" :fill="color || 'currentColor'" />
+      <marker :id="id" markerWidth="10" refX="9" v-bind="markerAttrs">
+        <polygon points="0 0, 10 3.5, 0 7" :fill="color || 'currentColor'" @dblclick="emit('dblclick')" />
       </marker>
-      <marker v-if="twoWay" :id="`${id}-rev`" v-bind="markerAttrs">
-        <polygon points="10 0, 0 3.5, 10 7" :fill="color || 'currentColor'" />
+      <marker v-if="twoWay" :id="`${id}-rev`" markerWidth="20" refX="11" v-bind="markerAttrs">
+        <polygon points="20 0, 10 3.5, 20 7" :fill="color || 'currentColor'" @dblclick="emit('dblclick')" />
       </marker>
     </defs>
     <line
@@ -53,6 +58,15 @@ const markerAttrs = {
       :stroke-width="width || 2"
       :marker-end="`url(#${id})`"
       :marker-start="twoWay ? `url(#${id}-rev)` : 'none'"
+      @dblclick="emit('dblclick')"
+    />
+    <line
+      ref="clickArea"
+      :x1 :y1 :x2 :y2
+      stroke="transparent"
+      stroke-linecap="round"
+      :stroke-width="20"
+      @dblclick="emit('dblclick')"
     />
   </svg>
 </template>

--- a/packages/client/builtin/VDrag.vue
+++ b/packages/client/builtin/VDrag.vue
@@ -8,7 +8,7 @@ const props = defineProps<{
   markdownSource?: DragElementMarkdownSource
 }>()
 
-const { id, container, containerStyle, mounted, unmounted, startDragging } = useDragElement(null, props.pos, props.markdownSource)
+const { dragId, container, containerStyle, mounted, unmounted, startDragging } = useDragElement(null, props.pos, props.markdownSource)
 
 onMounted(mounted)
 onUnmounted(unmounted)
@@ -17,7 +17,7 @@ onUnmounted(unmounted)
 <template>
   <div
     ref="container"
-    :data-drag-id="id"
+    :data-drag-id="dragId"
     :style="containerStyle"
     class="p-1"
     @dblclick="startDragging"

--- a/packages/client/builtin/VDragArrow.vue
+++ b/packages/client/builtin/VDragArrow.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted } from 'vue'
+import type { DragElementMarkdownSource } from '../composables/useDragElements'
+import { useDragElement } from '../composables/useDragElements'
+import Arrow from './Arrow.vue'
+
+const props = defineProps<{
+  pos?: string
+  markdownSource?: DragElementMarkdownSource
+  width?: number | string
+  color?: string
+  twoWay?: boolean
+}>()
+
+const { dragId, mounted, unmounted, startDragging, stopDragging, x0, y0, width, height } = useDragElement(null, props.pos ?? '100,100,300,300', props.markdownSource, true)
+
+onMounted(mounted)
+onUnmounted(unmounted)
+
+const x1 = computed(() => x0.value - width.value / 2)
+const y1 = computed(() => y0.value - height.value / 2)
+const x2 = computed(() => x0.value + width.value / 2)
+const y2 = computed(() => y0.value + height.value / 2)
+</script>
+
+<template>
+  <Arrow
+    :x1 :y1 :x2 :y2
+    :data-drag-id="dragId"
+    :width="props.width"
+    :color="props.color"
+    :two-way="props.twoWay"
+    @dblclick="startDragging"
+    @click-outside="stopDragging"
+  />
+</template>

--- a/packages/client/internals/DragControl.vue
+++ b/packages/client/internals/DragControl.vue
@@ -10,14 +10,14 @@ import { slideHeight, slideWidth } from '../env'
 import { magicKeys } from '../state'
 
 const { data } = defineProps<{ data: DragElementState }>()
-const { id, zoom, autoHeight, x0, y0, width, height, rotate } = data
+const { dragId, zoom, autoHeight, x0, y0, width, height, rotate, isArrow } = data
 
 const slideScale = inject(injectionSlideScale, ref(1))
 const scale = computed(() => slideScale.value * zoom.value)
 const { left: slideLeft, top: slideTop } = useSlideBounds()
 
 const ctrlSize = 10
-const minSize = 40
+const minSize = isArrow ? Number.NEGATIVE_INFINITY : 40
 const minRemain = 10
 
 const rotateRad = computed(() => rotate.value * Math.PI / 180)
@@ -31,6 +31,9 @@ const boundingLeft = computed(() => x0.value - boundingWidth.value / 2)
 const boundingTop = computed(() => y0.value - boundingHeight.value / 2)
 const boundingRight = computed(() => x0.value + boundingWidth.value / 2)
 const boundingBottom = computed(() => y0.value + boundingHeight.value / 2)
+
+const arrowRevX = computed(() => isArrow && width.value < 0)
+const arrowRevY = computed(() => isArrow && height.value < 0)
 
 let currentDrag: {
   x0: number
@@ -206,11 +209,12 @@ function getCornerProps(isLeft: boolean, isTop: boolean) {
       width: `${ctrlSize}px`,
       height: `${ctrlSize}px`,
       margin: `-${ctrlSize / 2}px`,
-      left: isLeft ? '0' : undefined,
-      right: isLeft ? undefined : '0',
-      top: isTop ? '0' : undefined,
-      bottom: isTop ? undefined : '0',
-      cursor: +isLeft + +isTop === 1 ? 'nesw-resize' : 'nwse-resize',
+      left: isLeft !== arrowRevX.value ? '0' : undefined,
+      right: isLeft !== arrowRevX.value ? undefined : '0',
+      top: isTop !== arrowRevY.value ? '0' : undefined,
+      bottom: isTop !== arrowRevY.value ? undefined : '0',
+      cursor: isArrow ? 'move' : +isLeft + +isTop === 1 ? 'nesw-resize' : 'nwse-resize',
+      borderRadius: isArrow ? '50%' : undefined,
     },
     class: ctrlClasses,
   }
@@ -356,14 +360,14 @@ watchEffect(() => {
   <div
     v-if="Number.isFinite(x0)"
     id="drag-control-container"
-    :data-drag-id="id"
+    :data-drag-id="dragId"
     :style="{
       position: 'absolute',
       zIndex: 100,
-      left: `${zoom * (x0 - width / 2)}px`,
-      top: `${zoom * (y0 - height / 2)}px`,
-      width: `${zoom * width}px`,
-      height: `${zoom * height}px`,
+      left: `${zoom * (x0 - Math.abs(width) / 2)}px`,
+      top: `${zoom * (y0 - Math.abs(height) / 2)}px`,
+      width: `${zoom * Math.abs(width)}px`,
+      height: `${zoom * Math.abs(height)}px`,
       transformOrigin: 'center center',
       transform: `rotate(${rotate}deg)`,
     }"
@@ -371,27 +375,31 @@ watchEffect(() => {
     @pointermove="onPointermove"
     @pointerup="onPointerup"
   >
-    <div class="absolute inset-0 z-100 b b-dark dark:b-gray-400">
+    <div class="absolute inset-0 z-100 dark:b-gray-400" :class="isArrow ? '' : 'b b-dark'">
       <template v-if="!autoHeight">
         <div v-bind="getCornerProps(true, true)" />
-        <div v-bind="getCornerProps(true, false)" />
-        <div v-bind="getCornerProps(false, true)" />
         <div v-bind="getCornerProps(false, false)" />
+        <template v-if="!isArrow">
+          <div v-bind="getCornerProps(true, false)" />
+          <div v-bind="getCornerProps(false, true)" />
+        </template>
       </template>
-      <div v-bind="getBorderProps('l')" />
-      <div v-bind="getBorderProps('r')" />
-      <template v-if="!autoHeight">
-        <div v-bind="getBorderProps('t')" />
-        <div v-bind="getBorderProps('b')" />
+      <template v-if="!isArrow">
+        <div v-bind="getBorderProps('l')" />
+        <div v-bind="getBorderProps('r')" />
+        <template v-if="!autoHeight">
+          <div v-bind="getBorderProps('t')" />
+          <div v-bind="getBorderProps('b')" />
+        </template>
+        <div v-bind="getRotateProps()" />
+        <div
+          class="absolute -top-15px w-0 b b-dashed b-dark dark:b-gray-400"
+          :style="{
+            left: 'calc(50% - 1px)',
+            height: autoHeight ? '14px' : '10px',
+          }"
+        />
       </template>
-      <div v-bind="getRotateProps()" />
-      <div
-        class="absolute -top-15px w-0 b b-dashed b-dark dark:b-gray-400"
-        :style="{
-          left: 'calc(50% - 1px)',
-          height: autoHeight ? '14px' : '10px',
-        }"
-      />
     </div>
   </div>
 </template>

--- a/packages/client/modules/v-drag.ts
+++ b/packages/client/modules/v-drag.ts
@@ -18,12 +18,12 @@ export function createVDragDirective() {
           }
           state.container.value = el
           el.draggingState = state
-          el.dataset.dragId = state.id
+          el.dataset.dragId = state.dragId
           state.watchStopHandles.push(
             watch(state.containerStyle, (style) => {
               for (const [k, v] of Object.entries(style)) {
                 if (v)
-                  el.style[k as any] = v
+                  el.style[k as any] = v as any
               }
             }, { immediate: true }),
           )

--- a/packages/slidev/node/syntax/markdown-it/markdown-it-v-drag.ts
+++ b/packages/slidev/node/syntax/markdown-it/markdown-it-v-drag.ts
@@ -34,14 +34,14 @@ export default function markdownItVDrag(md: MarkdownIt, markdownTransformMap: Ma
     }
     return _parse.call(this, src, env)
       .map((token) => {
-        if (token.type !== 'html_block' || !token.content.includes('v-drag') || visited.has(token))
+        if (!['html_block', 'html_inline'].includes(token.type) || !token.content.includes('v-drag') || visited.has(token))
           return token
 
         // Iterates all html tokens and replaces <v-drag> with <v-drag :markdownSource="..."> to pass the markdown source to the component
         token.content = token.content
           .replace(
-            /<v-drag([\s>])/g,
-            (_, space, idx) => `<v-drag :markdownSource="${toMarkdownSource(token.map!, idx)}"${space}`,
+            /<(v-?drag-?\w*)([\s>])/gi,
+            (_, tag, space, idx) => `<${tag} :markdownSource="${toMarkdownSource(token.map!, idx)}"${space}`,
           )
           .replace(
             /(?<![</\w])v-drag(=".*?")?/g,


### PR DESCRIPTION
Now arrows are draggable via the `<v-drag-arrow />` component. (See demo slides page 13)

- Should there be `<Line>` and `<v-drag-line>` ?
- I think currently the cost to maintain 3 kinds of draggable elements (directive, `<v-drag>`, `<v-drag-arrow>`) is lower than coming up with a more universal draggable solution. Because these 3 ones are different in many behaviors. Not sure if there will be more draggable components in the feature.