### PR TITLE
feat(vscode): optimize slide number with merging logic

### DIFF
--- a/packages/vscode/src/views/annotations.ts
+++ b/packages/vscode/src/views/annotations.ts
@@ -30,6 +30,20 @@ const frontmatterContentDecoration = window.createTextEditorDecorationType({
 })
 const frontmatterEndDecoration = window.createTextEditorDecorationType(dividerCommonOptions)
 
+function mergeSlideNumbers(slides: { index: number }[]): string {
+  const indexes = slides.map(s => s.index + 1)
+  const merged = [[indexes[0], indexes[0]]]
+  for (let i = 1; i < indexes.length; i++) {
+    if (merged[merged.length - 1][1] + 1 === indexes[i]) {
+      merged[merged.length - 1][1] = indexes[i]
+    }
+    else {
+      merged.push([indexes[i], indexes[i]])
+    }
+  }
+  return merged.map(([start, end]) => start === end ? `#${start}` : `#${start}-${end}`).join(', ')
+}
+
 export const useAnnotations = createSingletonComposable(() => {
   const editor = useActiveTextEditor()
   const doc = computed(() => editor.value?.document)
@@ -56,7 +70,7 @@ export const useAnnotations = createSingletonComposable(() => {
           s => s.source === source || s.importChain?.includes(source),
         )
         const posInfo = slides?.length
-          ? slides.map(s => `#${s.index + 1}`).join(', ')
+          ? mergeSlideNumbers(slides)
           : isActive ? '(hidden)' : ''
         const entryInfo = source.index === 0 && project.data.entry !== md
           ? ` (entry: ${toRelativePath(project.entry)})`

--- a/packages/vscode/src/views/annotations.ts
+++ b/packages/vscode/src/views/annotations.ts
@@ -33,11 +33,11 @@ const frontmatterEndDecoration = window.createTextEditorDecorationType(dividerCo
 function mergeSlideNumbers(slides: { index: number }[]): string {
   const indexes = slides.map(s => s.index + 1)
   const merged = [[indexes[0], indexes[0]]]
-  for (const index of indexes) {
-    if (merged.at(-1)[1] + 1 === index)
-      merged.at(-1)[1] = index
+  for (let i = 1; i < indexes.length; i++) {
+    if (merged[merged.length - 1][1] + 1 === indexes[i])
+      merged[merged.length - 1][1] = indexes[i]
     else
-      merged.push([index, index])
+      merged.push([indexes[i], indexes[i]])
   }
   return merged.map(([start, end]) => start === end ? `#${start}` : `#${start}-${end}`).join(', ')
 }

--- a/packages/vscode/src/views/annotations.ts
+++ b/packages/vscode/src/views/annotations.ts
@@ -33,13 +33,11 @@ const frontmatterEndDecoration = window.createTextEditorDecorationType(dividerCo
 function mergeSlideNumbers(slides: { index: number }[]): string {
   const indexes = slides.map(s => s.index + 1)
   const merged = [[indexes[0], indexes[0]]]
-  for (let i = 1; i < indexes.length; i++) {
-    if (merged[merged.length - 1][1] + 1 === indexes[i]) {
-      merged[merged.length - 1][1] = indexes[i]
-    }
-    else {
-      merged.push([indexes[i], indexes[i]])
-    }
+  for (const index of indexes) {
+    if (merged.at(-1)[1] + 1 === index)
+      merged.at(-1)[1] = index
+    else
+      merged.push([index, index])
   }
   return merged.map(([start, end]) => start === end ? `#${start}` : `#${start}-${end}`).join(', ')
 }


### PR DESCRIPTION
Old behaviour:

```
--- #2, #3, #4, #5, #6
src: ./other.md
---
```

New behaviour:
```
--- #2-6
src: ./other.md
---
```