### PR TITLE
docs: fix links and typos in features/slide-scope-style

### DIFF
--- a/demo/starter/slides.md
+++ b/demo/starter/slides.md
@@ -94,7 +94,7 @@ level: 2
 
 # Navigation
 
-Hover on the bottom-left corner to see the navigation's controls panel, [learn more](https://sli.dev/guide/navigation.html)
+Hover on the bottom-left corner to see the navigation's controls panel, [learn more](https://sli.dev/guide/ui#navigation-bar)
 
 ## Keyboard Shortcuts
 
@@ -140,7 +140,7 @@ image: https://cover.sli.dev
 
 # Code
 
-Use code snippets and get the highlighting directly, and even types hover![^1]
+Use code snippets and get the highlighting directly, and even types hover!
 
 ```ts {all|5|7|7-8|10|all} twoslash
 // TwoSlash enables TypeScript hover information
@@ -161,7 +161,8 @@ doubled.value = 2
 <<< @/snippets/external.ts#snippet
 
 <!-- Footer -->
-[^1]: [Learn More](https://sli.dev/guide/line-highlighting)
+
+[Learn more](https://sli.dev/features/line-highlighting)
 
 <!-- Inline style -->
 <style>
@@ -330,8 +331,8 @@ theme: seriph
 
 </div>
 
-Read more about [How to use a theme](https://sli.dev/themes/use.html) and
-check out the [Awesome Themes Gallery](https://sli.dev/themes/gallery.html).
+Read more about [How to use a theme](https://sli.dev/guide/theme-addon#use-theme) and
+check out the [Awesome Themes Gallery](https://sli.dev/resources/theme-gallery).
 
 ---
 
@@ -366,7 +367,7 @@ also allows you to add
 
 <div mt-20 v-click>
 
-[Learn More](https://sli.dev/guide/animations#click-animation)
+[Learn more](https://sli.dev/guide/animations#click-animation)
 
 </div>
 
@@ -446,7 +447,7 @@ const final = {
   :initial="{ x:35, y: 30, opacity: 0}"
   :enter="{ y: 0, opacity: 1, transition: { delay: 3500 } }">
 
-[Learn More](https://sli.dev/guide/animations.html#motion)
+[Learn more](https://sli.dev/guide/animations.html#motion)
 
 </div>
 
@@ -548,7 +549,7 @@ database "MySql" {
 
 </div>
 
-Learn More: [Mermaid Diagrams](https://sli.dev/guide/features/mermaid) and [PlantUML Diagrams](https://sli.dev/guide/features/plantuml)
+Learn more: [Mermaid Diagrams](https://sli.dev/features/mermaid) and [PlantUML Diagrams](https://sli.dev/features/plantuml)
 
 ---
 foo: bar
@@ -633,6 +634,6 @@ class: text-center
 
 # Learn More
 
-[Documentation](https://sli.dev) · [GitHub](https://github.com/slidevjs/slidev) · [Showcases](https://sli.dev/showcases.html)
+[Documentation](https://sli.dev) · [GitHub](https://github.com/slidevjs/slidev) · [Showcases](https://sli.dev/resources/showcases)
 
 <PoweredBySlidev mt-10 />


### PR DESCRIPTION
- change to the correct link
- change page `More` to `more`
- typo


https://sli.dev/features/slide-scope-style
https://github.com/slidevjs/slidev/blob/e92b9e2d3faad8f7cfabc4d571194e38bae30707/demo/starter/slides.md?plain=1#L71
There is an issue with this link.