### PR TITLE
fix: Updated types of PreparserSetup

### DIFF
--- a/packages/types/src/setups.ts
+++ b/packages/types/src/setups.ts
@@ -67,7 +67,11 @@ export type ShikiSetupReturn =
 export type ShikiSetup = (shiki: ShikiContext) => Awaitable<ShikiSetupReturn | void>
 export type KatexSetup = () => Awaitable<Partial<KatexOptions> | void>
 export type UnoSetup = () => Awaitable<Partial<UnoCssConfig> | void>
-export type PreparserSetup = (filepath: string) => SlidevPreparserExtension
+export type PreparserSetup = (context: {
+  filepath: string
+  headmatter: Record<string, unknown>
+  mode: string
+}) => SlidevPreparserExtension[]
 
 // client side
 export type MonacoSetup = (m: typeof monaco) => Awaitable<MonacoSetupReturn | void>

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -114,7 +114,7 @@ export interface SlidevData {
 }
 
 export interface SlidevPreparserExtension {
-  name: string
+  name?: string
   transformRawLines?: (lines: string[]) => Promise<void> | void
   transformSlide?: (content: string, frontmatter: any) => Promise<string | undefined>
 }


### PR DESCRIPTION
It seems like the types of the `PreparserSetup` are outdated. At least they don't match what's described at https://sli.dev/custom/config-parser#preparser-extensions :)