### PR TITLE
docs: fix minor error with relative clicks

### DIFF
--- a/docs/guide/animations.md
+++ b/docs/guide/animations.md
@@ -200,7 +200,7 @@ You can also specify the enter and leave index for the `v-click` directive by pa
   This will be hidden at click 2 and 3.
 </div>
 <div v-click />
-<div v-click="'[+1, +1]'">
+<div v-click="['+1', '+1']">
   This will be shown at click 3, and hidden since click 4.
 </div>
 ```


### PR DESCRIPTION
The single quotes were placed incorrectly.