### PR TITLE
fix: remove filepaths when building

### DIFF
--- a/packages/client/pages/overview.vue
+++ b/packages/client/pages/overview.vue
@@ -165,7 +165,7 @@ onMounted(() => {
             <carbon:presentation-file />
           </IconButton>
           <IconButton
-            v-if="route.meta?.slide"
+            v-if="__DEV__ && route.meta?.slide"
             class="mr--3 op0 group-hover:op80"
             title="Open in editor"
             @click="openInEditor(`${route.meta.slide.filepath}:${route.meta.slide.start}`)"

--- a/packages/slidev/node/commands/shared.ts
+++ b/packages/slidev/node/commands/shared.ts
@@ -32,7 +32,7 @@ function escapeHtml(unsafe: unknown) {
   )
 }
 
-export async function getIndexHtml({ entry, clientRoot, roots, data }: ResolvedSlidevOptions): Promise<string> {
+export async function getIndexHtml({ mode, entry, clientRoot, roots, data }: ResolvedSlidevOptions): Promise<string> {
   let main = await fs.readFile(join(clientRoot, 'index.html'), 'utf-8')
   let head = ''
   let body = ''
@@ -40,7 +40,7 @@ export async function getIndexHtml({ entry, clientRoot, roots, data }: ResolvedS
   const { info, author, keywords } = data.headmatter
   head += [
     `<meta name="slidev:version" content="${version}">`,
-    `<meta charset="slidev:entry" content="${slash(entry)}">`,
+    mode === 'dev' && `<meta charset="slidev:entry" content="${slash(entry)}">`,
     `<link rel="icon" href="${data.config.favicon}">`,
     `<title>${getSlideTitle(data)}</title>`,
     info && `<meta name="description" content=${escapeHtml(info)}>`,

--- a/packages/slidev/node/vite/loaders.ts
+++ b/packages/slidev/node/vite/loaders.ts
@@ -333,7 +333,7 @@ export function createSlidesLoader(
                     slide: {
                       ...(${JSON.stringify(slideBase)}),
                       frontmatter,
-                      filepath: ${JSON.stringify(slide.source.filepath)},
+                      filepath: ${JSON.stringify(mode === 'dev' ? slide.source.filepath : '')},
                       start: ${JSON.stringify(slide.source.start)},
                       id: ${pageNo},
                       no: ${no},


### PR DESCRIPTION
fix #1690. Removes file paths when building.

#1690 also reports some problems with chunk file names, but I can't figure out a good solution yet - Improvements to the chunking may need to be delayed.