### PR TITLE
fix: ToC link in Presenter Mode

### DIFF
--- a/packages/client/builtin/Toc.vue
+++ b/packages/client/builtin/Toc.vue
@@ -95,6 +95,7 @@ const toc = computed(() => {
       :list-style="listStyle"
       :list="toc"
       :list-class="listClass"
+      :isPresenter="$slidev.nav.isPresenter"
     />
   </div>
 </template>

--- a/packages/client/builtin/Toc.vue
+++ b/packages/client/builtin/Toc.vue
@@ -95,7 +95,7 @@ const toc = computed(() => {
       :list-style="listStyle"
       :list="toc"
       :list-class="listClass"
-      :isPresenter="$slidev.nav.isPresenter"
+      :is-presenter="$slidev.nav.isPresenter"
     />
   </div>
 </template>

--- a/packages/client/builtin/Toc.vue
+++ b/packages/client/builtin/Toc.vue
@@ -95,7 +95,6 @@ const toc = computed(() => {
       :list-style="listStyle"
       :list="toc"
       :list-class="listClass"
-      :is-presenter="$slidev.nav.isPresenter"
     />
   </div>
 </template>

--- a/packages/client/builtin/TocList.vue
+++ b/packages/client/builtin/TocList.vue
@@ -57,7 +57,7 @@ const styles = computed(() => {
         :list-style="listStyle"
         :list="item.children"
         :list-class="listClass"
-        :isPresenter="isPresenter"
+        :is-presenter="isPresenter"
       />
     </li>
   </ol>

--- a/packages/client/builtin/TocList.vue
+++ b/packages/client/builtin/TocList.vue
@@ -11,6 +11,7 @@ import type { TocItem } from '@slidev/types'
 import TitleRenderer from '#slidev/title-renderer'
 import { toArray } from '@antfu/utils'
 import { computed } from 'vue'
+import { useNav } from '../composables/useNav'
 
 const props = withDefaults(defineProps<{
   level: number
@@ -18,8 +19,9 @@ const props = withDefaults(defineProps<{
   listStyle?: string | string[]
   list: TocItem[]
   listClass?: string | string[]
-  isPresenter: boolean
 }>(), { level: 1 })
+
+const { isPresenter } = useNav()
 
 const classes = computed(() => {
   return [
@@ -57,7 +59,6 @@ const styles = computed(() => {
         :list-style="listStyle"
         :list="item.children"
         :list-class="listClass"
-        :is-presenter="isPresenter"
       />
     </li>
   </ol>

--- a/packages/client/builtin/TocList.vue
+++ b/packages/client/builtin/TocList.vue
@@ -18,6 +18,7 @@ const props = withDefaults(defineProps<{
   listStyle?: string | string[]
   list: TocItem[]
   listClass?: string | string[]
+  isPresenter: boolean
 }>(), { level: 1 })
 
 const classes = computed(() => {
@@ -47,7 +48,7 @@ const styles = computed(() => {
       :key="item.path" class="slidev-toc-item"
       :class="[{ 'slidev-toc-item-active': item.active }, { 'slidev-toc-item-parent-active': item.activeParent }]"
     >
-      <Link :to="item.path">
+      <Link :to="isPresenter ? `/presenter${item.path}` : item.path">
         <TitleRenderer :no="item.no" />
       </Link>
       <TocList
@@ -56,6 +57,7 @@ const styles = computed(() => {
         :list-style="listStyle"
         :list="item.children"
         :list-class="listClass"
+        :isPresenter="isPresenter"
       />
     </li>
   </ol>


### PR DESCRIPTION
## Issue
When clicking on a link in the `Toc`  Component in presenter mode, it exits presenter mode unintentionally. This disrupts the presenter experience by requiring the user to re-enter presenter mode, interrupting the flow.

## Solution
Modify the `TocList` component to prepend `/presenter` to each item's path when `$slidev.nav.isPresenter` is `true`.
