### PR TITLE
docs: fix typo `installed` -> `install`

### DIFF
--- a/docs/guide/syntax.md
+++ b/docs/guide/syntax.md
@@ -81,7 +81,7 @@ src: ./pages/4.md  # This slide only contains a frontmatter
 
 Configurations you can set are described in the [Slides deck configurations](/custom/#headmatter) and [Per slide configurations](/custom/#frontmatter) sections.
 
-To make the headmatter more readable, you can installed the VSCode extension:
+To make the headmatter more readable, you can install the VSCode extension:
 
 <LinkCard link="features/vscode-extension" />
 


### PR DESCRIPTION
Hi guys,
I've just found a typo while reading the documentation for the first time. I'm new to Slidev and I'm really impressed.
Looking forward to future continued cooperation.
Cheers!