### PR TITLE
fix(vscode): hover message, formatting and highlighting

### DIFF
--- a/packages/vscode/language-server/index.ts
+++ b/packages/vscode/language-server/index.ts
@@ -1,4 +1,3 @@
-import { fileURLToPath } from 'node:url'
 import { createConnection, createServer, createSimpleProject } from '@volar/language-server/node'
 import { create as createYamlService } from './volar-service-yaml'
 import { slidevLanguagePlugin } from './languagePlugin'
@@ -17,7 +16,7 @@ connection.onInitialize((params) => {
           return {
             completion: true,
             customTags: [],
-            format: true,
+            format: false,
             hover: true,
             isKubernetes: false,
             validate: true,
@@ -28,12 +27,12 @@ connection.onInitialize((params) => {
               {
                 priority: 3,
                 fileMatch: ['volar-embedded-content://frontmatter_0/**/*.md'],
-                uri: fileURLToPath(new URL('../schema/headmatter.json', import.meta.url)),
+                uri: (new URL('../schema/headmatter.json', import.meta.url)).toString(),
               },
               {
                 priority: 2,
                 fileMatch: ['volar-embedded-content://**/*.md'],
-                uri: fileURLToPath(new URL('../schema/frontmatter.json', import.meta.url)),
+                uri: (new URL('../schema/frontmatter.json', import.meta.url)).toString(),
               },
             ],
           }

--- a/packages/vscode/language-server/languagePlugin.ts
+++ b/packages/vscode/language-server/languagePlugin.ts
@@ -80,7 +80,7 @@ function* getEmbeddedCodes(parsed: SlidevMarkdown): Generator<VirtualCode> {
             semantic: true,
             navigation: true,
             structure: true,
-            format: true,
+            format: false,
           },
         }],
         embeddedCodes: [],

--- a/packages/vscode/language-server/prettierService.ts
+++ b/packages/vscode/language-server/prettierService.ts
@@ -6,6 +6,13 @@ export function create() {
     prettier,
     {
       documentSelector: ['yaml'],
+      async getFormattingOptions(_prettier, _document, formatOptions) {
+        return {
+          parser: 'yaml',
+          tabWidth: formatOptions.tabSize,
+          useTabs: !formatOptions.insertSpaces,
+        }
+      },
     },
   )
 }

--- a/packages/vscode/schema/frontmatter.json
+++ b/packages/vscode/schema/frontmatter.json
@@ -20,7 +20,8 @@
               "type": "null"
             }
           ],
-          "description": "Page transition, powered by Vue's `<TransitionGroup/>`\n\nBuilt-in transitions:\n- fade\n- fade-out\n- slide-left\n- slide-right\n- slide-up\n- slide-down\n\nSee https://sli.dev/guide/animations.html#pages-transitions\n\nSee https://vuejs.org/guide/built-ins/transition.html"
+          "description": "Page transition, powered by Vue's `<TransitionGroup/>`\n\nBuilt-in transitions:\n- fade\n- fade-out\n- slide-left\n- slide-right\n- slide-up\n- slide-down\n\nSee https://sli.dev/guide/animations.html#pages-transitions\n\nSee https://vuejs.org/guide/built-ins/transition.html",
+          "markdownDescription": "Page transition, powered by Vue's `<TransitionGroup/>`\n\nBuilt-in transitions:\n- fade\n- fade-out\n- slide-left\n- slide-right\n- slide-up\n- slide-down\n\nSee https://sli.dev/guide/animations.html#pages-transitions\n\nSee https://vuejs.org/guide/built-ins/transition.html"
         },
         "layout": {
           "anyOf": [
@@ -31,7 +32,8 @@
               "type": "string"
             }
           ],
-          "description": "Slide layout to use\n\nDefault to 'cover' for the first slide, 'default' for the rest"
+          "description": "Slide layout to use\n\nDefault to 'cover' for the first slide, 'default' for the rest",
+          "markdownDescription": "Slide layout to use\n\nDefault to 'cover' for the first slide, 'default' for the rest"
         },
         "class": {
           "anyOf": [
@@ -49,45 +51,55 @@
               "additionalProperties": {}
             }
           ],
-          "description": "Custom class added to the slide root element"
+          "description": "Custom class added to the slide root element",
+          "markdownDescription": "Custom class added to the slide root element"
         },
         "clicks": {
           "type": "number",
-          "description": "Manually specified the total clicks needed to this slide\n\nWhen not specified, the clicks will be calculated by the usage of v-clicks\n\nSee https://sli.dev/guide/animations"
+          "description": "Manually specified the total clicks needed to this slide\n\nWhen not specified, the clicks will be calculated by the usage of v-clicks\n\nSee https://sli.dev/guide/animations",
+          "markdownDescription": "Manually specified the total clicks needed to this slide\n\nWhen not specified, the clicks will be calculated by the usage of v-clicks\n\nSee https://sli.dev/guide/animations"
         },
         "clicksStart": {
           "type": "number",
           "description": "Manually specified the total clicks needed to this slide to start",
+          "markdownDescription": "Manually specified the total clicks needed to this slide to start",
           "default": 0
         },
         "preload": {
           "type": "boolean",
           "description": "Preload the slide when the previous slide is active",
+          "markdownDescription": "Preload the slide when the previous slide is active",
           "default": true
         },
         "hide": {
           "type": "boolean",
-          "description": "Completely hide and disable the slide"
+          "description": "Completely hide and disable the slide",
+          "markdownDescription": "Completely hide and disable the slide"
         },
         "disabled": {
           "type": "boolean",
-          "description": "Same as `hide`, completely hide and disable the slide"
+          "description": "Same as `hide`, completely hide and disable the slide",
+          "markdownDescription": "Same as `hide`, completely hide and disable the slide"
         },
         "hideInToc": {
           "type": "boolean",
-          "description": "hide the slide for the `<Toc>` components\n\nSee https://sli.dev/builtin/components#toc"
+          "description": "hide the slide for the `<Toc>` components\n\nSee https://sli.dev/builtin/components#toc",
+          "markdownDescription": "hide the slide for the `<Toc>` components\n\nSee https://sli.dev/builtin/components#toc"
         },
         "level": {
           "type": "number",
-          "description": "Override the title level for the <TitleRenderer> and <Toc> components Only if `title` has also been declared"
+          "description": "Override the title level for the <TitleRenderer> and <Toc> components Only if `title` has also been declared",
+          "markdownDescription": "Override the title level for the <TitleRenderer> and <Toc> components\nOnly if `title` has also been declared"
         },
         "routeAlias": {
           "type": "string",
-          "description": "Create a route alias that can be used in the URL or with the <Link> component"
+          "description": "Create a route alias that can be used in the URL or with the <Link> component",
+          "markdownDescription": "Create a route alias that can be used in the URL or with the <Link> component"
         },
         "zoom": {
           "type": "number",
           "description": "Custom zoom level for the slide",
+          "markdownDescription": "Custom zoom level for the slide",
           "default": 1
         },
         "dragPos": {
@@ -98,11 +110,13 @@
               "type": "string"
             }
           },
-          "description": "Store the positions of draggable elements Normally you don't need to set this manually\n\nSee https://sli.dev/features/draggable"
+          "description": "Store the positions of draggable elements Normally you don't need to set this manually\n\nSee https://sli.dev/features/draggable",
+          "markdownDescription": "Store the positions of draggable elements\nNormally you don't need to set this manually\n\nSee https://sli.dev/features/draggable"
         },
         "src": {
           "type": "string",
-          "description": "Includes a markdown file\n\nSee https://sli.dev/guide/syntax.html#importing-slides"
+          "description": "Includes a markdown file\n\nSee https://sli.dev/guide/syntax.html#importing-slides",
+          "markdownDescription": "Includes a markdown file\n\nSee https://sli.dev/guide/syntax.html#importing-slides"
         }
       }
     },

--- a/packages/vscode/schema/headmatter.json
+++ b/packages/vscode/schema/headmatter.json
@@ -20,7 +20,8 @@
               "type": "null"
             }
           ],
-          "description": "Page transition, powered by Vue's `<TransitionGroup/>`\n\nBuilt-in transitions:\n- fade\n- fade-out\n- slide-left\n- slide-right\n- slide-up\n- slide-down\n\nSee https://sli.dev/guide/animations.html#pages-transitions\n\nSee https://vuejs.org/guide/built-ins/transition.html"
+          "description": "Page transition, powered by Vue's `<TransitionGroup/>`\n\nBuilt-in transitions:\n- fade\n- fade-out\n- slide-left\n- slide-right\n- slide-up\n- slide-down\n\nSee https://sli.dev/guide/animations.html#pages-transitions\n\nSee https://vuejs.org/guide/built-ins/transition.html",
+          "markdownDescription": "Page transition, powered by Vue's `<TransitionGroup/>`\n\nBuilt-in transitions:\n- fade\n- fade-out\n- slide-left\n- slide-right\n- slide-up\n- slide-down\n\nSee https://sli.dev/guide/animations.html#pages-transitions\n\nSee https://vuejs.org/guide/built-ins/transition.html"
         },
         "layout": {
           "anyOf": [
@@ -31,7 +32,8 @@
               "type": "string"
             }
           ],
-          "description": "Slide layout to use\n\nDefault to 'cover' for the first slide, 'default' for the rest"
+          "description": "Slide layout to use\n\nDefault to 'cover' for the first slide, 'default' for the rest",
+          "markdownDescription": "Slide layout to use\n\nDefault to 'cover' for the first slide, 'default' for the rest"
         },
         "class": {
           "anyOf": [
@@ -49,45 +51,55 @@
               "additionalProperties": {}
             }
           ],
-          "description": "Custom class added to the slide root element"
+          "description": "Custom class added to the slide root element",
+          "markdownDescription": "Custom class added to the slide root element"
         },
         "clicks": {
           "type": "number",
-          "description": "Manually specified the total clicks needed to this slide\n\nWhen not specified, the clicks will be calculated by the usage of v-clicks\n\nSee https://sli.dev/guide/animations"
+          "description": "Manually specified the total clicks needed to this slide\n\nWhen not specified, the clicks will be calculated by the usage of v-clicks\n\nSee https://sli.dev/guide/animations",
+          "markdownDescription": "Manually specified the total clicks needed to this slide\n\nWhen not specified, the clicks will be calculated by the usage of v-clicks\n\nSee https://sli.dev/guide/animations"
         },
         "clicksStart": {
           "type": "number",
           "description": "Manually specified the total clicks needed to this slide to start",
+          "markdownDescription": "Manually specified the total clicks needed to this slide to start",
           "default": 0
         },
         "preload": {
           "type": "boolean",
           "description": "Preload the slide when the previous slide is active",
+          "markdownDescription": "Preload the slide when the previous slide is active",
           "default": true
         },
         "hide": {
           "type": "boolean",
-          "description": "Completely hide and disable the slide"
+          "description": "Completely hide and disable the slide",
+          "markdownDescription": "Completely hide and disable the slide"
         },
         "disabled": {
           "type": "boolean",
-          "description": "Same as `hide`, completely hide and disable the slide"
+          "description": "Same as `hide`, completely hide and disable the slide",
+          "markdownDescription": "Same as `hide`, completely hide and disable the slide"
         },
         "hideInToc": {
           "type": "boolean",
-          "description": "hide the slide for the `<Toc>` components\n\nSee https://sli.dev/builtin/components#toc"
+          "description": "hide the slide for the `<Toc>` components\n\nSee https://sli.dev/builtin/components#toc",
+          "markdownDescription": "hide the slide for the `<Toc>` components\n\nSee https://sli.dev/builtin/components#toc"
         },
         "level": {
           "type": "number",
-          "description": "Override the title level for the <TitleRenderer> and <Toc> components Only if `title` has also been declared"
+          "description": "Override the title level for the <TitleRenderer> and <Toc> components Only if `title` has also been declared",
+          "markdownDescription": "Override the title level for the <TitleRenderer> and <Toc> components\nOnly if `title` has also been declared"
         },
         "routeAlias": {
           "type": "string",
-          "description": "Create a route alias that can be used in the URL or with the <Link> component"
+          "description": "Create a route alias that can be used in the URL or with the <Link> component",
+          "markdownDescription": "Create a route alias that can be used in the URL or with the <Link> component"
         },
         "zoom": {
           "type": "number",
           "description": "Custom zoom level for the slide",
+          "markdownDescription": "Custom zoom level for the slide",
           "default": 1
         },
         "dragPos": {
@@ -98,24 +110,29 @@
               "type": "string"
             }
           },
-          "description": "Store the positions of draggable elements Normally you don't need to set this manually\n\nSee https://sli.dev/features/draggable"
+          "description": "Store the positions of draggable elements Normally you don't need to set this manually\n\nSee https://sli.dev/features/draggable",
+          "markdownDescription": "Store the positions of draggable elements\nNormally you don't need to set this manually\n\nSee https://sli.dev/features/draggable"
         },
         "src": {
           "type": "string",
-          "description": "Includes a markdown file\n\nSee https://sli.dev/guide/syntax.html#importing-slides"
+          "description": "Includes a markdown file\n\nSee https://sli.dev/guide/syntax.html#importing-slides",
+          "markdownDescription": "Includes a markdown file\n\nSee https://sli.dev/guide/syntax.html#importing-slides"
         },
         "title": {
           "type": "string",
-          "description": "Title of the slides"
+          "description": "Title of the slides",
+          "markdownDescription": "Title of the slides"
         },
         "titleTemplate": {
           "type": "string",
           "description": "String template to compose title",
+          "markdownDescription": "String template to compose title",
           "default": "%s - Slidev"
         },
         "theme": {
           "type": "string",
           "description": "Theme to use for the slides\n\nSee https://sli.dev/themes/use.html",
+          "markdownDescription": "Theme to use for the slides\n\nSee https://sli.dev/themes/use.html",
           "default": "default"
         },
         "addons": {
@@ -124,6 +141,7 @@
             "type": "string"
           },
           "description": "List of Slidev addons",
+          "markdownDescription": "List of Slidev addons",
           "default": []
         },
         "remoteAssets": {
@@ -141,6 +159,7 @@
             }
           ],
           "description": "Download remote assets in local using vite-plugin-remote-assets",
+          "markdownDescription": "Download remote assets in local using vite-plugin-remote-assets",
           "default": false
         },
         "download": {
@@ -149,11 +168,13 @@
             "string"
           ],
           "description": "Show a download button in the SPA build, could also be a link to custom pdf",
+          "markdownDescription": "Show a download button in the SPA build,\ncould also be a link to custom pdf",
           "default": false
         },
         "codeCopy": {
           "type": "boolean",
           "description": "Show a copy button in code blocks",
+          "markdownDescription": "Show a copy button in code blocks",
           "default": true
         },
         "info": {
@@ -162,6 +183,7 @@
             "boolean"
           ],
           "description": "Information shows on the built SPA Can be a markdown string",
+          "markdownDescription": "Information shows on the built SPA\nCan be a markdown string",
           "default": false
         },
         "highlighter": {
@@ -171,6 +193,7 @@
             "prism"
           ],
           "description": "Prefer highlighter\n\nSee https://sli.dev/custom/config-highlighter.html",
+          "markdownDescription": "Prefer highlighter\n\nSee https://sli.dev/custom/config-highlighter.html",
           "default": "shiki"
         },
         "twoslash": {
@@ -188,11 +211,13 @@
             }
           ],
           "description": "Enable Twoslash",
+          "markdownDescription": "Enable Twoslash",
           "default": true
         },
         "lineNumbers": {
           "type": "boolean",
           "description": "Show line numbers in code blocks",
+          "markdownDescription": "Show line numbers in code blocks",
           "default": false
         },
         "colorSchema": {
@@ -204,6 +229,7 @@
             "auto"
           ],
           "description": "Force slides color schema",
+          "markdownDescription": "Force slides color schema",
           "default": "auto"
         },
         "routerMode": {
@@ -213,46 +239,55 @@
             "history"
           ],
           "description": "Router mode for vue-router",
+          "markdownDescription": "Router mode for vue-router",
           "default": "history"
         },
         "aspectRatio": {
           "type": "number",
           "description": "Aspect ratio for slides should be like `16/9` or `1:1`",
+          "markdownDescription": "Aspect ratio for slides\nshould be like `16/9` or `1:1`",
           "default": "16/9"
         },
         "canvasWidth": {
           "type": "number",
           "description": "The actual width for slides canvas. unit in px.",
+          "markdownDescription": "The actual width for slides canvas.\nunit in px.",
           "default": "980"
         },
         "selectable": {
           "type": "boolean",
           "description": "Controls whether texts in slides are selectable",
+          "markdownDescription": "Controls whether texts in slides are selectable",
           "default": true
         },
         "themeConfig": {
           "$ref": "#/definitions/SlidevThemeConfig",
           "description": "Configure for themes, will inject intro root styles as `--slidev-theme-x` for attribute `x`\n\nThis allows themes to have customization options in frontmatter Refer to themes' document for options avaliable",
+          "markdownDescription": "Configure for themes, will inject intro root styles as\n`--slidev-theme-x` for attribute `x`\n\nThis allows themes to have customization options in frontmatter\nRefer to themes' document for options avaliable",
           "default": {}
         },
         "fonts": {
           "$ref": "#/definitions/FontOptions",
           "description": "Configure fonts for the slides and app",
+          "markdownDescription": "Configure fonts for the slides and app",
           "default": {}
         },
         "favicon": {
           "type": "string",
           "description": "Configure the icon for app",
+          "markdownDescription": "Configure the icon for app",
           "default": "https://cdn.jsdelivr.net/gh/slidevjs/slidev/assets/favicon.png"
         },
         "drawings": {
           "$ref": "#/definitions/DrawingsOptions",
           "description": "Options for drawings",
+          "markdownDescription": "Options for drawings",
           "default": {}
         },
         "plantUmlServer": {
           "type": "string",
           "description": "URL of PlantUML server used to render diagrams",
+          "markdownDescription": "URL of PlantUML server used to render diagrams",
           "default": "https://www.plantuml.com/plantuml"
         },
         "record": {
@@ -270,6 +305,7 @@
             }
           ],
           "description": "Enable slides recording",
+          "markdownDescription": "Enable slides recording",
           "default": "dev"
         },
         "remote": {
@@ -278,12 +314,14 @@
             "boolean"
           ],
           "description": "Expose the server to inbound requests (listen to `0.0.0.0`)\n\nPass a string to set the password for accessing presenter mode.",
+          "markdownDescription": "Expose the server to inbound requests (listen to `0.0.0.0`)\n\nPass a string to set the password for accessing presenter mode.",
           "default": false
         },
         "css": {
           "type": "string",
           "const": "unocss",
           "description": "Engine for Atomic CSS\n\nSee https://unocss.dev/",
+          "markdownDescription": "Engine for Atomic CSS\n\nSee https://unocss.dev/",
           "deprecated": true,
           "default": "unocss"
         },
@@ -302,6 +340,7 @@
             }
           ],
           "description": "Enable presenter mode",
+          "markdownDescription": "Enable presenter mode",
           "default": true
         },
         "htmlAttrs": {
@@ -310,16 +349,19 @@
             "type": "string"
           },
           "description": "Attributes to apply to the HTML element",
+          "markdownDescription": "Attributes to apply to the HTML element",
           "default": {}
         },
         "mdc": {
           "type": "boolean",
           "description": "Suppport MDC syntax\n\nSee https://github.com/antfu/markdown-it-mdc\n\nSee https://content.nuxtjs.org/guide/writing/mdc",
+          "markdownDescription": "Suppport MDC syntax\n\nSee https://github.com/antfu/markdown-it-mdc\n\nSee https://content.nuxtjs.org/guide/writing/mdc",
           "default": false
         },
         "editor": {
           "type": "boolean",
           "description": "Enable built-in editor",
+          "markdownDescription": "Enable built-in editor",
           "default": true
         },
         "contextMenu": {
@@ -340,6 +382,7 @@
             }
           ],
           "description": "Enable context menu",
+          "markdownDescription": "Enable context menu",
           "default": true
         },
         "wakeLock": {
@@ -356,7 +399,8 @@
               "const": "build"
             }
           ],
-          "description": "Enable wake lock"
+          "description": "Enable wake lock",
+          "markdownDescription": "Enable wake lock"
         },
         "exportFilename": {
           "type": [
@@ -364,6 +408,7 @@
             "null"
           ],
           "description": "Force the filename used when exporting the presentation. The extension, e.g. .pdf, gets automatically added.",
+          "markdownDescription": "Force the filename used when exporting the presentation.\nThe extension, e.g. .pdf, gets automatically added.",
           "default": ""
         },
         "monaco": {
@@ -381,6 +426,7 @@
             }
           ],
           "description": "Enable Monaco\n\nSee https://sli.dev/custom/config-monaco.html",
+          "markdownDescription": "Enable Monaco\n\nSee https://sli.dev/custom/config-monaco.html",
           "default": true
         },
         "monacoTypesSource": {
@@ -391,6 +437,7 @@
             "none"
           ],
           "description": "Where to load monaco types from\n\n- `cdn` - load from CDN with `@typescript/ata`\n- `local` - load from local node_modules",
+          "markdownDescription": "Where to load monaco types from\n\n- `cdn` - load from CDN with `@typescript/ata`\n- `local` - load from local node_modules",
           "default": "local"
         },
         "monacoTypesAdditionalPackages": {
@@ -399,6 +446,7 @@
             "type": "string"
           },
           "description": "Additional node packages to load as monaco types",
+          "markdownDescription": "Additional node packages to load as monaco types",
           "default": []
         },
         "monacoTypesIgnorePackages": {
@@ -407,6 +455,7 @@
             "type": "string"
           },
           "description": "Packages to ignore when loading monaco types",
+          "markdownDescription": "Packages to ignore when loading monaco types",
           "default": []
         },
         "monacoRunAdditionalDeps": {
@@ -415,11 +464,13 @@
             "type": "string"
           },
           "description": "Additional local modules to load as dependencies of monaco runnable",
+          "markdownDescription": "Additional local modules to load as dependencies of monaco runnable",
           "default": []
         },
         "defaults": {
           "$ref": "#/definitions/Frontmatter",
-          "description": "Default frontmatter options applied to all slides"
+          "description": "Default frontmatter options applied to all slides",
+          "markdownDescription": "Default frontmatter options applied to all slides"
         }
       }
     },
@@ -554,7 +605,8 @@
               }
             }
           ],
-          "description": "Sans serif fonts (default fonts for most text)"
+          "description": "Sans serif fonts (default fonts for most text)",
+          "markdownDescription": "Sans serif fonts (default fonts for most text)"
         },
         "serif": {
           "anyOf": [
@@ -568,7 +620,8 @@
               }
             }
           ],
-          "description": "Serif fonts"
+          "description": "Serif fonts",
+          "markdownDescription": "Serif fonts"
         },
         "mono": {
           "anyOf": [
@@ -582,7 +635,8 @@
               }
             }
           ],
-          "description": "Monospace fonts, for code blocks and etc."
+          "description": "Monospace fonts, for code blocks and etc.",
+          "markdownDescription": "Monospace fonts, for code blocks and etc."
         },
         "custom": {
           "anyOf": [
@@ -596,7 +650,8 @@
               }
             }
           ],
-          "description": "Load webfonts for custom CSS (does not apply anywhere by default)"
+          "description": "Load webfonts for custom CSS (does not apply anywhere by default)",
+          "markdownDescription": "Load webfonts for custom CSS (does not apply anywhere by default)"
         },
         "weights": {
           "anyOf": [
@@ -614,6 +669,7 @@
             }
           ],
           "description": "Weights for fonts",
+          "markdownDescription": "Weights for fonts",
           "default": [
             200,
             400,
@@ -623,6 +679,7 @@
         "italic": {
           "type": "boolean",
           "description": "Import italic fonts",
+          "markdownDescription": "Import italic fonts",
           "default": false
         },
         "provider": {
@@ -638,18 +695,21 @@
           "items": {
             "type": "string"
           },
-          "description": "Specify web fonts names, will detect from `sans`, `mono`, `serif` if not provided"
+          "description": "Specify web fonts names, will detect from `sans`, `mono`, `serif` if not provided",
+          "markdownDescription": "Specify web fonts names, will detect from `sans`, `mono`, `serif` if not provided"
         },
         "local": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "Specify local fonts names, be excluded from webfonts"
+          "description": "Specify local fonts names, be excluded from webfonts",
+          "markdownDescription": "Specify local fonts names, be excluded from webfonts"
         },
         "fallbacks": {
           "type": "boolean",
           "description": "Use fonts fallback",
+          "markdownDescription": "Use fonts fallback",
           "default": true
         }
       }
@@ -663,6 +723,7 @@
             "string"
           ],
           "description": "Persist the drawings to disk Passing string to specify the directory (default to `.slidev/drawings`)",
+          "markdownDescription": "Persist the drawings to disk\nPassing string to specify the directory (default to `.slidev/drawings`)",
           "default": false
         },
         "enabled": {
@@ -684,11 +745,13 @@
         "presenterOnly": {
           "type": "boolean",
           "description": "Only allow drawing from presenter mode",
+          "markdownDescription": "Only allow drawing from presenter mode",
           "default": false
         },
         "syncAll": {
           "type": "boolean",
           "description": "Sync drawing for all instances",
+          "markdownDescription": "Sync drawing for all instances",
           "default": true
         }
       }
@@ -711,7 +774,8 @@
               "type": "null"
             }
           ],
-          "description": "Page transition, powered by Vue's `<TransitionGroup/>`\n\nBuilt-in transitions:\n- fade\n- fade-out\n- slide-left\n- slide-right\n- slide-up\n- slide-down\n\nSee https://sli.dev/guide/animations.html#pages-transitions\n\nSee https://vuejs.org/guide/built-ins/transition.html"
+          "description": "Page transition, powered by Vue's `<TransitionGroup/>`\n\nBuilt-in transitions:\n- fade\n- fade-out\n- slide-left\n- slide-right\n- slide-up\n- slide-down\n\nSee https://sli.dev/guide/animations.html#pages-transitions\n\nSee https://vuejs.org/guide/built-ins/transition.html",
+          "markdownDescription": "Page transition, powered by Vue's `<TransitionGroup/>`\n\nBuilt-in transitions:\n- fade\n- fade-out\n- slide-left\n- slide-right\n- slide-up\n- slide-down\n\nSee https://sli.dev/guide/animations.html#pages-transitions\n\nSee https://vuejs.org/guide/built-ins/transition.html"
         },
         "layout": {
           "anyOf": [
@@ -722,7 +786,8 @@
               "type": "string"
             }
           ],
-          "description": "Slide layout to use\n\nDefault to 'cover' for the first slide, 'default' for the rest"
+          "description": "Slide layout to use\n\nDefault to 'cover' for the first slide, 'default' for the rest",
+          "markdownDescription": "Slide layout to use\n\nDefault to 'cover' for the first slide, 'default' for the rest"
         },
         "class": {
           "anyOf": [
@@ -740,45 +805,55 @@
               "additionalProperties": {}
             }
           ],
-          "description": "Custom class added to the slide root element"
+          "description": "Custom class added to the slide root element",
+          "markdownDescription": "Custom class added to the slide root element"
         },
         "clicks": {
           "type": "number",
-          "description": "Manually specified the total clicks needed to this slide\n\nWhen not specified, the clicks will be calculated by the usage of v-clicks\n\nSee https://sli.dev/guide/animations"
+          "description": "Manually specified the total clicks needed to this slide\n\nWhen not specified, the clicks will be calculated by the usage of v-clicks\n\nSee https://sli.dev/guide/animations",
+          "markdownDescription": "Manually specified the total clicks needed to this slide\n\nWhen not specified, the clicks will be calculated by the usage of v-clicks\n\nSee https://sli.dev/guide/animations"
         },
         "clicksStart": {
           "type": "number",
           "description": "Manually specified the total clicks needed to this slide to start",
+          "markdownDescription": "Manually specified the total clicks needed to this slide to start",
           "default": 0
         },
         "preload": {
           "type": "boolean",
           "description": "Preload the slide when the previous slide is active",
+          "markdownDescription": "Preload the slide when the previous slide is active",
           "default": true
         },
         "hide": {
           "type": "boolean",
-          "description": "Completely hide and disable the slide"
+          "description": "Completely hide and disable the slide",
+          "markdownDescription": "Completely hide and disable the slide"
         },
         "disabled": {
           "type": "boolean",
-          "description": "Same as `hide`, completely hide and disable the slide"
+          "description": "Same as `hide`, completely hide and disable the slide",
+          "markdownDescription": "Same as `hide`, completely hide and disable the slide"
         },
         "hideInToc": {
           "type": "boolean",
-          "description": "hide the slide for the `<Toc>` components\n\nSee https://sli.dev/builtin/components#toc"
+          "description": "hide the slide for the `<Toc>` components\n\nSee https://sli.dev/builtin/components#toc",
+          "markdownDescription": "hide the slide for the `<Toc>` components\n\nSee https://sli.dev/builtin/components#toc"
         },
         "level": {
           "type": "number",
-          "description": "Override the title level for the <TitleRenderer> and <Toc> components Only if `title` has also been declared"
+          "description": "Override the title level for the <TitleRenderer> and <Toc> components Only if `title` has also been declared",
+          "markdownDescription": "Override the title level for the <TitleRenderer> and <Toc> components\nOnly if `title` has also been declared"
         },
         "routeAlias": {
           "type": "string",
-          "description": "Create a route alias that can be used in the URL or with the <Link> component"
+          "description": "Create a route alias that can be used in the URL or with the <Link> component",
+          "markdownDescription": "Create a route alias that can be used in the URL or with the <Link> component"
         },
         "zoom": {
           "type": "number",
           "description": "Custom zoom level for the slide",
+          "markdownDescription": "Custom zoom level for the slide",
           "default": 1
         },
         "dragPos": {
@@ -789,11 +864,13 @@
               "type": "string"
             }
           },
-          "description": "Store the positions of draggable elements Normally you don't need to set this manually\n\nSee https://sli.dev/features/draggable"
+          "description": "Store the positions of draggable elements Normally you don't need to set this manually\n\nSee https://sli.dev/features/draggable",
+          "markdownDescription": "Store the positions of draggable elements\nNormally you don't need to set this manually\n\nSee https://sli.dev/features/draggable"
         },
         "src": {
           "type": "string",
-          "description": "Includes a markdown file\n\nSee https://sli.dev/guide/syntax.html#importing-slides"
+          "description": "Includes a markdown file\n\nSee https://sli.dev/guide/syntax.html#importing-slides",
+          "markdownDescription": "Includes a markdown file\n\nSee https://sli.dev/guide/syntax.html#importing-slides"
         }
       }
     }

--- a/packages/vscode/scripts/schema.ts
+++ b/packages/vscode/scripts/schema.ts
@@ -5,21 +5,22 @@ const program = tsj
   .createGenerator({
     path: '../../packages/types/src/frontmatter.ts',
     tsconfig: '../../tsconfig.json',
+    markdownDescription: true,
     additionalProperties: true,
     jsDoc: 'extended',
     skipTypeCheck: true,
   })
 
 await Promise.all([
-  fs.writeFile('./schema/headmatter.json', JSON.stringify(
+  fs.writeFile('./schema/headmatter.json', `${JSON.stringify(
     program.createSchema('Headmatter'),
     null,
     2,
-  )),
+  )}\n`),
 
-  fs.writeFile('./schema/frontmatter.json', JSON.stringify(
+  fs.writeFile('./schema/frontmatter.json', `${JSON.stringify(
     program.createSchema('Frontmatter'),
     null,
     2,
-  )),
+  )}\n`),
 ])

--- a/packages/vscode/syntaxes/slidev.tmLanguage.json
+++ b/packages/vscode/syntaxes/slidev.tmLanguage.json
@@ -62,7 +62,7 @@
       }
     },
     "range": {
-      "match": "(\\d+|\\*)([,-])?",
+      "match": "(\\d+|\\*|all)([,-])?",
       "captures": {
         "1": {
           "name": "constant.numeric.range.slidev"


### PR DESCRIPTION
Fixes:

- "Scheme not found" error on my machine
- Hover message wasn't rendered as Markdown
- Prettier used to parse frontmatters as Markdown instead of YAML
- Highlight `all` inside code block attributes
- Add trailing <del>comma</del> new line to generated schemas so that ESLint won't complain (should the generated files be added to `.gitignore`?)