### PR TITLE
docs(context-menu): Update config-context-menu.md

### DIFF
--- a/docs/custom/config-context-menu.md
+++ b/docs/custom/config-context-menu.md
@@ -1,32 +1,33 @@
-import { useNav } from '@slidev/client'
-/_ eslint-disable import/first _/
-// ---cut---
+# Configure Context Menu
+
+<Environment type="client" />
+
+Customize the context menu items in Slidev.
+
+Create `./setup/context-menu.ts` with the following content:
+
+```
 import { defineContextMenuSetup } from '@slidev/types'
 import { computed } from 'vue'
-// ---cut-start---
-// @ts-expect-error missing types
-// ---cut-end---
 import Icon3DCursor from '~icons/carbon/3d-cursor'
 
 export default defineContextMenuSetup((items) => {
-const { isPresenter } = useNav()
-return computed(() => [
-...items.value,
-{
-small: false,
-icon: Icon3DCursor, // if `small` is `true`, only the icon is shown
-label: 'Custom Menu Item', // or a Vue component
-action() {
-alert('Custom Menu Item Clicked!')
-},
-disabled: isPresenter.value,
-},
-])
+  const { isPresenter } = useNav()
+  return computed(() => [
+    ...items.value,
+    {
+      small: false,
+      icon: Icon3DCursor, // Used as `title` if `small` is `true`
+      label: 'Custom Menu Item', // or a Vue component
+      action() {
+        alert('Custom Menu Item Clicked!')
+      },
+      disabled: isPresenter.value,
+    },
+  ])
 })
-
 ```
 
 This will append a new menu item to the context menu.
 
 To disable context menu globally, set `contextMenu` to `false` in the frontmatter. `contextMenu` can also be set to `dev` or `build` to only enable the context menu in development or build mode.
-```


### PR DESCRIPTION
In the latest version of the document, the context-menu content is displayed incorrectly, and this PR will fix it.

<img width="947" alt="image" src="https://github.com/user-attachments/assets/4b66328d-c411-440f-9696-b2286b6c9bd3">
