### PR TITLE
fix(vscode): textmate grammar

### DIFF
--- a/packages/vscode/syntaxes/slidev.tmLanguage.json
+++ b/packages/vscode/syntaxes/slidev.tmLanguage.json
@@ -96,7 +96,7 @@
           "patterns": [
             {
               "begin": "\\G",
-              "end": "(?=(^|\\G)(---).*$)",
+              "while": "^(?!(^|\\G)(---).*$)",
               "contentName": "meta.embedded.block.yaml",
               "patterns": [
                 {


### PR DESCRIPTION
fix #1801

Slidev's syntax highlighting is broken in the latest VSCode. I think this is due to https://github.com/microsoft/vscode/pull/221204.

This fix works but I don't know if it is the best way.