### PR TITLE
docs: add example and correct usage of `[click]` & `[click:{n+1}]`

### DIFF
--- a/docs/guide/syntax.md
+++ b/docs/guide/syntax.md
@@ -431,7 +431,23 @@ Basic Markdown and HTML are also supported in notes when the Presenter renders n
 
 > Available since v0.48
 
-For some slides you might have longer notes that could be hard to find your place. Slidev supports click markers that allow highlighting and auto-scrolling to the section of notes from your corresponding content. Put `[click]` markers in your notes for the timing you need to go to another [click](/guide/animations#click-animations), Slidev divides the content between the click markers and highlights it in presenter notes, synchronized with your slide progress.
+For some slides you might have longer notes that could be hard to find your place. Slidev supports click markers that allow highlighting and auto-scrolling to the section of notes from your corresponding content. Put `[click]` markers at the beginning of any line in your notes for the timing you need to go to another [click](/guide/animations#click-animations). You may skip `n` clicks by using `[click:{n+1}]`. For example:
+
+```md
+<!--
+Content before the first click
+
+[click] This will be highlighted after the first click
+
+Also highlighted after the first click
+
+- [click] This list element will be highlighted after the second click
+
+[click:3] Last click (skip two clicks)
+-->
+```
+
+Slidev divides the content between the click markers and highlights it in presenter notes, synchronized with your slide progress.
 
 <video src="https://github.com/slidevjs/slidev/assets/11247099/40014e34-67cd-4830-8c8d-8431754a3672" controls rounded shadow w-full></video>
 


### PR DESCRIPTION
Documenting the behavior described at https://github.com/slidevjs/slidev/issues/1680#issuecomment-2197852296