### PR TITLE
feat: add `--wait-until` option for exporting

### DIFF
--- a/docs/guide/exporting.md
+++ b/docs/guide/exporting.md
@@ -182,7 +182,9 @@ $ slidev export --wait-until .my-selector
 - `'load'` - consider operation to be finished when the `load` event is fired.
 - `'none'` - do not wait for any event.
 
+::: warning
 When specifying values other than `'networkidle'`, please make sure the printed slides are complete and correct. If some contents are missing, you may need to use the `--wait` option.
+:::
 
 ### Executable path
 

--- a/docs/guide/exporting.md
+++ b/docs/guide/exporting.md
@@ -174,7 +174,7 @@ $ slidev export --wait 10000
 There is also a `--wait-until` option to wait for a state before exporting each slide:
 
 ```bash
-$ slidev export --wait-until .my-selector
+$ slidev export --wait-until none
 ```
 
 - `'networkidle'` - (_default_) consider operation to be finished when there are no network connections for at least `500` ms. Don't use this method for testing, rely on web assertions to assess readiness instead.

--- a/docs/guide/exporting.md
+++ b/docs/guide/exporting.md
@@ -177,6 +177,8 @@ There is also a `--wait-until` option to wait for a state before exporting each 
 $ slidev export --wait-until none
 ```
 
+Possible values:
+
 - `'networkidle'` - (_default_) consider operation to be finished when there are no network connections for at least `500` ms. Don't use this method for testing, rely on web assertions to assess readiness instead.
 - `'domcontentloaded'` - consider operation to be finished when the `DOMContentLoaded` event is fired.
 - `'load'` - consider operation to be finished when the `load` event is fired.

--- a/docs/guide/exporting.md
+++ b/docs/guide/exporting.md
@@ -165,11 +165,24 @@ $ slidev export --timeout 60000
 
 ### Wait
 
-Some parts of your slides may require a longer time to render. You can use the `--wait` option to have an extra delay before exporting.
+Some parts of your slides may require a longer time to render. You can use the `--wait` option to have an extra delay before exporting:
 
 ```bash
 $ slidev export --wait 10000
 ```
+
+There is also a `--wait-until` option to wait for a state before exporting each slide:
+
+```bash
+$ slidev export --wait-until .my-selector
+```
+
+- `'networkidle'` - (_default_) consider operation to be finished when there are no network connections for at least `500` ms. Don't use this method for testing, rely on web assertions to assess readiness instead.
+- `'domcontentloaded'` - consider operation to be finished when the `DOMContentLoaded` event is fired.
+- `'load'` - consider operation to be finished when the `load` event is fired.
+- `'none'` - do not wait for any event.
+
+When specifying values other than `'networkidle'`, please make sure the printed slides are complete and correct. If some contents are missing, you may need to use the `--wait` option.
 
 ### Executable path
 

--- a/packages/slidev/node/cli.ts
+++ b/packages/slidev/node/cli.ts
@@ -582,6 +582,11 @@ function exportOptions<T>(args: Argv<T>) {
       type: 'number',
       describe: 'wait for the specified ms before exporting',
     })
+    .option('wait-until', {
+      type: 'string',
+      choices: ['networkidle', 'load', 'domcontentloaded', 'none'],
+      describe: 'wait until the specified event before exporting each slide',
+    })
     .option('range', {
       type: 'string',
       describe: 'page ranges to export, for example "1,4-5,6"',

--- a/packages/types/src/cli.ts
+++ b/packages/types/src/cli.ts
@@ -8,6 +8,7 @@ export interface ExportArgs extends CommonArgs {
   'format'?: string
   'timeout'?: number
   'wait'?: number
+  'wait-until'?: string
   'range'?: string
   'dark'?: boolean
   'with-clicks'?: boolean


### PR DESCRIPTION
resolves #1514.

This PR introduces the `--wait-until` option, so that users can skip `waitUntil: 'networkidle'` if they want, which often causes timeout.

#### Docs

There is also a `--wait-until` option to wait for a state before exporting each slide:

```bash
$ slidev export --wait-until none
```

Possible values:

- `'networkidle'` - (_default_) consider operation to be finished when there are no network connections for at least `500` ms. Don't use this method for testing, rely on web assertions to assess readiness instead.
- `'domcontentloaded'` - consider operation to be finished when the `DOMContentLoaded` event is fired.
- `'load'` - consider operation to be finished when the `load` event is fired.
- `'none'` - do not wait for any event.

> [!warning]
> When specifying values other than `'networkidle'`, please make sure the printed slides are complete and correct. If some contents are missing, you may need to use the `--wait` option.
>