### PR TITLE
feat: add CLI option to allow transparent pngs

### DIFF
--- a/docs/builtin/cli.md
+++ b/docs/builtin/cli.md
@@ -74,6 +74,7 @@ Options:
 - `--dark` (`boolean`, default: `false`): export as dark theme.
 - `--with-clicks`, `-c` (`boolean`, default: `false`): export pages for every click animation (see https://sli.dev/guide/animations.html#click-animation).
 - `--theme`, `-t` (`string`): override theme.
+- `--transparent` (`boolean`, default: `false`): remove the default browser background
 
 ## `slidev format [entry]` {#format}
 

--- a/docs/builtin/cli.md
+++ b/docs/builtin/cli.md
@@ -74,7 +74,7 @@ Options:
 - `--dark` (`boolean`, default: `false`): export as dark theme.
 - `--with-clicks`, `-c` (`boolean`, default: `false`): export pages for every click animation (see https://sli.dev/guide/animations.html#click-animation).
 - `--theme`, `-t` (`string`): override theme.
-- `--transparent` (`boolean`, default: `false`): remove the default browser background
+- `--omit-background` (`boolean`, default: `false`): remove the default browser background
 
 ## `slidev format [entry]` {#format}
 

--- a/docs/guide/exporting.md
+++ b/docs/guide/exporting.md
@@ -182,6 +182,7 @@ You can generate the PDF outline by passing the `--with-toc` option:
 ```bash
 $ slidev export --with-toc
 ```
+
 ### Transparent PNGs
 
 You can remove the default browser background by passing `--transparent`:
@@ -189,11 +190,13 @@ You can remove the default browser background by passing `--transparent`:
 ```bash
 $ slidev export --transparent
 ```
+
 The default browser background is the white background visible on all browser windows and is different than other backgrounds applied throughout the application using CSS styling. [See Playwright docs](https://playwright.dev/docs/api/class-page#page-screenshot-option-omit-background). You will then need to apply additional CSS styling to the application to reveal the transparency.
 
 Here is a basic example that covers all backgrounds in the application:
+
 ```css
 * {
-    background: transparent !important;
-  }
+  background: transparent !important;
+}
 ```

--- a/docs/guide/exporting.md
+++ b/docs/guide/exporting.md
@@ -189,7 +189,7 @@ You can remove the default browser background by passing `--transparent`:
 ```bash
 $ slidev export --transparent
 ```
-The default browser background is the white background visible on all browser windows and is different than other backgrounds applied throughout the application using CSS styling. You will then need to apply additional CSS styling to the application to reveal the transparency.
+The default browser background is the white background visible on all browser windows and is different than other backgrounds applied throughout the application using CSS styling. [See Playwright docs](https://playwright.dev/docs/api/class-page#page-screenshot-option-omit-background). You will then need to apply additional CSS styling to the application to reveal the transparency.
 
 Here is a basic example that covers all backgrounds in the application:
 ```css

--- a/docs/guide/exporting.md
+++ b/docs/guide/exporting.md
@@ -185,10 +185,10 @@ $ slidev export --with-toc
 
 ### Transparent PNGs
 
-You can remove the default browser background by passing `--transparent`:
+You can remove the default browser background by passing `--omit-background`:
 
 ```bash
-$ slidev export --transparent
+$ slidev export --omit-background
 ```
 
 The default browser background is the white background visible on all browser windows and is different than other backgrounds applied throughout the application using CSS styling. [See Playwright docs](https://playwright.dev/docs/api/class-page#page-screenshot-option-omit-background). You will then need to apply additional CSS styling to the application to reveal the transparency.

--- a/docs/guide/exporting.md
+++ b/docs/guide/exporting.md
@@ -183,9 +183,9 @@ You can generate the PDF outline by passing the `--with-toc` option:
 $ slidev export --with-toc
 ```
 
-### Transparent PNGs
+### Omit Background
 
-You can remove the default browser background by passing `--omit-background`:
+When exporting to PNGs, you can remove the default browser background by passing `--omit-background`:
 
 ```bash
 $ slidev export --omit-background

--- a/docs/guide/exporting.md
+++ b/docs/guide/exporting.md
@@ -182,3 +182,18 @@ You can generate the PDF outline by passing the `--with-toc` option:
 ```bash
 $ slidev export --with-toc
 ```
+### Transparent PNGs
+
+You can remove the default browser background by passing `--transparent`:
+
+```bash
+$ slidev export --transparent
+```
+The default browser background is the white background visible on all browser windows and is different than other backgrounds applied throughout the application using CSS styling. You will then need to apply additional CSS styling to the application to reveal the transparency.
+
+Here is a basic example that covers all backgrounds in the application:
+```css
+* {
+    background: transparent !important;
+  }
+```

--- a/packages/slidev/node/cli.ts
+++ b/packages/slidev/node/cli.ts
@@ -603,6 +603,10 @@ function exportOptions<T>(args: Argv<T>) {
       type: 'number',
       describe: 'scale factor for image export',
     })
+    .option('transparent', {
+      type: 'boolean',
+      describe: 'export png pages without the default browser background',
+    })
 }
 
 function printInfo(

--- a/packages/slidev/node/cli.ts
+++ b/packages/slidev/node/cli.ts
@@ -603,7 +603,7 @@ function exportOptions<T>(args: Argv<T>) {
       type: 'number',
       describe: 'scale factor for image export',
     })
-    .option('transparent', {
+    .option('omit-background', {
       type: 'boolean',
       describe: 'export png pages without the default browser background',
     })

--- a/packages/slidev/node/commands/export.ts
+++ b/packages/slidev/node/commands/export.ts
@@ -37,6 +37,7 @@ export interface ExportOptions {
    */
   perSlide?: boolean
   scale?: number
+  transparent?: boolean
 }
 
 interface ExportPngResult {
@@ -183,6 +184,7 @@ export async function exportSlides({
   perSlide = false,
   scale = 1,
   waitUntil,
+  transparent = false,
 }: ExportOptions) {
   const pages: number[] = parseRangeString(total, range)
 
@@ -402,7 +404,9 @@ export async function exportSlides({
       progress.update(i + 1)
       const id = (await slideContainers.nth(i).getAttribute('id')) || ''
       const slideNo = +id.split('-')[0]
-      const buffer = await slideContainers.nth(i).screenshot()
+      const buffer = await slideContainers.nth(i).screenshot({
+        omitBackground: transparent,
+      })
       result.push({ slideIndex: slideNo - 1, buffer })
       if (writeToDisk)
         await fs.writeFile(path.join(output, `${withClicks ? id : slideNo}.png`), buffer)
@@ -414,7 +418,9 @@ export async function exportSlides({
     const result: ExportPngResult[] = []
     const genScreenshot = async (no: number, clicks?: string) => {
       await go(no, clicks)
-      const buffer = await page.screenshot()
+      const buffer = await page.screenshot({
+        omitBackground: transparent,
+      })
       result.push({ slideIndex: no - 1, buffer })
       if (writeToDisk) {
         await fs.writeFile(
@@ -585,6 +591,7 @@ export function getExportOptions(args: ExportArgs, options: ResolvedSlidevOption
     withToc,
     perSlide,
     scale,
+    transparent,
   } = config
   outFilename = output || options.data.config.exportFilename || outFilename || `${path.basename(entry, '.md')}-export`
   if (outDir)
@@ -607,6 +614,7 @@ export function getExportOptions(args: ExportArgs, options: ResolvedSlidevOption
     withToc: withToc || false,
     perSlide: perSlide || false,
     scale: scale || 2,
+    transparent: transparent || false,
   }
 }
 

--- a/packages/slidev/node/commands/export.ts
+++ b/packages/slidev/node/commands/export.ts
@@ -614,7 +614,7 @@ export function getExportOptions(args: ExportArgs, options: ResolvedSlidevOption
     withToc: withToc || false,
     perSlide: perSlide || false,
     scale: scale || 2,
-    transparent: transparent || false,
+    transparent: transparent ?? false,
   }
 }
 

--- a/packages/slidev/node/commands/export.ts
+++ b/packages/slidev/node/commands/export.ts
@@ -37,7 +37,7 @@ export interface ExportOptions {
    */
   perSlide?: boolean
   scale?: number
-  transparent?: boolean
+  omitBackground?: boolean
 }
 
 interface ExportPngResult {
@@ -184,7 +184,7 @@ export async function exportSlides({
   perSlide = false,
   scale = 1,
   waitUntil,
-  transparent = false,
+  omitBackground = false,
 }: ExportOptions) {
   const pages: number[] = parseRangeString(total, range)
 
@@ -405,7 +405,7 @@ export async function exportSlides({
       const id = (await slideContainers.nth(i).getAttribute('id')) || ''
       const slideNo = +id.split('-')[0]
       const buffer = await slideContainers.nth(i).screenshot({
-        omitBackground: transparent,
+        omitBackground,
       })
       result.push({ slideIndex: slideNo - 1, buffer })
       if (writeToDisk)
@@ -419,7 +419,7 @@ export async function exportSlides({
     const genScreenshot = async (no: number, clicks?: string) => {
       await go(no, clicks)
       const buffer = await page.screenshot({
-        omitBackground: transparent,
+        omitBackground,
       })
       result.push({ slideIndex: no - 1, buffer })
       if (writeToDisk) {
@@ -575,6 +575,7 @@ export function getExportOptions(args: ExportArgs, options: ResolvedSlidevOption
       executablePath: args['executable-path'],
       withToc: args['with-toc'],
       perSlide: args['per-slide'],
+      omitBackground: args['omit-background'],
     }),
   }
   const {
@@ -591,7 +592,7 @@ export function getExportOptions(args: ExportArgs, options: ResolvedSlidevOption
     withToc,
     perSlide,
     scale,
-    transparent,
+    omitBackground,
   } = config
   outFilename = output || options.data.config.exportFilename || outFilename || `${path.basename(entry, '.md')}-export`
   if (outDir)
@@ -614,7 +615,7 @@ export function getExportOptions(args: ExportArgs, options: ResolvedSlidevOption
     withToc: withToc || false,
     perSlide: perSlide || false,
     scale: scale || 2,
-    transparent: transparent ?? false,
+    omitBackground: omitBackground ?? false,
   }
 }
 

--- a/packages/types/src/cli.ts
+++ b/packages/types/src/cli.ts
@@ -16,7 +16,7 @@ export interface ExportArgs extends CommonArgs {
   'with-toc'?: boolean
   'per-slide'?: boolean
   'scale'?: number
-  'transparent'?: boolean
+  'omit-background'?: boolean
 }
 
 export interface BuildArgs extends ExportArgs {

--- a/packages/types/src/cli.ts
+++ b/packages/types/src/cli.ts
@@ -16,6 +16,7 @@ export interface ExportArgs extends CommonArgs {
   'with-toc'?: boolean
   'per-slide'?: boolean
   'scale'?: number
+  'transparent'?: boolean
 }
 
 export interface BuildArgs extends ExportArgs {


### PR DESCRIPTION
PNGs are generated by taking a screenshot of the page as if it were running in a browser using Playwright. Currently, PNG exports will never be transparent and will always have the default, white, browser background regardless of if the user has removed all backgrounds using css. Playwright has an `omitBackground` property that can be added to the `.screenshot` method to remove this final browser background.

https://playwright.dev/docs/api/class-page#page-screenshot-option-omit-background

This PR adds the `--omit-background` CLI option to control the visibility of the default browser background and allow for the possibility of transparent png exports. It also adds docs for this feature

Users will still need to apply additional css styling to remove the css backgrounds from their slides in order to reveal the transparency in their exports.