### PR TITLE
docs: update Mermaid name and URLs, fix grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Presentation <b>slide</b>s for <b>dev</b>elopers 🧑‍💻👩‍💻👨‍�
 - 🎙 [**Presenter Mode**](https://sli.dev/guide/ui#presenter-mode) - use another window, or even your phone to control your slides
 - 🎨 [**Drawing**](https://sli.dev/features/drawing) - draw and annotate on your slides
 - 🧮 [**LaTeX**](https://sli.dev/features/latex) - built-in LaTeX math equations support
-- 📰 [**Diagrams**](https://sli.dev/guide/syntax#diagrams) - creates diagrams using textual descriptions with [Mermaid.js](https://mermaid.js.org/)
+- 📰 [**Diagrams**](https://sli.dev/guide/syntax#diagrams) - creates diagrams using textual descriptions with [Mermaid](https://mermaid.js.org/)
 - 🌟 [**Icons**](https://sli.dev/features/icons) - access to icons from any icon set directly
 - 💻 [**Editor**](https://sli.dev/guide/index#editor) - integrated editor, or the [VSCode extension](https://sli.dev/features/vscode-extension)
 - 🎥 [**Recording**](https://sli.dev/features/recording) - built-in recording and camera view

--- a/docs/custom/config-mermaid.md
+++ b/docs/custom/config-mermaid.md
@@ -14,7 +14,7 @@ export default defineMermaidSetup(() => {
 })
 ```
 
-The return value should be the custom configs for [Mermaid.js](https://mermaid.js.org/). Refer to the [Mermaid's documentation](http://mermaid.js.org/config/schema-docs/config.html) or the type definition for the full config list.
+The return value should be the custom configs for [Mermaid](https://mermaid.js.org/). Refer to the [Mermaid documentation](https://mermaid.js.org/config/schema-docs/config.html) or the type definition for the full config list.
 
 ## Custom theme/styles
 

--- a/docs/features/mermaid.md
+++ b/docs/features/mermaid.md
@@ -9,9 +9,9 @@ description: |
   Create diagrams/graphs from textual descriptions, powered by Mermaid.
 ---
 
-# Mermaid.js Diagrams
+# Mermaid Diagrams
 
-You can also create diagrams/graphs from textual descriptions in your Markdown, powered by [Mermaid](https://mermaid-js.github.io/mermaid).
+You can also create diagrams/graphs from textual descriptions in your Markdown, powered by [Mermaid](https://mermaid.js.org/).
 
 Code blocks marked as `mermaid` will be converted to diagrams, for example:
 
@@ -34,4 +34,4 @@ C -->|Two| E[Result 2]
 ```
 ````
 
-Visit the [Mermaid Website](http://mermaid.js.org/) for more information.
+Visit the [Mermaid Website](https://mermaid.js.org/) for more information.

--- a/docs/features/mermaid.md
+++ b/docs/features/mermaid.md
@@ -1,6 +1,6 @@
 ---
 relates:
-  - Mermaid: http://mermaid.js.org/
+  - Mermaid: https://mermaid.js.org/
   - Mermaid Live Editor: https://mermaid.live/
   - Demo Slide: https://sli.dev/demo/starter/12
   - features/plantuml

--- a/docs/guide/syntax.md
+++ b/docs/guide/syntax.md
@@ -157,7 +157,7 @@ Slidev supports LaTeX blocks for mathematical and chemical formulas:
 
 ## Diagrams {#diagrams}
 
-Slidev supports [Mermaid.js](http://mermaid.js.org/) and [PlantUML](https://plantuml.com/) for creating diagrams from text:
+Slidev supports [Mermaid](https://mermaid.js.org/) and [PlantUML](https://plantuml.com/) for creating diagrams from text:
 
 <LinkCard link="features/mermaid" />
 <LinkCard link="features/plantuml" />


### PR DESCRIPTION
_Mermaid.js_ is now just referenced as _Mermaid_ on their website.