### PR TITLE
fix: setup preparser correctly when no addons are used

### DIFF
--- a/packages/slidev/node/setups/preparser.ts
+++ b/packages/slidev/node/setups/preparser.ts
@@ -7,14 +7,15 @@ import { loadSetups } from './load'
 
 export default function setupPreparser() {
   injectPreparserExtensionLoader(async (headmatter: Record<string, unknown>, filepath: string, mode?: string) => {
-    const addons = headmatter?.addons as string[]
-    if (!addons?.length)
-      return []
+    // Ensure addons is an array or an empty array if undefined
+    const addons = Array.isArray(headmatter?.addons) ? headmatter.addons as string[] : []
+
     const { userRoot } = await getRoots()
     const roots = uniq([
       ...await resolveAddons(addons),
       userRoot,
     ])
+
     const returns = await loadSetups<PreparserSetup>(roots, 'preparser.ts', [{ filepath, headmatter, mode }])
     return returns.flat()
   })


### PR DESCRIPTION
Currently the preparser is only called if `addons.length > 0`. If no addons are used the preparser does not work. This fixes that issue.