### PR TITLE
feat: support async output in code runner

### DIFF
--- a/packages/client/internals/CodeRunner.vue
+++ b/packages/client/internals/CodeRunner.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { debounce, toArray } from '@antfu/utils'
 import { useVModel } from '@vueuse/core'
-import type { CodeRunnerOutput, RawAtValue } from '@slidev/types'
-import { computed, onMounted, onUnmounted, ref, shallowRef, watch, watchSyncEffect } from 'vue'
+import type { CodeRunnerOutputs, RawAtValue } from '@slidev/types'
+import { computed, onMounted, onUnmounted, ref, shallowRef, toValue, watch, watchSyncEffect } from 'vue'
 import { useSlideContext } from '../context'
 import setupCodeRunners from '../setup/code-runners'
 import { useNav } from '../composables/useNav'
@@ -31,7 +31,7 @@ const disabled = computed(() => !['slide', 'presenter'].includes($renderContext.
 
 const autorun = isPrintMode.value ? 'once' : props.autorun
 const isRunning = ref(autorun)
-const outputs = shallowRef<CodeRunnerOutput[]>()
+const outputs = shallowRef<CodeRunnerOutputs>()
 const runCount = ref(0)
 const highlightFn = ref<(code: string, lang: string) => string>()
 
@@ -64,7 +64,7 @@ const triggerRun = debounce(200, async () => {
     isRunning.value = true
   }, 500)
 
-  outputs.value = toArray(await run(code.value, props.lang, props.runnerOptions ?? {}))
+  outputs.value = await run(code.value, props.lang, props.runnerOptions ?? {})
   runCount.value += 1
   isRunning.value = false
 
@@ -90,11 +90,11 @@ else if (autorun)
     <div v-else-if="isRunning" class="text-sm text-center opacity-50">
       Running...
     </div>
-    <div v-else-if="!outputs?.length" class="text-sm text-center opacity-50">
+    <div v-else-if="!outputs" class="text-sm text-center opacity-50">
       Click the play button to run the code
     </div>
     <div v-else :key="`run-${runCount}`" class="slidev-runner-output">
-      <template v-for="output, _idx1 of outputs" :key="_idx1">
+      <template v-for="output, _idx1 of toArray(toValue(outputs))" :key="_idx1">
         <div v-if="'html' in output" v-html="output.html" />
         <div v-else-if="'error' in output" class="text-red-500">
           {{ output.error }}

--- a/packages/client/setup/code-runners.ts
+++ b/packages/client/setup/code-runners.ts
@@ -63,7 +63,7 @@ export default createSingletonPromise(async () => {
 })
 
 // Ported from https://github.com/microsoft/TypeScript-Website/blob/v2/packages/playground/src/sidebar/runtime.ts
-async function runJavaScript(code: string): Promise<CodeRunnerOutputs> {
+function runJavaScript(code: string): CodeRunnerOutputs {
   const result = ref<CodeRunnerOutput[]>([])
 
   const onError = (error: any) => result.value.push({ error: String(error) })
@@ -184,7 +184,7 @@ export async function runTypeScript(code: string) {
   const importRegex = /import\s*\((.+)\)/g
   code = code.replace(importRegex, (_full, specifier) => `__slidev_import(${specifier})`)
 
-  return await runJavaScript(code)
+  return runJavaScript(code)
 }
 
 /**

--- a/packages/types/src/code-runner.ts
+++ b/packages/types/src/code-runner.ts
@@ -1,5 +1,6 @@
 import type { CodeToHastOptions } from 'shiki'
 import type { Arrayable, Awaitable } from '@antfu/utils'
+import type { MaybeRefOrGetter } from 'vue'
 
 export interface CodeRunnerContext {
   /**
@@ -58,7 +59,7 @@ export type CodeRunnerOutputTextArray = CodeRunnerOutputText[]
 
 export type CodeRunnerOutput = CodeRunnerOutputHtml | CodeRunnerOutputError | CodeRunnerOutputText | CodeRunnerOutputTextArray | CodeRunnerOutputDom
 
-export type CodeRunnerOutputs = Arrayable<CodeRunnerOutput>
+export type CodeRunnerOutputs = MaybeRefOrGetter<Arrayable<CodeRunnerOutput>>
 
 export type CodeRunner = (code: string, ctx: CodeRunnerContext) => Awaitable<CodeRunnerOutputs>
 


### PR DESCRIPTION
resolve #1505.

Example snippet:
```ts
import { sleep } from '@antfu/utils'

await sleep(400)
console.log('1')
await sleep(400)
console.log('2')
await sleep(400)
throw 'err!'
console.log('3')
```


Note that the runner **itself** can still be async and will be awaited. So the runner can choose whether to output or the contents in one go, or asynchronously.