### PR TITLE
chore: fix dead links like `/themes`

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Presentation <b>slide</b>s for <b>dev</b>elopers 🧑‍💻👩‍💻👨‍�
 <a href="https://www.npmjs.com/package/@slidev/cli" target="__blank"><img src="https://img.shields.io/npm/v/@slidev/cli?color=2B90B6&label=" alt="NPM version"></a>
 <a href="https://www.npmjs.com/package/@slidev/cli" target="__blank"><img alt="NPM Downloads" src="https://img.shields.io/npm/dm/@slidev/cli?color=349dbe&label="></a>
 <a href="https://sli.dev/" target="__blank"><img src="https://img.shields.io/static/v1?label=&message=docs%20%26%20demos&color=45b8cd" alt="Docs & Demos"></a>
-<a href="https://sli.dev/themes/gallery.html" target="__blank"><img src="https://img.shields.io/static/v1?label=&message=themes&color=4ec5d4" alt="Themes"></a>
+<a href="https://sli.dev/resources/theme-gallery" target="__blank"><img src="https://img.shields.io/static/v1?label=&message=themes&color=4ec5d4" alt="Themes"></a>
 <br>
 <a href="https://github.com/slidevjs/slidev" target="__blank"><img alt="GitHub stars" src="https://img.shields.io/github/stars/slidevjs/slidev?style=social"></a>
 </p>

--- a/packages/create-theme/template/README.md
+++ b/packages/create-theme/template/README.md
@@ -27,7 +27,7 @@ Add the following frontmatter to your `slides.md`. Start Slidev then it will pro
 theme: <b>{{name}}</b>
 ---</code></pre>
 
-Learn more about [how to use a theme](https://sli.dev/themes/use).
+Learn more about [how to use a theme](https://sli.dev/guide/theme-addon#use-theme).
 
 ## Layouts
 

--- a/packages/slidev/template.md
+++ b/packages/slidev/template.md
@@ -235,8 +235,8 @@ theme: seriph
 
 </div>
 
-Read more about [How to use a theme](https://sli.dev/themes/use.html) and
-check out the [Awesome Themes Gallery](https://sli.dev/themes/gallery.html).
+Read more about [How to use a theme](https://sli.dev/guide/theme-addon#use-theme) and
+check out the [Awesome Themes Gallery](https://sli.dev/resources/theme-gallery).
 
 ---
 preload: false

--- a/packages/types/src/frontmatter.ts
+++ b/packages/types/src/frontmatter.ts
@@ -23,7 +23,7 @@ export interface HeadmatterConfig extends TransitionOptions {
   /**
    * Theme to use for the slides
    *
-   * See https://sli.dev/themes/use.html
+   * See https://sli.dev/guide/theme-addon#use-theme
    * @default 'default'
    */
   theme?: string

--- a/packages/vscode/schema/headmatter.json
+++ b/packages/vscode/schema/headmatter.json
@@ -131,8 +131,8 @@
         },
         "theme": {
           "type": "string",
-          "description": "Theme to use for the slides\n\nSee https://sli.dev/themes/use.html",
-          "markdownDescription": "Theme to use for the slides\n\nSee https://sli.dev/themes/use.html",
+          "description": "Theme to use for the slides\n\nSee https://sli.dev/guide/theme-addon#use-theme",
+          "markdownDescription": "Theme to use for the slides\n\nSee https://sli.dev/guide/theme-addon#use-theme",
           "default": "default"
         },
         "addons": {


### PR DESCRIPTION
### Description

This PR suggests fixing some dead links in several files:
* https://sli.dev/themes/use or https://sli.dev/themes/use.html → https://sli.dev/guide/theme-addon#use-theme
* https://sli.dev/themes/gallery or https://sli.dev/themes/gallery.html → https://sli.dev/resources/theme-gallery