### PR TITLE
fix: display slide import errors in client

### DIFF
--- a/packages/slidev/node/virtual/slides.ts
+++ b/packages/slidev/node/virtual/slides.ts
@@ -27,7 +27,7 @@ export const templateSlides: VirtualModuleTemplate = {
           // For some unknown reason, import error won't be caught by the error component. Catch it here.
           `const load${no} = async () => {`,
           `  try { return componentsCache[${idx}] ??= await import('${VIRTUAL_SLIDE_PREFIX}${no}/md') }`,
-          `  catch (e) { console.error('slide import failed', e); return SlideError }`,
+          `  catch (e) { console.error('slide failed to load', e); return SlideError }`,
           `}`,
         )
         return `{ no: ${no}, meta: f${no}, load: load${no}, component: getAsyncComponent(${idx}, load${no}) }`

--- a/packages/slidev/node/virtual/slides.ts
+++ b/packages/slidev/node/virtual/slides.ts
@@ -27,7 +27,7 @@ export const templateSlides: VirtualModuleTemplate = {
           // For some unknown reason, import error won't be caught by the error component. Catch it here.
           `const load${no} = async () => {`,
           `  try { return componentsCache[${idx}] ??= await import('${VIRTUAL_SLIDE_PREFIX}${no}/md') }`,
-          `  catch (e) { return SlideError }`,
+          `  catch (e) { console.error('slide import failed', e); return SlideError }`,
           `}`,
         )
         return `{ no: ${no}, meta: f${no}, load: load${no}, component: getAsyncComponent(${idx}, load${no}) }`


### PR DESCRIPTION
While debugging some other issue, it appeared that error messages were consumed in some scenarios. This PR adds error logging to the console when the cached slide import fails, making it easier for others to debug their issues. 