### PR TITLE
fix: add `html-to-image` package to `optimizeDeps`

### DIFF
--- a/packages/slidev/node/vite/extendConfig.ts
+++ b/packages/slidev/node/vite/extendConfig.ts
@@ -15,6 +15,7 @@ const INCLUDE_GLOBAL = [
   'recordrtc',
   'typescript',
   'yaml',
+  'html-to-image',
 ]
 
 const INCLUDE_LOCAL = INCLUDE_GLOBAL.map(i => `@slidev/cli > @slidev/client > ${i}`)


### PR DESCRIPTION
Avoid reloading the page on the first start:

```txt
17:57:56 [vite] ✨ new dependencies optimized: html-to-image
17:57:56 [vite] ✨ optimized dependencies changed. reloading
```