### PR TITLE
fix(monaco): `editorOptions` from monaco setup not applied

### DIFF
--- a/packages/client/builtin/Monaco.vue
+++ b/packages/client/builtin/Monaco.vue
@@ -97,7 +97,7 @@ const stopWatchTypesLoading = whenever(
 onMounted(async () => {
   // Lazy load monaco, so it will be bundled in async chunk
   const { default: setup } = await import('../setup/monaco')
-  const { ata, monaco } = await setup()
+  const { ata, monaco, editorOptions } = await setup()
   const model = monaco.editor.createModel(code.value, lang, monaco.Uri.parse(`file:///${makeId()}.${ext}`))
   model.onDidChangeContent(() => code.value = model.getValue())
   const commonOptions = {
@@ -114,6 +114,7 @@ onMounted(async () => {
     fontSize: 11.5,
     fontFamily: 'var(--slidev-code-font-family)',
     scrollBeyondLastLine: false,
+    ...editorOptions,
     ...props.editorOptions,
   } satisfies monaco.editor.IStandaloneEditorConstructionOptions & monaco.editor.IDiffEditorConstructionOptions
 

--- a/packages/client/setup/monaco.ts
+++ b/packages/client/setup/monaco.ts
@@ -95,10 +95,10 @@ const setup = createSingletonPromise(async () => {
   const { shiki, themes, shikiToMonaco } = await import('#slidev/shiki')
   const highlighter = await shiki
 
-  const setupReturn: MonacoSetupReturn = {}
+  const editorOptions: MonacoSetupReturn['editorOptions'] & object = {}
   for (const setup of setups) {
     const result = await setup(monaco)
-    Object.assign(setupReturn, result)
+    Object.assign(editorOptions, result?.editorOptions)
   }
 
   // Use Shiki to highlight Monaco
@@ -117,7 +117,7 @@ const setup = createSingletonPromise(async () => {
   return {
     monaco,
     ata,
-    ...setupReturn,
+    editorOptions,
   }
 })
 


### PR DESCRIPTION
Hi 👋 

first of all: thank you for this great tool :)

I noticed that it's not possible to configure the monaco editor via a `setup/monaco.ts` file as described at https://sli.dev/custom/config-monaco. This PR fixes that 😁