### PR TITLE
fix: do not run `resolveConfig` to get Vite configs in user root

### DIFF
--- a/packages/slidev/node/commands/build.ts
+++ b/packages/slidev/node/commands/build.ts
@@ -24,7 +24,7 @@ export async function build(
   let config: ResolvedConfig = undefined!
 
   try {
-    let inlineConfig = await mergeViteConfigs(
+    const inlineConfig = await mergeViteConfigs(
       options,
       viteConfig,
       <InlineConfig>({
@@ -44,16 +44,14 @@ export async function build(
       'build',
     )
 
-    inlineConfig = mergeConfig(
+    await viteBuild(mergeConfig(
       inlineConfig,
       {
         plugins: [
           await ViteSlidevPlugin(options, inlineConfig.slidev || {}),
         ],
       },
-    )
-
-    await viteBuild(inlineConfig)
+    ))
   }
   finally {
     if (originalIndexHTML != null)

--- a/packages/slidev/node/commands/shared.ts
+++ b/packages/slidev/node/commands/shared.ts
@@ -73,16 +73,16 @@ export async function getIndexHtml({ entry, clientRoot, roots, data }: ResolvedS
 }
 
 export async function mergeViteConfigs(
-  { roots, entry }: ResolvedSlidevOptions,
-  viteConfig: InlineConfig,
+  { roots }: ResolvedSlidevOptions,
+  overrideConfigs: InlineConfig,
   config: InlineConfig,
   command: 'serve' | 'build',
 ) {
   const configEnv: ConfigEnv = {
-    mode: 'development',
+    mode: command === 'build' ? 'production' : 'development',
     command,
   }
-  // Merge theme & addon configs
+  // Merge theme & addon & user configs
   const files = roots.map(i => join(i, 'vite.config.ts'))
 
   for await (const file of files) {
@@ -95,11 +95,7 @@ export async function mergeViteConfigs(
   }
 
   // Merge viteConfig argument
-  config = mergeConfig(config, viteConfig)
-
-  // Merge local config (slidev options only)
-  const localConfig = await resolveConfig({}, command, entry)
-  config = mergeConfig(config, { slidev: localConfig.slidev || {} })
+  config = mergeConfig(config, overrideConfigs)
 
   return config
 }


### PR DESCRIPTION
fix #1669.

Previously, the `<userroot>/vite.config.ts` was loaded twice. The second time `resolveConfig` was used, which made some side-effects. One of the side-effects was setting `NODE_ENV` to `development`, which caused #1669.