### PR TITLE
fix: code snippets HMR

### DIFF
--- a/packages/parser/src/fs.ts
+++ b/packages/parser/src/fs.ts
@@ -40,6 +40,7 @@ export async function load(userRoot: string, filepath: string, loadedSource: Rec
   }
 
   const markdownFiles: Record<string, SlidevMarkdown> = {}
+  const watchFiles: Record<string, Set<number>> = {}
   const slides: SlideInfo[] = []
 
   async function loadMarkdown(path: string, range?: string, frontmatterOverride?: Record<string, unknown>, importers?: SourceSlideInfo[]) {
@@ -48,6 +49,7 @@ export async function load(userRoot: string, filepath: string, loadedSource: Rec
       const raw = loadedSource[path] ?? fs.readFileSync(path, 'utf-8')
       md = await parse(raw, path, extensions)
       markdownFiles[path] = md
+      watchFiles[path] = new Set()
     }
 
     const directImporter = importers?.at(-1)
@@ -125,7 +127,7 @@ export async function load(userRoot: string, filepath: string, loadedSource: Rec
     headmatter,
     features: detectFeatures(slides.map(s => s.source.raw).join('')),
     markdownFiles,
-    watchFiles: Object.keys(markdownFiles).map(slash),
+    watchFiles,
   }
 }
 

--- a/packages/slidev/node/syntax/transform/snippet.ts
+++ b/packages/slidev/node/syntax/transform/snippet.ts
@@ -84,7 +84,7 @@ function findRegion(lines: Array<string>, regionName: string) {
  * captures: ['/path/to/file.extension', '#region', 'language', '{meta}']
  */
 export function transformSnippet({ s, slide, options }: MarkdownTransformContext) {
-  const data = options.data
+  const watchFiles = options.data.watchFiles
   const dir = path.dirname(slide.source?.filepath ?? options.entry ?? options.userRoot)
 
   s.replace(
@@ -97,7 +97,8 @@ export function transformSnippet({ s, slide, options }: MarkdownTransformContext
           : path.resolve(dir, filepath),
       )
 
-      data.watchFiles.push(src)
+      watchFiles[src] ??= new Set()
+      watchFiles[src].add(slide.index)
 
       const isAFile = fs.statSync(src).isFile()
       if (!fs.existsSync(src) || !isAFile) {
@@ -107,9 +108,6 @@ export function transformSnippet({ s, slide, options }: MarkdownTransformContext
       }
 
       let content = fs.readFileSync(src, 'utf8')
-
-      slide.snippetsUsed ??= {}
-      slide.snippetsUsed[src] = content
 
       if (regionName) {
         const lines = content.split(/\r?\n/)

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -51,7 +51,6 @@ export interface SlideInfo extends SlideInfoBase {
    * The source slide where the content is from
    */
   source: SourceSlideInfo
-  snippetsUsed?: LoadedSnippets
   noteHTML?: string
 }
 
@@ -112,7 +111,10 @@ export interface SlidevData {
   features: SlidevDetectedFeatures
   themeMeta?: SlidevThemeMeta
   markdownFiles: Record<string, SlidevMarkdown>
-  watchFiles: string[]
+  /**
+   * From watched files to indexes of slides that must be reloaded regardless of the loaded content
+   */
+  watchFiles: Record<string, Set<number>>
 }
 
 export interface SlidevPreparserExtension {
@@ -137,5 +139,3 @@ export interface SlideRoute {
    */
   component: Component
 }
-
-export type LoadedSnippets = Record<string, string>

--- a/packages/vscode/src/projects.ts
+++ b/packages/vscode/src/projects.ts
@@ -75,7 +75,7 @@ export function useProjects() {
   onScopeDispose(() => fsWatcher.dispose())
 
   fsWatcher.onDidChange(async (uri) => {
-    const path = slash(uri.fsPath).toLowerCase()
+    const path = slash(uri.fsPath)
     logger.info(`File ${path} changed.`)
     const startMs = Date.now()
     if (pendingUpdate)
@@ -83,7 +83,7 @@ export function useProjects() {
     const thisUpdate = pendingUpdate = { cancelled: false }
     const effects: (() => void)[] = []
     for (const project of projects.values()) {
-      if (!project.data.watchFiles.some(f => f.toLowerCase() === path))
+      if (!project.data.markdownFiles[path])
         continue
 
       if (existsSync(project.entry)) {

--- a/packages/vscode/src/views/projectsTree.ts
+++ b/packages/vscode/src/views/projectsTree.ts
@@ -47,7 +47,7 @@ export const useProjectsTree = createSingletonComposable(() => {
   const treeData = computed(() => {
     return [...projects.values()].map(project => ({
       treeItem: getProjectTreeItem(project),
-      children: project.data.watchFiles
+      children: Object.keys(project.data.markdownFiles)
         .filter(file => file.toLowerCase() !== project.entry.toLowerCase())
         .map(file => ({ treeItem: getFileTreeItem(file) })),
     }))

--- a/test/_tutils.ts
+++ b/test/_tutils.ts
@@ -13,7 +13,7 @@ export function createTransformContext(code: string, shiki?: any): MarkdownTrans
         slides: [
           {} as any,
         ],
-        watchFiles: [],
+        watchFiles: {},
         config: {} as any,
         features: {},
       },


### PR DESCRIPTION
fix HMR for code snippets (`<<< path/to/snippet.ts`)

Redesigned `data.watchFiles`:

Previously, it was an array for all watched files that should trigger Slidev's `handleHotUpdate`. In `handleHotUpdate`, Slidev first **load**s the slides and compares each slide to know which slide should be updated. However, code snippets are loaded in **transform** hook. The new `data.watchFiles` is an object mapping from the watched file path to slide indexes that **must** be updated when the file is changed.
