### PR TITLE
fix: add frequently missing classes to unocss safelist

### DIFF
--- a/packages/client/uno.config.ts
+++ b/packages/client/uno.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
   safelist: [
     '!opacity-0',
     'prose',
+    // See https://github.com/slidevjs/slidev/issues/1705
     'grid-rows-[1fr_max-content]',
     'grid-cols-[1fr_max-content]',
   ],

--- a/packages/client/uno.config.ts
+++ b/packages/client/uno.config.ts
@@ -13,6 +13,8 @@ export default defineConfig({
   safelist: [
     '!opacity-0',
     'prose',
+    'grid-rows-[1fr_max-content]',
+    'grid-cols-[1fr_max-content]',
   ],
   shortcuts: {
     'bg-main': 'bg-white dark:bg-[#121212]',


### PR DESCRIPTION
A temporary workaround for #1705.