### PR TITLE
docs: add "Python Zero To Hero" to showcases

### DIFF
--- a/docs/.vitepress/showcases.ts
+++ b/docs/.vitepress/showcases.ts
@@ -238,6 +238,13 @@ export const showcases: ShowCaseInfo[] = [
     cover: 'https://raw.githubusercontent.com/hdm/decks-2024-lascon-numerology/refs/heads/main/screenshot.png',
     datetime: '2024-10-25',
   },
+  {
+    title: 'Python Zero To Hero - Episode 1',
+    cover: 'https://i.ytimg.com/vi/hVMaPBrWvAo/hqdefault.jpg?sqp=-oaymwEnCNACELwBSFryq4qpAxkIARUAAIhCGAHYAQHiAQoIGBACGAY4AUAB&rs=AOn4CLDxJOR7JGUM5LQJmcs96i2l2est7w',
+    author: {
+      name: 'Kareim Tarek',
+      link: 'https://github.com/KareimGazer',
+    },
   // Add yours here!
   {
     title: 'Yours?',

--- a/docs/.vitepress/showcases.ts
+++ b/docs/.vitepress/showcases.ts
@@ -245,6 +245,7 @@ export const showcases: ShowCaseInfo[] = [
       name: 'Kareim Tarek',
       link: 'https://github.com/KareimGazer',
     },
+  },
   // Add yours here!
   {
     title: 'Yours?',

--- a/docs/.vitepress/showcases.ts
+++ b/docs/.vitepress/showcases.ts
@@ -240,11 +240,15 @@ export const showcases: ShowCaseInfo[] = [
   },
   {
     title: 'Python Zero To Hero - Episode 1',
-    cover: 'https://i.ytimg.com/vi/hVMaPBrWvAo/hqdefault.jpg?sqp=-oaymwEnCNACELwBSFryq4qpAxkIARUAAIhCGAHYAQHiAQoIGBACGAY4AUAB&rs=AOn4CLDxJOR7JGUM5LQJmcs96i2l2est7w',
     author: {
       name: 'Kareim Tarek',
-      link: 'https://github.com/KareimGazer',
+      link: 'https://kareimgazer.github.io/',
     },
+    at: 'Kareem Kreates YouTube Channel',
+    slidesLink: 'https://kareimgazer.github.io/py-intro/',
+    sourceLink: 'https://github.com/KareimGazer/py-intro',
+    cover: 'https://i.ytimg.com/vi/hVMaPBrWvAo/hqdefault.jpg?sqp=-oaymwEnCNACELwBSFryq4qpAxkIARUAAIhCGAHYAQHiAQoIGBACGAY4AUAB&rs=AOn4CLDxJOR7JGUM5LQJmcs96i2l2est7w',
+    datetime: '2025-01-12',
   },
   // Add yours here!
   {

--- a/docs/.vitepress/showcases.ts
+++ b/docs/.vitepress/showcases.ts
@@ -247,7 +247,7 @@ export const showcases: ShowCaseInfo[] = [
     at: 'Kareem Kreates YouTube Channel',
     slidesLink: 'https://kareimgazer.github.io/py-intro/',
     sourceLink: 'https://github.com/KareimGazer/py-intro',
-    cover: 'https://i.ytimg.com/vi/hVMaPBrWvAo/hqdefault.jpg?sqp=-oaymwEnCNACELwBSFryq4qpAxkIARUAAIhCGAHYAQHiAQoIGBACGAY4AUAB&rs=AOn4CLDxJOR7JGUM5LQJmcs96i2l2est7w',
+    cover: 'https://i.ytimg.com/vi/hVMaPBrWvAo/hqdefault.jpg',
     datetime: '2025-01-12',
   },
   // Add yours here!


### PR DESCRIPTION
I have created a presentation explaining Python for the Arabic community using the Python add-on to run Python inside the slide. this adds a step further above and beyond Jupiter notebooks. I thought that it was a good idea to spread the word in the Arabic community and announce that here.

The [slides ](https://kareimgazer.github.io/py-intro/1) is for the first episode of my Python series "Python From Zero To Hero", and it uses almost all the features of Slidev. 