### PR TITLE
fix: should not pass entry files to MarkdownIt

### DIFF
--- a/packages/parser/src/fs.ts
+++ b/packages/parser/src/fs.ts
@@ -19,8 +19,8 @@ export function injectPreparserExtensionLoader(fn: PreparserExtensionLoader) {
  */
 export type LoadedSlidevData = Omit<SlidevData, 'config' | 'themeMeta'>
 
-export async function load(userRoot: string, filepath: string, content?: string, mode?: string): Promise<LoadedSlidevData> {
-  const markdown = content ?? fs.readFileSync(filepath, 'utf-8')
+export async function load(userRoot: string, filepath: string, loadedSource: Record<string, string> = {}, mode?: string): Promise<LoadedSlidevData> {
+  const markdown = loadedSource[filepath] ?? fs.readFileSync(filepath, 'utf-8')
 
   let extensions: SlidevPreparserExtension[] | undefined
   if (preparserExtensionLoader) {
@@ -45,7 +45,7 @@ export async function load(userRoot: string, filepath: string, content?: string,
   async function loadMarkdown(path: string, range?: string, frontmatterOverride?: Record<string, unknown>, importers?: SourceSlideInfo[]) {
     let md = markdownFiles[path]
     if (!md) {
-      const raw = fs.readFileSync(path, 'utf-8')
+      const raw = loadedSource[path] ?? fs.readFileSync(path, 'utf-8')
       md = await parse(raw, path, extensions)
       markdownFiles[path] = md
     }

--- a/packages/slidev/node/cli.ts
+++ b/packages/slidev/node/cli.ts
@@ -154,9 +154,9 @@ cli.command(
           logLevel: log as LogLevel,
         },
         {
-          async loadData() {
+          async loadData(loadedSource) {
             const { data: oldData, entry } = options
-            const loaded = await parser.load(options.userRoot, entry, undefined, 'dev')
+            const loaded = await parser.load(options.userRoot, entry, loadedSource, 'dev')
 
             const themeRaw = theme || loaded.headmatter.theme as string || 'default'
             if (options.themeRaw !== themeRaw) {

--- a/packages/slidev/node/vite/loaders.ts
+++ b/packages/slidev/node/vite/loaders.ts
@@ -65,6 +65,7 @@ export function createSlidesLoader(
 
   return {
     name: 'slidev:loader',
+    enforce: 'pre',
 
     configureServer(_server) {
       server = _server
@@ -125,9 +126,10 @@ export function createSlidesLoader(
       if (!data.watchFiles.includes(ctx.file))
         return
 
-      await ctx.read()
+      const newData = await serverOptions.loadData?.({
+        [ctx.file]: await ctx.read(),
+      })
 
-      const newData = await serverOptions.loadData?.()
       if (!newData)
         return []
 
@@ -323,6 +325,10 @@ export function createSlidesLoader(
           }
         }
       }
+
+      // Entry files, shouldn't be processed by MarkdownIt
+      if (data.markdownFiles[id])
+        return ''
     },
   }
 }

--- a/packages/slidev/node/vite/markdown.ts
+++ b/packages/slidev/node/vite/markdown.ts
@@ -34,6 +34,10 @@ export async function createMarkdownPlugin(
     transforms: {
       ...mdOptions?.transforms,
       before(code, id) {
+        // Skip entry Markdown files
+        if (options.data.markdownFiles[id])
+          return ''
+
         code = mdOptions?.transforms?.before?.(code, id) ?? code
 
         const match = id.match(regexSlideSourceId)

--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -56,5 +56,5 @@ export interface SlidevServerOptions {
   /**
    * @returns `false` if server should be restarted
    */
-  loadData?: () => Promise<SlidevData | false>
+  loadData?: (loadedSource: Record<string, string>) => Promise<SlidevData | false>
 }


### PR DESCRIPTION
fix #1772.

This is a regression caused by #1767. In which the check of whether the processed file is the entry file was removed from the `before` hook of `unplugin-vue-markdown`.

And inside `handleHotUpdate`, `await ctx.read` was called because of #884. Unfortunately, `unplugin-vue-markdown` overrides this method [here](https://github.com/unplugin/unplugin-vue-markdown/blob/825ffc0d780f16297e48b9a27a278d7b72146408/src/index.ts#L34-L43). This causes unexpected processing of the entry file, while the client hasn't import it at all.

This PR fixes this by adding `order: 'pre'` to the loader plugin to use `await ctx.read` before `unplugin-vue-markdown`, and re-adding the checks in the `before` hook of `unplugin-vue-markdown`.