### PR TITLE
fix(vscode): should pass entry file name to CLI

### DIFF
--- a/packages/vscode/src/composables/useDevServer.ts
+++ b/packages/vscode/src/composables/useDevServer.ts
@@ -29,7 +29,7 @@ export function useDevServer(project: SlidevProject) {
     if (isTerminalActive())
       return
     port.value ??= await getPort()
-    sendText(`npm exec slidev -- --port ${port.value} ${basename(project.entry)}`)
+    sendText(`npm exec slidev -- --port ${port.value} ${JSON.stringify(basename(project.entry))}`)
   }
 
   function stop() {

--- a/packages/vscode/src/composables/useDevServer.ts
+++ b/packages/vscode/src/composables/useDevServer.ts
@@ -1,3 +1,4 @@
+import { basename } from 'node:path'
 import type { Ref } from '@vue/runtime-core'
 import { toRef } from '@vue/runtime-core'
 import { getPort as getPortPlease } from 'get-port-please'
@@ -28,7 +29,7 @@ export function useDevServer(project: SlidevProject) {
     if (isTerminalActive())
       return
     port.value ??= await getPort()
-    sendText(`npm exec slidev -- --port ${port.value}`)
+    sendText(`npm exec slidev -- --port ${port.value} ${basename(project.entry)}`)
   }
 
   function stop() {


### PR DESCRIPTION
This PR fixes an issue in which the "Start Dev Server" command executed with the VSCode extension can build only default "slides.md".
For building custom markdown files, the filename should be explicitly specified.