### PR TITLE
fix: typo on pnpm create command

### DIFF
--- a/docs/guide/write-theme.md
+++ b/docs/guide/write-theme.md
@@ -13,7 +13,7 @@ $ npm init slidev-theme@latest
 ```
 
 ```bash [pnpm]
-$ pnpm init slidev-theme
+$ pnpm create slidev-theme
 ```
 
 ```bash [yarn]


### PR DESCRIPTION
Fixes a typo in the docs where `pnpm create` was incorrectly referred as `pnpm init`