### PR TITLE
docs: fix links in features/shiki-magic-move.md

### DIFF
--- a/docs/features/shiki-magic-move.md
+++ b/docs/features/shiki-magic-move.md
@@ -32,7 +32,7 @@ console.log(`Step ${3}` as string)
 ````
 `````
 
-It's also possible to mix Magic Move with [line highlighting](#line-highlighting) and [line numbers](#line-numbers), for example:
+It's also possible to mix Magic Move with [line highlighting](/features/line-highlighting) and [line numbers](/features/code-block-line-numbers), for example:
 
 `````md
 ````md magic-move {at:4, lines: true} // [!code hl]

--- a/docs/features/shiki-magic-move.md
+++ b/docs/features/shiki-magic-move.md
@@ -32,7 +32,7 @@ console.log(`Step ${3}` as string)
 ````
 `````
 
-It's also possible to mix Magic Move with [line highlighting](/features/line-highlighting) and [line numbers](/features/code-block-line-numbers), for example:
+It's also possible to mix Magic Move with <LinkInline link="features/line-highlighting" /> and <LinkInline link="features/code-block-line-numbers" />, for example:
 
 `````md
 ````md magic-move {at:4, lines: true} // [!code hl]


### PR DESCRIPTION
I noticed these links while clicking around and discovering features. They currently don't link anywhere useful, so I edited them to point towards their mentioned features.