### PR TITLE
fix: introduce `isMounted` state for clicks context

### DIFF
--- a/packages/client/composables/useClicks.ts
+++ b/packages/client/composables/useClicks.ts
@@ -30,18 +30,42 @@ export function createClicksContextBase(
   clicksStart = 0,
   clicksTotalOverrides?: number,
 ): ClicksContext {
+  const isMounted = ref(false)
+  let relativeSizeMap: ClicksContext['relativeSizeMap'] = new Map()
+  let maxMap: ClicksContext['maxMap'] = new Map()
   const context: ClicksContext = {
     get current() {
-      // Here we haven't know clicksTotal yet.
       return clamp(+current.value, clicksStart, context.total)
     },
     set current(value) {
-      current.value = clamp(+value, clicksStart, context.total)
+      current.value = isMounted.value
+        ? clamp(value, clicksStart, context.total)
+        : value /* context.total is not available yet */
     },
     clicksStart,
-    relativeOffsets: new Map(),
-    maxMap: shallowReactive(new Map()),
-    onMounted() { },
+    get relativeSizeMap() {
+      if (__DEV__ && isMounted.value)
+        console.warn('[slidev] ClicksContext: Unexpected access to relativeSizeMap after mounted')
+      return relativeSizeMap
+    },
+    get maxMap() {
+      return maxMap
+    },
+    get isMounted() {
+      return isMounted.value
+    },
+    onMounted: () => {
+      isMounted.value = true
+      // Convert maxMap to reactive
+      maxMap = shallowReactive(maxMap)
+      // Make sure the query is not greater than the total
+      context.current = current.value
+    },
+    onUnmounted: () => {
+      isMounted.value = false
+      relativeSizeMap = new Map()
+      maxMap = new Map()
+    },
     calculateSince(rawAt, size = 1) {
       const at = normalizeSingleAtValue(rawAt)
       if (at == null)
@@ -109,23 +133,29 @@ export function createClicksContextBase(
     register(el, info) {
       if (!info)
         return
+      if (__DEV__ && isMounted.value)
+        console.warn('[slidev] ClicksContext: Unexpected register after mounted')
       const { delta, max } = info
-      context.relativeOffsets.set(el, delta)
-      context.maxMap.set(el, max)
+      relativeSizeMap.set(el, delta)
+      maxMap.set(el, max)
     },
     unregister(el) {
-      context.relativeOffsets.delete(el)
-      context.maxMap.delete(el)
+      relativeSizeMap.delete(el)
+      maxMap.delete(el)
     },
     get currentOffset() {
       // eslint-disable-next-line no-unused-expressions
       routeForceRefresh.value
-      return sum(...context.relativeOffsets.values())
+      return sum(...relativeSizeMap.values())
     },
     get total() {
       // eslint-disable-next-line no-unused-expressions
       routeForceRefresh.value
-      return clicksTotalOverrides ?? Math.max(0, ...context.maxMap.values())
+      return clicksTotalOverrides
+        ?? (isMounted.value
+          ? Math.max(0, ...maxMap.values())
+          : 0 /* fallback value */
+        )
     },
   }
   return context

--- a/packages/client/composables/useNav.ts
+++ b/packages/client/composables/useNav.ts
@@ -327,18 +327,12 @@ const useNavState = createSharedComposable((): SlidevContextNavState => {
         },
         set(v) {
           if (currentSlideNo.value === thisNo)
-            queryClicksRaw.value = clamp(v, context.clicksStart, context.total).toString()
+            queryClicksRaw.value = v.toString()
         },
       }),
       route?.meta.slide?.frontmatter.clicksStart ?? 0,
       route?.meta.clicks,
     )
-
-    // On slide mounted, make sure the query is not greater than the total
-    context.onMounted = () => {
-      if (currentSlideNo.value === thisNo)
-        queryClicksRaw.value = clamp(+queryClicksRaw.value, context.clicksStart, context.total).toString()
-    }
 
     if (route?.meta)
       route.meta.__clicksContext = context

--- a/packages/client/internals/ClicksSlider.vue
+++ b/packages/client/internals/ClicksSlider.vue
@@ -39,7 +39,7 @@ function onMousedown() {
   <div
     class="flex gap-1 items-center select-none"
     :title="`Clicks in this slide: ${length}`"
-    :class="length ? '' : 'op50'"
+    :class="length && props.clicksContext.isMounted ? '' : 'op50'"
   >
     <div class="flex gap-0.5 items-center min-w-16 font-mono mr1">
       <carbon:cursor-1 text-sm op50 />

--- a/packages/client/internals/SlideWrapper.vue
+++ b/packages/client/internals/SlideWrapper.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, defineAsyncComponent, defineComponent, h, onMounted, ref, toRef } from 'vue'
+import { computed, defineAsyncComponent, defineComponent, h, ref, toRef } from 'vue'
 import type { CSSProperties, PropType } from 'vue'
 import { provideLocal } from '@vueuse/core'
 import type { ClicksContext, RenderContext, SlideRoute } from '@slidev/types'
@@ -51,10 +51,9 @@ const SlideComponent = computed(() => props.route && defineAsyncComponent({
   loader: async () => {
     const component = await props.route.component()
     return defineComponent({
-      setup(_, { attrs }) {
-        onMounted(() => props.clicksContext?.onMounted?.())
-        return () => h(component.default, attrs)
-      },
+      mounted: props.clicksContext?.onMounted,
+      unmounted: props.clicksContext?.onUnmounted,
+      render: () => h(component.default),
     })
   },
   delay: 300,

--- a/packages/client/pages/presenter.vue
+++ b/packages/client/pages/presenter.vue
@@ -40,7 +40,6 @@ const {
   hasNext,
   nextRoute,
   slides,
-  queryClicks,
   getPrimaryClicks,
   total,
 } = useNav()
@@ -67,10 +66,10 @@ const nextFrameClicksCtx = computed(() => {
 })
 
 watch(
-  [currentSlideRoute, queryClicks],
+  nextFrame,
   () => {
-    if (nextFrameClicksCtx.value)
-      nextFrameClicksCtx.value.current = nextFrame.value![1]
+    if (nextFrameClicksCtx.value && nextFrame.value)
+      nextFrameClicksCtx.value.current = nextFrame.value[1]
   },
   { immediate: true },
 )

--- a/packages/types/src/clicks.ts
+++ b/packages/types/src/clicks.ts
@@ -55,14 +55,16 @@ export interface ClicksInfo {
 export interface ClicksContext {
   current: number
   readonly clicksStart: number
-  readonly relativeOffsets: Map<ClicksElement, number>
+  readonly relativeSizeMap: Map<ClicksElement, number>
   readonly maxMap: Map<ClicksElement, number>
   calculateSince: (at: RawSingleAtValue, size?: number) => ClicksInfo | null
   calculateRange: (at: RawRangeAtValue) => ClicksInfo | null
   calculate: (at: RawAtValue) => ClicksInfo | null
   register: (el: ClicksElement, info: Pick<ClicksInfo, 'delta' | 'max'> | null) => void
   unregister: (el: ClicksElement) => void
+  readonly isMounted: boolean
   onMounted: () => void
+  onUnmounted: () => void
   readonly currentOffset: number
   readonly total: number
 }


### PR DESCRIPTION
`isMounted` represents whether the clicks elements in this slide are all mounted. After `isMounted` becomes `true`, `clicksContext.total` will represent the real value, instead of an intermediate one. This makes the clicks system much more stable - and we can fix possible bugs caused by the "intermediate state before all children are mounted" in the future.

Fix: `previewNext` displays the first click instead of the next one after refreshing.

Also fix #1678.