### PR TITLE
feat: run Slidev in browser

### DIFF
--- a/packages/client/logic/utils.ts
+++ b/packages/client/logic/utils.ts
@@ -1,4 +1,4 @@
-import { parseRangeString } from '@slidev/parser/core'
+import { parseRangeString } from '@slidev/parser/utils'
 import { useTimestamp } from '@vueuse/core'
 import { computed, ref } from 'vue'
 

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -23,6 +23,10 @@
     "./fs": {
       "types": "./dist/fs.d.mts",
       "import": "./dist/fs.mjs"
+    },
+    "./utils": {
+      "types": "./dist/utils.d.mts",
+      "import": "./dist/utils.mjs"
     }
   },
   "main": "dist/index.mjs",

--- a/packages/slidev/node/options.ts
+++ b/packages/slidev/node/options.ts
@@ -9,6 +9,7 @@ import { getThemeMeta, resolveTheme } from './integrations/themes'
 import { resolveAddons } from './integrations/addons'
 import { getRoots, resolveEntry } from './resolver'
 import setupShiki from './setups/shiki'
+import { getDefine } from './vite/extendConfig'
 
 const debug = Debug('slidev:options')
 
@@ -76,6 +77,7 @@ export async function createDataUtils(data: SlidevData, clientRoot: string, root
 
   return {
     ...await setupShiki(roots),
+    defines: getDefine(options),
     isMonacoTypesIgnored: pkg => monacoTypesIgnorePackagesMatches.some(i => i(pkg)),
     getLayouts: () => {
       const now = Date.now()

--- a/packages/slidev/node/vite/compilerFlagsVue.ts
+++ b/packages/slidev/node/vite/compilerFlagsVue.ts
@@ -1,7 +1,6 @@
 import type { Plugin } from 'vite'
 import { objectEntries } from '@antfu/utils'
 import type { ResolvedSlidevOptions } from '@slidev/types'
-import { getDefine } from './extendConfig'
 
 /**
  * Replace compiler flags like `__DEV__` in Vue SFC
@@ -9,7 +8,7 @@ import { getDefine } from './extendConfig'
 export function createVueCompilerFlagsPlugin(
   options: ResolvedSlidevOptions,
 ): Plugin[] {
-  const define = objectEntries(getDefine(options))
+  const define = objectEntries(options.utils.defines)
   return [
     {
       name: 'slidev:flags',

--- a/packages/slidev/node/vite/extendConfig.ts
+++ b/packages/slidev/node/vite/extendConfig.ts
@@ -70,7 +70,7 @@ export function createConfigPlugin(options: ResolvedSlidevOptions): Plugin {
     name: 'slidev:config',
     async config(config) {
       const injection: InlineConfig = {
-        define: getDefine(options),
+        define: options.utils.defines,
         resolve: {
           alias: [
             {

--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -48,6 +48,7 @@ export interface ResolvedSlidevOptions extends RootsInfo, SlidevEntryOptions {
 export interface ResolvedSlidevUtils {
   shiki: HighlighterGeneric<any, any>
   shikiOptions: MarkdownItShikiOptions
+  defines: Record<string, string>
   isMonacoTypesIgnored: (pkg: string) => boolean
   getLayouts: () => Record<string, string>
 }

--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="icon" href="https://cdn.jsdelivr.net/gh/slidevjs/slidev/assets/favicon.png">
+  <title>Slidev Online</title>
+</head>
+<body>
+  <div id="app"></div>
+  <script type="module" src="src/main.ts"></script>
+  <div id="mermaid-rendering-container"></div>
+  <!-- body -->
+</body>
+</html>

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@slidev/compiler",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build"
+  },
+  "devDependencies": {
+    "@antfu/utils": "^0.7.10",
+    "@babel/standalone": "^7.25.3",
+    "@slidev/client": "workspace:*",
+    "@slidev/parser": "workspace:*",
+    "@types/babel__standalone": "^7.1.7",
+    "@vue/babel-plugin-jsx": "^1.2.2",
+    "ohash": "^1.1.3",
+    "sucrase": "^3.35.0",
+    "typescript": "^5.5.4",
+    "unocss": "^0.61.5",
+    "unplugin-vue-markdown": "^0.26.2",
+    "vite": "^5.3.4",
+    "vue": "^3.4.33",
+    "vue-router": "^4.4.0"
+  }
+}

--- a/packages/web/polyfills/node-module.ts
+++ b/packages/web/polyfills/node-module.ts
@@ -1,0 +1,1 @@
+export const createRequire = () => null

--- a/packages/web/polyfills/rollup-pluginutils.ts
+++ b/packages/web/polyfills/rollup-pluginutils.ts
@@ -1,0 +1,1 @@
+export const createFilter = () => () => true

--- a/packages/web/polyfills/unplugin.ts
+++ b/packages/web/polyfills/unplugin.ts
@@ -1,0 +1,1 @@
+export const createUnplugin = () => null

--- a/packages/web/src/compiler/file.ts
+++ b/packages/web/src/compiler/file.ts
@@ -1,0 +1,61 @@
+// Ported from https://github.com/vuejs/repl/blob/main/src/transform.ts
+
+import { compileMd } from './md'
+import { transformTS } from './ts'
+import { isJsLikeFile, isJsxFile, isTsFile } from './utils'
+import { compileVue } from './vue'
+
+export interface CompileResult {
+  js?: string
+  css?: string
+  errors?: (string | Error)[]
+}
+
+export async function compileFile(filename: string, code: string): Promise<CompileResult> {
+  if (!code.trim()) {
+    return {}
+  }
+
+  if (filename.endsWith('.css')) {
+    return {
+      css: code,
+    }
+  }
+
+  if (isJsLikeFile(filename)) {
+    const isJSX = isJsxFile(filename)
+    if (isTsFile(filename)) {
+      code = await transformTS(code, isJSX)
+    }
+    if (isJSX) {
+      code = await import('./jsx').then(m => m.transformJSX(code))
+    }
+    return {
+      js: code,
+    }
+  }
+
+  if (filename.endsWith('.json')) {
+    let parsed
+    try {
+      parsed = JSON.parse(code)
+    }
+    catch (err: any) {
+      console.error(`Error parsing ${filename}`, err.message)
+      return {
+        errors: [err.message],
+      }
+    }
+    return {
+      js: `export default ${JSON.stringify(parsed)}`,
+    }
+  }
+
+  if (filename.endsWith('.vue')) {
+    return compileVue(filename, code)
+  }
+
+  if (filename.endsWith('.md')) {
+    return compileMd(filename, code)
+  }
+}

--- a/packages/web/src/compiler/jsx.ts
+++ b/packages/web/src/compiler/jsx.ts
@@ -1,0 +1,10 @@
+// Ported from https://github.com/vuejs/repl/blob/main/src/jsx.ts
+
+import { transform } from '@babel/standalone'
+import jsx from '@vue/babel-plugin-jsx'
+
+export async function transformJSX(src: string) {
+  return transform(src, {
+    plugins: [jsx],
+  }).code!
+}

--- a/packages/web/src/compiler/md.ts
+++ b/packages/web/src/compiler/md.ts
@@ -1,0 +1,67 @@
+import { unpluginFactory } from 'unplugin-vue-markdown'
+import type { UnpluginOptions } from 'unplugin'
+import { computed } from 'vue'
+import { mdOptions } from '../configs/plugins'
+import type { CompileResult } from './file'
+import { compileVue } from './vue'
+
+const plugin = computed(() => {
+  return unpluginFactory({
+    include: [/\.md$/],
+    wrapperClasses: '',
+    headEnabled: false,
+    frontmatter: false,
+    escapeCodeTagInterpolation: false,
+    markdownItOptions: {
+      quotes: '""\'\'',
+      html: true,
+      xhtmlOut: true,
+      linkify: true,
+      ...mdOptions?.markdownItOptions,
+    },
+    ...mdOptions,
+    async markdownItSetup(md) {
+      // await useMarkdownItPlugins(md, options, markdownTransformMap)
+      await mdOptions?.markdownItSetup?.(md)
+    },
+    transforms: {
+      ...mdOptions?.transforms,
+      //   before(code, id) {
+      //     // Skip entry Markdown files
+      //     if (options.data.markdownFiles[id])
+      //       return ''
+
+      //     code = mdOptions?.transforms?.before?.(code, id) ?? code
+
+      //     const match = id.match(regexSlideSourceId)
+      //     if (!match)
+      //       return code
+
+      //     const s = new MagicString(code)
+      //     markdownTransformMap.set(id, s)
+      //     const ctx: MarkdownTransformContext = {
+      //       s,
+      //       slide: options.data.slides[+match[1] - 1],
+      //       options,
+      //     }
+
+      //     for (const transformer of transformers) {
+      //       if (!transformer)
+      //         continue
+      //       transformer(ctx)
+      //       if (!ctx.s.isEmpty())
+      //         ctx.s.commit()
+      //     }
+
+    //     return s.toString()
+    //   },
+    },
+  }, {
+    framework: 'vite',
+  }) as UnpluginOptions
+})
+
+export async function compileMd(filename: string, code: string): Promise<CompileResult> {
+  const vue = ((await plugin.value.transform?.call({} as any, code, 'file.md')) as any).code
+  return compileVue(filename, vue)
+}

--- a/packages/web/src/compiler/ts.ts
+++ b/packages/web/src/compiler/ts.ts
@@ -1,0 +1,8 @@
+import { transform } from 'sucrase'
+
+export async function transformTS(src: string, isJSX?: boolean) {
+  return transform(src, {
+    transforms: ['typescript', ...(isJSX ? (['jsx'] as const) : [])],
+    jsxRuntime: 'preserve',
+  }).code
+}

--- a/packages/web/src/compiler/utils.ts
+++ b/packages/web/src/compiler/utils.ts
@@ -1,0 +1,11 @@
+// Ported from https://github.com/vuejs/repl/blob/main/src/transform.ts
+
+export function isJsLikeFile(filename: string | undefined | null) {
+  return !!(filename && /\.[jt]sx?$/.test(filename))
+}
+export function isTsFile(filename: string | undefined | null) {
+  return !!(filename && /(?:\.|\b)tsx?$/.test(filename))
+}
+export function isJsxFile(filename: string | undefined | null) {
+  return !!(filename && /(?:\.|\b)[jt]sx$/.test(filename))
+}

--- a/packages/web/src/compiler/vue.ts
+++ b/packages/web/src/compiler/vue.ts
@@ -1,0 +1,281 @@
+// Ported from https://github.com/vuejs/repl/blob/main/src/transform.ts
+
+import type { BindingMetadata, CompilerOptions, SFCDescriptor } from 'vue/compiler-sfc'
+import * as compiler from 'vue/compiler-sfc'
+import { toArray } from '@antfu/utils'
+import { hash } from 'ohash'
+import { sfcOptions } from '../configs/plugins'
+import { transformTS } from './ts'
+import type { CompileResult } from './file'
+import { isJsxFile, isTsFile } from './utils'
+
+export const COMP_IDENTIFIER = `__sfc__`
+
+async function doCompileScript(
+  descriptor: SFCDescriptor,
+  id: string,
+  ssr: boolean,
+  isTS: boolean,
+  isJSX: boolean,
+): Promise<[code: string, bindings: BindingMetadata | undefined]> {
+  if (descriptor.script || descriptor.scriptSetup) {
+    const expressionPlugins: CompilerOptions['expressionPlugins'] = []
+    if (isTS) {
+      expressionPlugins.push('typescript')
+    }
+    if (isJSX) {
+      expressionPlugins.push('jsx')
+    }
+
+    const compiledScript = compiler.compileScript(descriptor, {
+      inlineTemplate: true,
+      ...sfcOptions?.script,
+      id,
+      genDefaultAs: COMP_IDENTIFIER,
+      templateOptions: {
+        ...sfcOptions?.template,
+        ssr,
+        ssrCssVars: descriptor.cssVars,
+        compilerOptions: {
+          ...sfcOptions?.template?.compilerOptions,
+          expressionPlugins,
+        },
+      },
+    })
+    let code = compiledScript.content
+    if (isTS) {
+      code = await transformTS(code, isJSX)
+    }
+    if (isJSX) {
+      code = await import('./jsx').then(m => m.transformJSX(code))
+    }
+
+    return [code, compiledScript.bindings]
+  }
+  else {
+    return [`\nconst ${COMP_IDENTIFIER} = {}`, undefined]
+  }
+}
+
+async function doCompileTemplate(
+  descriptor: SFCDescriptor,
+  id: string,
+  bindingMetadata: BindingMetadata | undefined,
+  ssr: boolean,
+  isTS: boolean,
+  isJSX: boolean,
+) {
+  const expressionPlugins: CompilerOptions['expressionPlugins'] = []
+  if (isTS) {
+    expressionPlugins.push('typescript')
+  }
+  if (isJSX) {
+    expressionPlugins.push('jsx')
+  }
+
+  let { code, errors } = compiler.compileTemplate({
+    isProd: false,
+    ...sfcOptions?.template,
+    ast: descriptor.template!.ast,
+    source: descriptor.template!.content,
+    filename: descriptor.filename,
+    id,
+    scoped: descriptor.styles.some(s => s.scoped),
+    slotted: descriptor.slotted,
+    ssr,
+    ssrCssVars: descriptor.cssVars,
+    compilerOptions: {
+      ...sfcOptions?.template?.compilerOptions,
+      bindingMetadata,
+      expressionPlugins,
+    },
+  })
+  if (errors.length) {
+    return errors
+  }
+
+  const fnName = ssr ? `ssrRender` : `render`
+
+  code
+    = `\n${code.replace(
+      /\nexport (function|const) (render|ssrRender)/,
+      `$1 ${fnName}`,
+    )}` + `\n${COMP_IDENTIFIER}.${fnName} = ${fnName}`
+
+  if (isTS) {
+    code = await transformTS(code, isJSX)
+  }
+  if (isJSX) {
+    code = await import('./jsx').then(m => m.transformJSX(code))
+  }
+
+  return code
+}
+
+function isCustomElement(filename: string) {
+  const filter = sfcOptions.customElement || /\.ce\.vue$/
+  if (filter === true) {
+    return true
+  }
+  return toArray(filter).some((f) => {
+    if (typeof f === 'string') {
+      return filename.includes(f)
+    }
+    return f.test(filename)
+  })
+}
+
+export async function compileVue(filename: string, code: string): Promise<CompileResult> {
+  const id = hash(filename)
+  const { errors, descriptor } = compiler.parse(code, {
+    filename,
+    sourceMap: true,
+    templateParseOptions: sfcOptions?.template?.compilerOptions,
+  })
+  if (errors.length) {
+    return {
+      errors,
+    }
+  }
+
+  const styleLangs = descriptor.styles.map(s => s.lang).filter(Boolean)
+  const templateLang = descriptor.template?.lang
+  if (styleLangs.length && templateLang) {
+    return {
+      errors: [
+      `lang="${styleLangs.join(
+        ',',
+      )}" pre-processors for <style> and lang="${templateLang}" `
+      + `for <template> are currently not supported.`,
+      ],
+    }
+  }
+  else if (styleLangs.length) {
+    return {
+      errors: [
+      `lang="${styleLangs.join(
+        ',',
+      )}" pre-processors for <style> are currently not supported.`,
+      ],
+    }
+  }
+  else if (templateLang) {
+    return {
+      errors: [
+      `lang="${templateLang}" pre-processors for `
+      + `<template> are currently not supported.`,
+      ],
+    }
+  }
+
+  const scriptLang = descriptor.script?.lang || descriptor.scriptSetup?.lang
+  const isTS = isTsFile(scriptLang)
+  const isJSX = isJsxFile(scriptLang)
+
+  if (scriptLang && scriptLang !== 'js' && !isTS && !isJSX) {
+    return {
+      errors: [`Unsupported lang "${scriptLang}" in <script> blocks.`],
+    }
+  }
+
+  const hasScoped = descriptor.styles.some(s => s.scoped)
+  let clientCode = ''
+
+  let clientScript: string
+  let bindings: compiler.BindingMetadata | undefined
+  try {
+    ;[clientScript, bindings] = await doCompileScript(
+      descriptor,
+      id,
+      false,
+      isTS,
+      isJSX,
+    )
+  }
+  catch (e: any) {
+    return {
+      errors: [e.stack.split('\n').slice(0, 12).join('\n')],
+    }
+  }
+
+  clientCode += clientScript
+
+  // template
+  // only need dedicated compilation if not using <script setup>
+  if (
+    descriptor.template
+    && (!descriptor.scriptSetup)
+  ) {
+    const clientTemplateResult = await doCompileTemplate(
+      descriptor,
+      id,
+      bindings,
+      false,
+      isTS,
+      isJSX,
+    )
+    if (Array.isArray(clientTemplateResult)) {
+      return {
+        errors: clientTemplateResult,
+      }
+    }
+    clientCode += `;${clientTemplateResult}`
+  }
+
+  if (hasScoped) {
+    clientCode += `\n${COMP_IDENTIFIER}.__scopeId = ${JSON.stringify(`data-v-${id}`)}`
+  }
+
+  // styles
+  const isCE = isCustomElement(filename)
+
+  let css = ''
+  const styles: string[] = []
+  for (const style of descriptor.styles) {
+    if (style.module) {
+      return {
+        errors: [`<style module> is not supported in the playground.`],
+      }
+    }
+
+    const styleResult = await compiler.compileStyleAsync({
+      ...sfcOptions?.style,
+      source: style.content,
+      filename,
+      id,
+      scoped: style.scoped,
+      modules: !!style.module,
+    })
+    if (styleResult.errors.length) {
+      // postcss uses pathToFileURL which isn't polyfilled in the browser
+      // ignore these errors for now
+      if (!styleResult.errors[0].message.includes('pathToFileURL')) {
+        // store.errors = styleResult.errors
+      }
+      // proceed even if css compile errors
+    }
+    else {
+      if (isCE) {
+        styles.push(styleResult.code)
+      }
+      else {
+        css += `${styleResult.code}\n`
+      }
+    }
+  }
+
+  if (clientCode) {
+    const ceStyles = isCE
+      ? `\n${COMP_IDENTIFIER}.styles = ${JSON.stringify(styles)}`
+      : ''
+
+    clientCode += `\n${COMP_IDENTIFIER}.__file = ${JSON.stringify(filename)}${
+        ceStyles
+        }\nexport default ${COMP_IDENTIFIER}`
+  }
+
+  return {
+    css: css.trim(),
+    js: clientCode.trimStart(),
+  }
+}

--- a/packages/web/src/configs/plugins.ts
+++ b/packages/web/src/configs/plugins.ts
@@ -1,0 +1,13 @@
+import type { SlidevPluginOptions } from '@slidev/types'
+import { reactive } from 'vue'
+import type { SFCAsyncStyleCompileOptions, SFCScriptCompileOptions, SFCTemplateCompileOptions } from 'vue/compiler-sfc'
+
+// export interface SFCOptions {
+//   script?: Partial<SFCScriptCompileOptions>
+//   style?: Partial<SFCAsyncStyleCompileOptions>
+//   template?: Partial<SFCTemplateCompileOptions>
+// }
+
+export const sfcOptions = reactive<NonNullable<SlidevPluginOptions['vue']>>({})
+
+export const mdOptions = reactive<NonNullable<SlidevPluginOptions['markdown']>>({})

--- a/packages/web/src/configs/slidev.ts
+++ b/packages/web/src/configs/slidev.ts
@@ -1,0 +1,7 @@
+import { getDefaultConfig } from '@slidev/parser'
+import { shallowReactive } from 'vue'
+
+export default shallowReactive<typeof import('#slidev/configs').default>({
+  ...getDefaultConfig(),
+  slidesTitle: 'TODO',
+})

--- a/packages/web/src/custom-components.ts
+++ b/packages/web/src/custom-components.ts
@@ -1,0 +1,11 @@
+import { defineComponent } from 'vue'
+
+const EmptyComponent = defineComponent(() => () => [])
+
+export const GlobalTop = EmptyComponent
+export const GlobalBottom = EmptyComponent
+
+export const SlideTop = EmptyComponent
+export const SlideBottom = EmptyComponent
+
+export default EmptyComponent

--- a/packages/web/src/main.ts
+++ b/packages/web/src/main.ts
@@ -1,0 +1,10 @@
+/// <reference types="@slidev/types/client" />
+
+import { createApp } from 'vue'
+import './styles'
+import setupMain from '../../client/setup/main'
+import App from '../../client/App.vue'
+
+const app = createApp(App)
+setupMain(app)
+app.mount('#app')

--- a/packages/web/src/shiki.ts
+++ b/packages/web/src/shiki.ts
@@ -1,0 +1,38 @@
+import { createHighlighter } from 'shiki/index.mjs'
+
+export { shikiToMonaco } from '@shikijs/monaco'
+export const languages = ['markdown', 'vue', 'javascript', 'typescript', 'html', 'css']
+export const themes = [
+  'vitesse-dark',
+  'vitesse-light',
+]
+export const shiki = createHighlighter({
+  themes: [
+    import('shiki/themes/vitesse-dark.mjs'),
+    import('shiki/themes/vitesse-light.mjs'),
+  ],
+  langs: [
+    import('shiki/langs/markdown.mjs'),
+    import('shiki/langs/vue.mjs'),
+    import('shiki/langs/javascript.mjs'),
+    import('shiki/langs/typescript.mjs'),
+    import('shiki/langs/html.mjs'),
+    import('shiki/langs/css.mjs'),
+  ],
+})
+let highlight: any
+export async function getHighlighter() {
+  if (highlight)
+    return highlight
+  const highlighter = await shiki
+  highlight = (code: string, lang: string, options: any) => highlighter.codeToHtml(code, {
+    lang,
+    themes: {
+      dark: 'vitesse-dark',
+      light: 'vitesse-light',
+    },
+    defaultColor: false,
+    ...options,
+  })
+  return highlight
+}

--- a/packages/web/src/slides.ts
+++ b/packages/web/src/slides.ts
@@ -1,0 +1,27 @@
+import { h, shallowRef } from 'vue'
+import type { SlideRoute } from '@slidev/types'
+
+const FakeComponent = {
+  render: () => h('div', 'FakeComponent'),
+}
+
+export const slides = shallowRef<SlideRoute[]>([
+  {
+    no: 1,
+    meta: {
+      slide: {
+        index: 0,
+        frontmatter: {},
+        content: '# Hello',
+        noteHTML: '',
+        filepath: '/slides.md',
+        start: 0,
+        id: 0,
+        no: 1,
+      },
+      __clicksContext: null,
+    },
+    load: async () => ({ default: FakeComponent }),
+    component: FakeComponent,
+  },
+])

--- a/packages/web/src/styles.ts
+++ b/packages/web/src/styles.ts
@@ -1,0 +1,11 @@
+import '@unocss/reset/tailwind.css'
+import 'uno:preflights.css'
+import 'uno:typography.css'
+import 'uno:shortcuts.css'
+
+import '@slidev/client/styles/vars.css'
+import '@slidev/client/styles/index.css'
+import '@slidev/client/styles/code.css'
+import '@slidev/client/styles/katex.css'
+import '@slidev/client/styles/transitions.css'
+import 'uno.css'

--- a/packages/web/src/title-renderer.vue
+++ b/packages/web/src/title-renderer.vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+import { useSlideContext } from '@slidev/client/context.ts'
+import { computed } from 'vue'
+
+const props = defineProps<{ no?: number | string }>()
+const { $page } = useSlideContext()
+const no = computed(() => +(props.no ?? $page.value))
+</script>
+
+<template>
+  Title {{ no }}
+</template>

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -1,0 +1,100 @@
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vite'
+import UnoCSS from 'unocss/vite'
+import type { ResolvedSlidevOptions, SlidevPluginOptions } from '@slidev/types'
+import { createVueCompilerFlagsPlugin } from '../slidev/node/vite/compilerFlagsVue'
+import { createInspectPlugin } from '../slidev/node/vite/inspect'
+import { createIconsPlugin } from '../slidev/node/vite/icons'
+import { createComponentsPlugin } from '../slidev/node/vite/components'
+import { toAtFS } from '../slidev/node/resolver'
+import { createVuePlugin } from '../slidev/node/vite/vue'
+
+const absolute = (path: string) => fileURLToPath(new URL(path, import.meta.url))
+const clientRoot = absolute('../client')
+const parserRoot = absolute('../parser')
+
+const options = {
+  clientRoot,
+  roots: [],
+  mode: 'build',
+  inspect: true,
+  utils: {
+    defines: {
+      __DEV__: 'true',
+      __SLIDEV_CLIENT_ROOT__: JSON.stringify(toAtFS(clientRoot)),
+      __SLIDEV_HASH_ROUTE__: false,
+      __SLIDEV_FEATURE_DRAWINGS__: 'true',
+      __SLIDEV_FEATURE_EDITOR__: 'true',
+      __SLIDEV_FEATURE_DRAWINGS_PERSIST__: 'false',
+      __SLIDEV_FEATURE_RECORD__: 'true',
+      __SLIDEV_FEATURE_PRESENTER__: 'true',
+      __SLIDEV_FEATURE_PRINT__: 'false',
+      __SLIDEV_FEATURE_WAKE_LOCK__: 'true',
+      __SLIDEV_HAS_SERVER__: 'false',
+    },
+  },
+} as unknown as ResolvedSlidevOptions
+
+const pluginOptions = {} as SlidevPluginOptions
+
+export default defineConfig({
+  plugins: [
+    createInspectPlugin(options, pluginOptions),
+    createVueCompilerFlagsPlugin(options),
+    UnoCSS({
+      configFile: absolute('../client/uno.config.ts'),
+    }),
+    createVuePlugin(options, pluginOptions),
+    createComponentsPlugin(options, pluginOptions),
+    createIconsPlugin(options, pluginOptions),
+    {
+      name: 'slidev:loader',
+      resolveId: {
+        order: 'pre',
+        handler(id) {
+          if (id.startsWith('/@slidev/') || id.includes('__slidev_') || id.startsWith('server-reactive:'))
+            return id
+          return null
+        },
+      },
+      load(id) {
+        if (id.startsWith('/@slidev/setups'))
+          return 'export default []'
+        if (id === '/@slidev/styles')
+          return `export {}`
+        if (id.startsWith('server-reactive:'))
+          return `export default {}`
+      },
+    },
+  ],
+  resolve: {
+    alias: [
+      ...Object.entries({
+        '@rollup/pluginutils': absolute('./polyfills/rollup-pluginutils.ts'),
+        'unplugin': absolute('./polyfills/unplugin.ts'),
+        'module': absolute('./polyfills/node-module.ts'),
+
+        '#slidev/configs': absolute('./src/configs/slidev.ts'),
+        '#slidev/global-layers': absolute('./src/custom-components.ts'),
+        '#slidev/custom-nav-controls': absolute('./src/custom-components.ts'),
+        '#slidev/title-renderer': absolute('./src/title-renderer.vue'),
+        '#slidev/shiki': absolute('./src/shiki.ts'),
+        '#slidev/slides': absolute('./src/slides.ts'),
+        '@slidev/parser/utils': absolute('../parser/src/utils.ts'),
+      }).map(([find, replacement]) => ({ find, replacement })),
+      {
+        find: /^@slidev\/client$/,
+        replacement: `${toAtFS(clientRoot)}/index.ts`,
+      },
+      {
+        find: /^@slidev\/parser\/(.*)/,
+        replacement: `${toAtFS(parserRoot)}/$1`,
+      },
+      {
+        find: /^#slidev\/(.*)/,
+        replacement: '/@slidev/$1',
+      },
+    ],
+  },
+  define: options.utils.defines,
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -518,7 +518,7 @@ importers:
         version: 3.7.0
       debug:
         specifier: ^4.3.5
-        version: 4.3.5(supports-color@8.1.1)
+        version: 4.3.5(supports-color@5.5.0)
       fast-deep-equal:
         specifier: ^3.1.3
         version: 3.1.3
@@ -784,6 +784,51 @@ importers:
       volar-service-yaml:
         specifier: ^0.0.59
         version: 0.0.59
+
+  packages/web:
+    devDependencies:
+      '@antfu/utils':
+        specifier: ^0.7.10
+        version: 0.7.10
+      '@babel/standalone':
+        specifier: ^7.25.3
+        version: 7.25.3
+      '@slidev/client':
+        specifier: workspace:*
+        version: link:../client
+      '@slidev/parser':
+        specifier: workspace:*
+        version: link:../parser
+      '@types/babel__standalone':
+        specifier: ^7.1.7
+        version: 7.1.7
+      '@vue/babel-plugin-jsx':
+        specifier: ^1.2.2
+        version: 1.2.2(@babel/core@7.24.9)
+      ohash:
+        specifier: ^1.1.3
+        version: 1.1.3
+      sucrase:
+        specifier: ^3.35.0
+        version: 3.35.0
+      typescript:
+        specifier: ^5.5.4
+        version: 5.5.4
+      unocss:
+        specifier: ^0.61.5
+        version: 0.61.5(postcss@8.4.39)(rollup@4.19.0)(vite@5.3.4(@types/node@20.14.11))
+      unplugin-vue-markdown:
+        specifier: ^0.26.2
+        version: 0.26.2(rollup@4.19.0)(vite@5.3.4(@types/node@20.14.11))
+      vite:
+        specifier: ^5.3.4
+        version: 5.3.4(@types/node@20.14.11)
+      vue:
+        specifier: ^3.4.33
+        version: 3.4.33(typescript@5.5.4)
+      vue-router:
+        specifier: ^4.4.0
+        version: 4.4.0(vue@3.4.33(typescript@5.5.4))
 
 packages:
 
@@ -1110,6 +1155,10 @@ packages:
 
   '@babel/standalone@7.23.10':
     resolution: {integrity: sha512-xqWviI/pt1Zb/d+6ilWa5IDL2mkDzsBnlHbreqnfyP3/QB/ofQ1bNVcHj8YQX154Rf/xZKR6y0s1ydVF3nAS8g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/standalone@7.25.3':
+    resolution: {integrity: sha512-uR+EoBqIIIvKGCG7fOj7HKupu3zVObiMfdEwoPZfVCPpcWJaZ1PkshaP5/6cl6BKAm1Zcv25O1rf+uoQ7V8nqA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/template@7.24.7':
@@ -1996,6 +2045,21 @@ packages:
   '@szmarczak/http-timer@5.0.1':
     resolution: {integrity: sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==}
     engines: {node: '>=14.16'}
+
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.6.8':
+    resolution: {integrity: sha512-ASsj+tpEDsEiFr1arWrlN6V3mdfjRMZt6LtK/Vp/kreFLnr5QH5+DhvD5nINYZXzwJvXeGq+05iUXcAzVrqWtw==}
+
+  '@types/babel__standalone@7.1.7':
+    resolution: {integrity: sha512-4RUJX9nWrP/emaZDzxo/+RYW8zzLJTXWJyp2k78HufG459HCz754hhmSymt3VFOU6/Wy+IZqfPvToHfLuGOr7w==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.20.6':
+    resolution: {integrity: sha512-r1bzfrm0tomOI8g1SzvCaQHo6Lcv6zu0EA+W2kHrt8dyrHQxGzBBL4kdkzIS+jBMV+EYcMAEAqXqYaLJq5rOZg==}
 
   '@types/braces@3.0.4':
     resolution: {integrity: sha512-0WR3b8eaISjEW7RpZnclONaLFDf7buaowRHdqLp4vLj54AsSAYWfh3DRbfiYJY9XDxMgx1B4sE1Afw2PGpuHOA==}
@@ -7052,7 +7116,7 @@ snapshots:
       '@babel/traverse': 7.24.8
       '@babel/types': 7.24.9
       convert-source-map: 2.0.0
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -7233,6 +7297,8 @@ snapshots:
   '@babel/standalone@7.23.10':
     optional: true
 
+  '@babel/standalone@7.25.3': {}
+
   '@babel/template@7.24.7':
     dependencies:
       '@babel/code-frame': 7.24.7
@@ -7249,7 +7315,7 @@ snapshots:
       '@babel/helper-split-export-declaration': 7.24.7
       '@babel/parser': 7.24.8
       '@babel/types': 7.24.9
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -7573,7 +7639,7 @@ snapshots:
   '@eslint/config-array@0.17.0':
     dependencies:
       '@eslint/object-schema': 2.1.4
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -7581,7 +7647,7 @@ snapshots:
   '@eslint/eslintrc@3.1.0':
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       espree: 10.1.0
       globals: 14.0.0
       ignore: 5.3.1
@@ -7652,7 +7718,7 @@ snapshots:
       '@antfu/install-pkg': 0.1.1
       '@antfu/utils': 0.5.2
       '@iconify/types': 1.1.0
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       kolorist: 1.8.0
       local-pkg: 0.4.3
     transitivePeerDependencies:
@@ -7663,7 +7729,7 @@ snapshots:
       '@antfu/install-pkg': 0.1.1
       '@antfu/utils': 0.7.10
       '@iconify/types': 2.0.0
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       kolorist: 1.8.0
       local-pkg: 0.5.0
       mlly: 1.7.1
@@ -8059,6 +8125,31 @@ snapshots:
     dependencies:
       defer-to-connect: 2.0.1
 
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.24.8
+      '@babel/types': 7.24.9
+      '@types/babel__generator': 7.6.8
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.20.6
+
+  '@types/babel__generator@7.6.8':
+    dependencies:
+      '@babel/types': 7.24.9
+
+  '@types/babel__standalone@7.1.7':
+    dependencies:
+      '@types/babel__core': 7.20.5
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.24.8
+      '@babel/types': 7.24.9
+
+  '@types/babel__traverse@7.20.6':
+    dependencies:
+      '@babel/types': 7.24.9
+
   '@types/braces@3.0.4': {}
 
   '@types/cli-progress@3.11.6':
@@ -8210,7 +8301,7 @@ snapshots:
       '@typescript-eslint/types': 8.0.0-alpha.40
       '@typescript-eslint/typescript-estree': 8.0.0-alpha.40(typescript@5.5.4)
       '@typescript-eslint/visitor-keys': 8.0.0-alpha.40
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       eslint: 9.7.0
     optionalDependencies:
       typescript: 5.5.4
@@ -8231,7 +8322,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 8.0.0-alpha.40(typescript@5.5.4)
       '@typescript-eslint/utils': 8.0.0-alpha.40(eslint@9.7.0)(typescript@5.5.4)
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       ts-api-utils: 1.3.0(typescript@5.5.4)
     optionalDependencies:
       typescript: 5.5.4
@@ -8247,7 +8338,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 7.14.1
       '@typescript-eslint/visitor-keys': 7.14.1
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -8262,7 +8353,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.0.0-alpha.40
       '@typescript-eslint/visitor-keys': 8.0.0-alpha.40
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -8311,7 +8402,7 @@ snapshots:
 
   '@typescript/vfs@1.5.0':
     dependencies:
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -8914,7 +9005,7 @@ snapshots:
 
   '@windicss/config@1.9.3':
     dependencies:
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       jiti: 1.21.6
       windicss: 3.5.6
     transitivePeerDependencies:
@@ -8924,7 +9015,7 @@ snapshots:
     dependencies:
       '@antfu/utils': 0.7.10
       '@windicss/config': 1.9.3
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       fast-glob: 3.3.2
       magic-string: 0.30.10
       micromatch: 4.0.7
@@ -8952,7 +9043,7 @@ snapshots:
 
   agent-base@7.1.1:
     dependencies:
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -10050,7 +10141,7 @@ snapshots:
     dependencies:
       '@rtsao/scc': 1.1.0
       '@typescript-eslint/utils': 7.14.1(eslint@9.7.0)(typescript@5.5.4)
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       doctrine: 3.0.0
       eslint: 9.7.0
       eslint-import-resolver-node: 0.3.9
@@ -10069,7 +10160,7 @@ snapshots:
       '@es-joy/jsdoccomment': 0.46.0
       are-docs-informative: 0.0.2
       comment-parser: 1.4.1
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       escape-string-regexp: 4.0.0
       eslint: 9.7.0
       esquery: 1.6.0
@@ -10137,7 +10228,7 @@ snapshots:
 
   eslint-plugin-toml@0.11.1(eslint@9.7.0):
     dependencies:
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       eslint: 9.7.0
       eslint-compat-utils: 0.5.0(eslint@9.7.0)
       lodash: 4.17.21
@@ -10201,7 +10292,7 @@ snapshots:
 
   eslint-plugin-yml@1.14.0(eslint@9.7.0):
     dependencies:
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       eslint: 9.7.0
       eslint-compat-utils: 0.5.0(eslint@9.7.0)
       lodash: 4.17.21
@@ -10244,7 +10335,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       escape-string-regexp: 4.0.0
       eslint-scope: 8.0.2
       eslint-visitor-keys: 4.0.0
@@ -10477,7 +10568,7 @@ snapshots:
 
   follow-redirects@1.15.6(debug@4.3.5):
     optionalDependencies:
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
 
   foreground-child@3.1.1:
     dependencies:
@@ -10760,7 +10851,7 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -10778,7 +10869,7 @@ snapshots:
   https-proxy-agent@7.0.4:
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -10816,7 +10907,7 @@ snapshots:
   importx@0.3.10:
     dependencies:
       bundle-require: 5.0.0(esbuild@0.20.2)
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       esbuild: 0.20.2
       jiti: 1.21.6
       pathe: 1.1.2
@@ -11150,7 +11241,7 @@ snapshots:
     dependencies:
       chalk: 5.3.0
       commander: 12.1.0
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       execa: 8.0.1
       lilconfig: 3.1.1
       listr2: 8.2.1
@@ -11747,7 +11838,7 @@ snapshots:
 
   micromark@2.11.4:
     dependencies:
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       parse-entities: 2.0.0
     transitivePeerDependencies:
       - supports-color
@@ -11755,7 +11846,7 @@ snapshots:
   micromark@3.2.0:
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       decode-named-character-reference: 1.0.2
       micromark-core-commonmark: 1.1.0
       micromark-factory-space: 1.1.0
@@ -11777,7 +11868,7 @@ snapshots:
   micromark@4.0.0:
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       decode-named-character-reference: 1.0.2
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.0
@@ -12687,7 +12778,7 @@ snapshots:
   socks-proxy-agent@8.0.4:
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       socks: 2.8.3
     transitivePeerDependencies:
       - supports-color
@@ -12993,7 +13084,7 @@ snapshots:
       cac: 6.7.14
       chokidar: 3.6.0
       consola: 3.2.3
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       esbuild: 0.23.0
       execa: 5.1.1
       globby: 11.1.0
@@ -13243,7 +13334,7 @@ snapshots:
       '@antfu/install-pkg': 0.3.3
       '@antfu/utils': 0.7.10
       '@iconify/utils': 2.1.25
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       kolorist: 1.8.0
       local-pkg: 0.5.0
       unplugin: 1.11.0
@@ -13258,7 +13349,7 @@ snapshots:
       '@antfu/utils': 0.7.10
       '@rollup/pluginutils': 5.1.0(rollup@4.19.0)
       chokidar: 3.6.0
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       fast-glob: 3.3.2
       local-pkg: 0.5.0
       magic-string: 0.30.10
@@ -13375,7 +13466,7 @@ snapshots:
   vite-node@2.0.4(@types/node@20.14.11):
     dependencies:
       cac: 6.7.14
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       pathe: 1.1.2
       tinyrainbow: 1.2.0
       vite: 5.3.4(@types/node@20.14.11)
@@ -13393,7 +13484,7 @@ snapshots:
     dependencies:
       '@antfu/utils': 0.7.10
       '@rollup/pluginutils': 5.1.0(rollup@4.19.0)
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       error-stack-parser-es: 0.1.4
       fs-extra: 11.2.0
       open: 10.1.0
@@ -13412,7 +13503,7 @@ snapshots:
       '@antfu/utils': 0.7.10
       axios: 1.7.2(debug@4.3.5)
       blueimp-md5: 2.19.0
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       fs-extra: 11.2.0
       magic-string: 0.30.10
       vite: 5.3.4(@types/node@20.14.11)
@@ -13430,7 +13521,7 @@ snapshots:
   vite-plugin-vue-server-ref@0.4.2(vite@5.3.4(@types/node@20.14.11))(vue@3.4.33(typescript@5.5.4)):
     dependencies:
       '@antfu/utils': 0.7.10
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       klona: 2.0.6
       mlly: 1.7.1
       ufo: 1.5.3
@@ -13442,7 +13533,7 @@ snapshots:
   vite-plugin-windicss@1.9.3(vite@5.3.4(@types/node@20.14.11)):
     dependencies:
       '@windicss/plugin-utils': 1.9.3
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       kolorist: 1.8.0
       vite: 5.3.4(@types/node@20.14.11)
       windicss: 3.5.6
@@ -13519,7 +13610,7 @@ snapshots:
       '@vitest/spy': 2.0.4
       '@vitest/utils': 2.0.4
       chai: 5.1.1
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       execa: 8.0.1
       magic-string: 0.30.10
       pathe: 1.1.2
@@ -13604,7 +13695,7 @@ snapshots:
 
   vue-eslint-parser@9.4.3(eslint@9.7.0):
     dependencies:
-      debug: 4.3.5(supports-color@8.1.1)
+      debug: 4.3.5(supports-color@5.5.0)
       eslint: 9.7.0
       eslint-scope: 7.2.2
       eslint-visitor-keys: 3.4.3

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,6 @@
     "target": "es2022",
     "jsx": "preserve",
     "lib": ["DOM", "ESNext"],
-    "baseUrl": ".",
     "module": "ESNext",
     "moduleResolution": "node",
     "paths": {


### PR DESCRIPTION
[WIP] This PR tries to run Slidev in the browser, with a better editor. I think the most commonly used functions work in the browser, but some don't. In this PR, changes to existing code will be very minimal, so the Node.js version will always be workable.

Although Slidev can run in StackBlitz, it is slow regarding startup time and operational efficiency.
