### PR TITLE
fix: code block regex

### DIFF
--- a/packages/slidev/node/syntax/transform/code-wrapper.ts
+++ b/packages/slidev/node/syntax/transform/code-wrapper.ts
@@ -14,7 +14,7 @@ export function transformCodeWrapper(ctx: MarkdownTransformContext) {
       const ranges = normalizeRangeStr(rangeStr)
       code = code.trimEnd()
       options = options.trim() || '{}'
-      return `\n<CodeBlockWrapper v-bind="${options}" :ranges='${JSON.stringify(ranges)}'>\n\n\`\`\`${lang} ${attrs}\n${code}\n\`\`\`\n\n</CodeBlockWrapper>`
+      return `\n<CodeBlockWrapper v-bind="${options}" :ranges='${JSON.stringify(ranges)}'>\n\n\`\`\`${lang}${attrs}\n${code}\n\`\`\`\n\n</CodeBlockWrapper>`
     },
   )
 }

--- a/packages/slidev/node/syntax/transform/code-wrapper.ts
+++ b/packages/slidev/node/syntax/transform/code-wrapper.ts
@@ -2,7 +2,7 @@ import type { MarkdownTransformContext } from '@slidev/types'
 import { normalizeRangeStr } from './utils'
 
 // eslint-disable-next-line regexp/no-super-linear-backtracking
-export const reCodeBlock = /^```([\w'-]+)(?:\s*\{([\w*,|-]+)\}\s*?(\{[^}]*\})?([^\r\n]*))?\r?\n(\S[\s\S]*?)^```$/gm
+export const reCodeBlock = /^```([\w'-]+)?\s*(?:\{([\w*,|-]+)\}\s*?(\{[^}]*\})?([^\r\n]*))?\r?\n(\S[\s\S]*?)^```$/gm
 
 /**
  * Transform code block with wrapper
@@ -14,7 +14,7 @@ export function transformCodeWrapper(ctx: MarkdownTransformContext) {
       const ranges = normalizeRangeStr(rangeStr)
       code = code.trimEnd()
       options = options.trim() || '{}'
-      return `\n<CodeBlockWrapper v-bind="${options}" :ranges='${JSON.stringify(ranges)}'>\n\n\`\`\`${lang}${attrs}\n${code}\n\`\`\`\n\n</CodeBlockWrapper>`
+      return `\n<CodeBlockWrapper v-bind="${options}" :ranges='${JSON.stringify(ranges)}'>\n\n\`\`\`${lang} ${attrs}\n${code}\n\`\`\`\n\n</CodeBlockWrapper>`
     },
   )
 }

--- a/test/__snapshots__/transform-all.test.ts.snap
+++ b/test/__snapshots__/transform-all.test.ts.snap
@@ -50,15 +50,9 @@ Foo \`{{ code }}\`
 <CodeBlockWrapper v-bind="{}" :ranges='[]'>
 
 \`\`\`ts
-// line 1
-
-// #region snippet
 function _foo() {
   // ...
 }
-// #endregion snippet
-
-// line 9
 \`\`\`
 
 </CodeBlockWrapper>

--- a/test/__snapshots__/transform-all.test.ts.snap
+++ b/test/__snapshots__/transform-all.test.ts.snap
@@ -9,7 +9,7 @@ Default Slot
 
 <CodeBlockWrapper v-bind="{lines:true}" :ranges='["2","3","4"]'>
 
-\`\`\`ts 
+\`\`\`ts
 function _foo() {
   // ...
 }
@@ -33,7 +33,7 @@ Foo \`{{ code }}\`
 
 <CodeBlockWrapper v-bind="{}" :ranges='[]'>
 
-\`\`\`md 
+\`\`\`md
 <style>
 .text-red { color: red; }
 </style>
@@ -49,7 +49,7 @@ Foo \`{{ code }}\`
 
 <CodeBlockWrapper v-bind="{}" :ranges='[]'>
 
-\`\`\`ts 
+\`\`\`ts
 // line 1
 
 // #region snippet

--- a/test/__snapshots__/transform-all.test.ts.snap
+++ b/test/__snapshots__/transform-all.test.ts.snap
@@ -9,7 +9,7 @@ Default Slot
 
 <CodeBlockWrapper v-bind="{lines:true}" :ranges='["2","3","4"]'>
 
-\`\`\`ts
+\`\`\`ts 
 function _foo() {
   // ...
 }
@@ -33,7 +33,7 @@ Foo \`{{ code }}\`
 
 <CodeBlockWrapper v-bind="{}" :ranges='[]'>
 
-\`\`\`md
+\`\`\`md 
 <style>
 .text-red { color: red; }
 </style>
@@ -46,6 +46,22 @@ Foo \`{{ code }}\`
 .text-green { color: green; }
 </style>
 
+
+<CodeBlockWrapper v-bind="{}" :ranges='[]'>
+
+\`\`\`ts 
+// line 1
+
+// #region snippet
+function _foo() {
+  // ...
+}
+// #endregion snippet
+
+// line 9
+\`\`\`
+
+</CodeBlockWrapper>
 
 </template>"
 `;

--- a/test/__snapshots__/transform.test.ts.snap
+++ b/test/__snapshots__/transform.test.ts.snap
@@ -24,7 +24,7 @@ h1 {
 
 <CodeBlockWrapper v-bind="{}" :ranges='[]'>
 
-\`\`\`css
+\`\`\`css 
 <style>
 h1 {
   color: green;
@@ -79,7 +79,7 @@ Default Slot
 
 <CodeBlockWrapper v-bind="{}" :ranges='[]'>
 
-\`\`\`md
+\`\`\`md 
 Slot Usage
 ::right::
 ::left::

--- a/test/__snapshots__/transform.test.ts.snap
+++ b/test/__snapshots__/transform.test.ts.snap
@@ -24,7 +24,7 @@ h1 {
 
 <CodeBlockWrapper v-bind="{}" :ranges='[]'>
 
-\`\`\`css 
+\`\`\`css
 <style>
 h1 {
   color: green;
@@ -79,7 +79,7 @@ Default Slot
 
 <CodeBlockWrapper v-bind="{}" :ranges='[]'>
 
-\`\`\`md 
+\`\`\`md
 Slot Usage
 ::right::
 ::left::

--- a/test/transform-all.test.ts
+++ b/test/transform-all.test.ts
@@ -26,6 +26,8 @@ Foo \`{{ code }}\`
 <style>
 .text-green { color: green; }
 </style>
+
+<<< ./fixtures/snippets/snippet.ts
 `)
 
   applyMarkdownTransform(ctx)

--- a/test/transform-all.test.ts
+++ b/test/transform-all.test.ts
@@ -27,7 +27,7 @@ Foo \`{{ code }}\`
 .text-green { color: green; }
 </style>
 
-<<< ./fixtures/snippets/snippet.ts
+<<< ./fixtures/snippets/snippet.ts#snippet
 `)
 
   applyMarkdownTransform(ctx)


### PR DESCRIPTION
close #1754.

Previously, the code block regex couldn't match

````md
```ts·
abc
```
````

(There is a space after `ts`)