### PR TITLE
docs: add `slidev-addon-rabbit` to addon gallery

### DIFF
--- a/docs/.vitepress/addons.ts
+++ b/docs/.vitepress/addons.ts
@@ -28,7 +28,7 @@ export const community: AddonInfo[] = [
   {
     id: 'slidev-addon-rabbit',
     name: 'slidev-addon-rabbit',
-    description: 'Presentation time management for slidev inspired by Rabbit.',
+    description: 'Presentation time management for Slidev inspired by Rabbit',
     author: {
       name: 'kaakaa',
       link: 'https://github.com/kaakaa',

--- a/docs/.vitepress/addons.ts
+++ b/docs/.vitepress/addons.ts
@@ -25,6 +25,16 @@ export const community: AddonInfo[] = [
     },
     repo: 'https://github.com/AlbertBrand/slidev-addon-tldraw',
   },
+  {
+    id: 'slidev-addon-rabbit',
+    name: 'slidev-addon-rabbit',
+    description: 'Presentation time management for slidev inspired by Rabbit.',
+    author: {
+      name: 'kaakaa',
+      link: 'https://github.com/kaakaa',
+    },
+    repo: 'https://github.com/kaakaa/slidev-addon-rabbit',
+  },
   // Add yours here!
   {
     id: '',


### PR DESCRIPTION
Add my addon [slidev-addon-rabbit](https://github.com/kaakaa/slidev-addon-rabbit) to [Addon Gallery \| Slidev](https://sli.dev/resources/addon-gallery).