### PR TITLE
fix: do not duplicate Vite config

### DIFF
--- a/packages/slidev/node/commands/server.ts
+++ b/packages/slidev/node/commands/server.ts
@@ -32,6 +32,7 @@ export async function createServer(
     mergeConfig(
       config,
       {
+        configFile: false,
         plugins: [
           await ViteSlidevPlugin(options, config.slidev || {}, serverOptions),
         ],


### PR DESCRIPTION
We already load and merge the vite.config.ts files from different roots, but createServer from Vite (imported as createViteServer) will load the the vite.config.ts from the project root and merge it with the provided config. This means, in particular, that plugins may end up being duplicated which can lead to various issues.