### PR TITLE
fix: frontmatter types and vscode schemas

### DIFF
--- a/docs/custom/index.md
+++ b/docs/custom/index.md
@@ -147,15 +147,17 @@ src: undefined # or string
 title: undefined # or string
 # defines the transition between the slide and the next one
 # Learn more: https://sli.dev/guide/animations.html#slide-transitions
-transition: undefined # or string | TransitionProps
+transition: undefined # or BuiltinSlideTransition | string | TransitionGroupProps | null
 # custom zoom scale
 # useful for slides with a lot of content
 zoom: 1
 # used as positions of draggable elements
 # Learn more: https://sli.dev/features/draggable.html
-dragPos: {} # type: Record<string,string>
+dragPos: {} # type: Record<string, string> | Record<string, string>[]
 ---
 ```
+
+Check out the [type definition](https://github.com/slidevjs/slidev/blob/main/packages/types/src/frontmatter.ts#L260) for more details.
 
 ## Directory Structure
 

--- a/packages/types/src/frontmatter.ts
+++ b/packages/types/src/frontmatter.ts
@@ -1,7 +1,7 @@
 import type { BuiltinLayouts } from './builtin-layouts'
 import type { SlidevThemeConfig } from './types'
 
-export interface Headmatter extends HeadmatterConfig, Frontmatter {
+export interface Headmatter extends HeadmatterConfig, Omit<Frontmatter, 'title'> {
   /**
    * Default frontmatter options applied to all slides
    */
@@ -296,18 +296,23 @@ export interface Frontmatter extends TransitionOptions {
    */
   disabled?: boolean
   /**
-   * hide the slide for the `<Toc>` components
+   * Hide the slide for the `<Toc>` components
    *
    * See https://sli.dev/builtin/components#toc
    */
   hideInToc?: boolean
   /**
-   * Override the title level for the <TitleRenderer> and <Toc> components
+   * Override the title for the `<TitleRenderer>` and `<Toc>` components
+   * Only if `title` has also been declared
+   */
+  title?: string
+  /**
+   * Override the title level for the `<TitleRenderer>` and `<Toc>` components
    * Only if `title` has also been declared
    */
   level?: number
   /**
-   * Create a route alias that can be used in the URL or with the <Link> component
+   * Create a route alias that can be used in the URL or with the `<Link>` component
    */
   routeAlias?: string
   /**
@@ -321,7 +326,7 @@ export interface Frontmatter extends TransitionOptions {
    *
    * See https://sli.dev/features/draggable
    */
-  dragPos?: Record<string, string>[]
+  dragPos?: Record<string, string> | Record<string, string>[]
   /**
    * Includes a markdown file
    *

--- a/packages/vscode/schema/frontmatter.json
+++ b/packages/vscode/schema/frontmatter.json
@@ -83,18 +83,23 @@
         },
         "hideInToc": {
           "type": "boolean",
-          "description": "hide the slide for the `<Toc>` components\n\nSee https://sli.dev/builtin/components#toc",
-          "markdownDescription": "hide the slide for the `<Toc>` components\n\nSee https://sli.dev/builtin/components#toc"
+          "description": "Hide the slide for the `<Toc>` components\n\nSee https://sli.dev/builtin/components#toc",
+          "markdownDescription": "Hide the slide for the `<Toc>` components\n\nSee https://sli.dev/builtin/components#toc"
+        },
+        "title": {
+          "type": "string",
+          "description": "Override the title for the `<TitleRenderer>` and `<Toc>` components Only if `title` has also been declared",
+          "markdownDescription": "Override the title for the `<TitleRenderer>` and `<Toc>` components\nOnly if `title` has also been declared"
         },
         "level": {
           "type": "number",
-          "description": "Override the title level for the <TitleRenderer> and <Toc> components Only if `title` has also been declared",
-          "markdownDescription": "Override the title level for the <TitleRenderer> and <Toc> components\nOnly if `title` has also been declared"
+          "description": "Override the title level for the `<TitleRenderer>` and `<Toc>` components Only if `title` has also been declared",
+          "markdownDescription": "Override the title level for the `<TitleRenderer>` and `<Toc>` components\nOnly if `title` has also been declared"
         },
         "routeAlias": {
           "type": "string",
-          "description": "Create a route alias that can be used in the URL or with the <Link> component",
-          "markdownDescription": "Create a route alias that can be used in the URL or with the <Link> component"
+          "description": "Create a route alias that can be used in the URL or with the `<Link>` component",
+          "markdownDescription": "Create a route alias that can be used in the URL or with the `<Link>` component"
         },
         "zoom": {
           "type": "number",
@@ -103,13 +108,23 @@
           "default": 1
         },
         "dragPos": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
+          "anyOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              }
             }
-          },
+          ],
           "description": "Store the positions of draggable elements Normally you don't need to set this manually\n\nSee https://sli.dev/features/draggable",
           "markdownDescription": "Store the positions of draggable elements\nNormally you don't need to set this manually\n\nSee https://sli.dev/features/draggable"
         },

--- a/packages/vscode/schema/headmatter.json
+++ b/packages/vscode/schema/headmatter.json
@@ -5,24 +5,6 @@
     "Headmatter": {
       "type": "object",
       "properties": {
-        "transition": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/BuiltinSlideTransition"
-            },
-            {
-              "type": "string"
-            },
-            {
-              "$ref": "#/definitions/TransitionGroupProps"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "Page transition, powered by Vue's `<TransitionGroup/>`\n\nBuilt-in transitions:\n- fade\n- fade-out\n- slide-left\n- slide-right\n- slide-up\n- slide-down\n\nSee https://sli.dev/guide/animations.html#pages-transitions\n\nSee https://vuejs.org/guide/built-ins/transition.html",
-          "markdownDescription": "Page transition, powered by Vue's `<TransitionGroup/>`\n\nBuilt-in transitions:\n- fade\n- fade-out\n- slide-left\n- slide-right\n- slide-up\n- slide-down\n\nSee https://sli.dev/guide/animations.html#pages-transitions\n\nSee https://vuejs.org/guide/built-ins/transition.html"
-        },
         "layout": {
           "anyOf": [
             {
@@ -83,18 +65,18 @@
         },
         "hideInToc": {
           "type": "boolean",
-          "description": "hide the slide for the `<Toc>` components\n\nSee https://sli.dev/builtin/components#toc",
-          "markdownDescription": "hide the slide for the `<Toc>` components\n\nSee https://sli.dev/builtin/components#toc"
+          "description": "Hide the slide for the `<Toc>` components\n\nSee https://sli.dev/builtin/components#toc",
+          "markdownDescription": "Hide the slide for the `<Toc>` components\n\nSee https://sli.dev/builtin/components#toc"
         },
         "level": {
           "type": "number",
-          "description": "Override the title level for the <TitleRenderer> and <Toc> components Only if `title` has also been declared",
-          "markdownDescription": "Override the title level for the <TitleRenderer> and <Toc> components\nOnly if `title` has also been declared"
+          "description": "Override the title level for the `<TitleRenderer>` and `<Toc>` components Only if `title` has also been declared",
+          "markdownDescription": "Override the title level for the `<TitleRenderer>` and `<Toc>` components\nOnly if `title` has also been declared"
         },
         "routeAlias": {
           "type": "string",
-          "description": "Create a route alias that can be used in the URL or with the <Link> component",
-          "markdownDescription": "Create a route alias that can be used in the URL or with the <Link> component"
+          "description": "Create a route alias that can be used in the URL or with the `<Link>` component",
+          "markdownDescription": "Create a route alias that can be used in the URL or with the `<Link>` component"
         },
         "zoom": {
           "type": "number",
@@ -103,13 +85,23 @@
           "default": 1
         },
         "dragPos": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
+          "anyOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              }
             }
-          },
+          ],
           "description": "Store the positions of draggable elements Normally you don't need to set this manually\n\nSee https://sli.dev/features/draggable",
           "markdownDescription": "Store the positions of draggable elements\nNormally you don't need to set this manually\n\nSee https://sli.dev/features/draggable"
         },
@@ -117,6 +109,24 @@
           "type": "string",
           "description": "Includes a markdown file\n\nSee https://sli.dev/guide/syntax.html#importing-slides",
           "markdownDescription": "Includes a markdown file\n\nSee https://sli.dev/guide/syntax.html#importing-slides"
+        },
+        "transition": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/BuiltinSlideTransition"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/TransitionGroupProps"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Page transition, powered by Vue's `<TransitionGroup/>`\n\nBuilt-in transitions:\n- fade\n- fade-out\n- slide-left\n- slide-right\n- slide-up\n- slide-down\n\nSee https://sli.dev/guide/animations.html#pages-transitions\n\nSee https://vuejs.org/guide/built-ins/transition.html",
+          "markdownDescription": "Page transition, powered by Vue's `<TransitionGroup/>`\n\nBuilt-in transitions:\n- fade\n- fade-out\n- slide-left\n- slide-right\n- slide-up\n- slide-down\n\nSee https://sli.dev/guide/animations.html#pages-transitions\n\nSee https://vuejs.org/guide/built-ins/transition.html"
         },
         "title": {
           "type": "string",
@@ -492,7 +502,36 @@
           "description": "Default frontmatter options applied to all slides",
           "markdownDescription": "Default frontmatter options applied to all slides"
         }
-      }
+      },
+      "required": [
+        "transition"
+      ]
+    },
+    "BuiltinLayouts": {
+      "type": "string",
+      "enum": [
+        "404",
+        "center",
+        "cover",
+        "default",
+        "end",
+        "error",
+        "fact",
+        "full",
+        "iframe-left",
+        "iframe-right",
+        "iframe",
+        "image-left",
+        "image-right",
+        "image",
+        "intro",
+        "none",
+        "quote",
+        "section",
+        "statement",
+        "two-cols-header",
+        "two-cols"
+      ]
     },
     "BuiltinSlideTransition": {
       "type": "string",
@@ -574,32 +613,6 @@
           "type": "string"
         }
       }
-    },
-    "BuiltinLayouts": {
-      "type": "string",
-      "enum": [
-        "404",
-        "center",
-        "cover",
-        "default",
-        "end",
-        "error",
-        "fact",
-        "full",
-        "iframe-left",
-        "iframe-right",
-        "iframe",
-        "image-left",
-        "image-right",
-        "image",
-        "intro",
-        "none",
-        "quote",
-        "section",
-        "statement",
-        "two-cols-header",
-        "two-cols"
-      ]
     },
     "SlidevThemeConfig": {
       "type": "object",
@@ -858,18 +871,23 @@
         },
         "hideInToc": {
           "type": "boolean",
-          "description": "hide the slide for the `<Toc>` components\n\nSee https://sli.dev/builtin/components#toc",
-          "markdownDescription": "hide the slide for the `<Toc>` components\n\nSee https://sli.dev/builtin/components#toc"
+          "description": "Hide the slide for the `<Toc>` components\n\nSee https://sli.dev/builtin/components#toc",
+          "markdownDescription": "Hide the slide for the `<Toc>` components\n\nSee https://sli.dev/builtin/components#toc"
+        },
+        "title": {
+          "type": "string",
+          "description": "Override the title for the `<TitleRenderer>` and `<Toc>` components Only if `title` has also been declared",
+          "markdownDescription": "Override the title for the `<TitleRenderer>` and `<Toc>` components\nOnly if `title` has also been declared"
         },
         "level": {
           "type": "number",
-          "description": "Override the title level for the <TitleRenderer> and <Toc> components Only if `title` has also been declared",
-          "markdownDescription": "Override the title level for the <TitleRenderer> and <Toc> components\nOnly if `title` has also been declared"
+          "description": "Override the title level for the `<TitleRenderer>` and `<Toc>` components Only if `title` has also been declared",
+          "markdownDescription": "Override the title level for the `<TitleRenderer>` and `<Toc>` components\nOnly if `title` has also been declared"
         },
         "routeAlias": {
           "type": "string",
-          "description": "Create a route alias that can be used in the URL or with the <Link> component",
-          "markdownDescription": "Create a route alias that can be used in the URL or with the <Link> component"
+          "description": "Create a route alias that can be used in the URL or with the `<Link>` component",
+          "markdownDescription": "Create a route alias that can be used in the URL or with the `<Link>` component"
         },
         "zoom": {
           "type": "number",
@@ -878,13 +896,23 @@
           "default": 1
         },
         "dragPos": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
+          "anyOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              }
             }
-          },
+          ],
           "description": "Store the positions of draggable elements Normally you don't need to set this manually\n\nSee https://sli.dev/features/draggable",
           "markdownDescription": "Store the positions of draggable elements\nNormally you don't need to set this manually\n\nSee https://sli.dev/features/draggable"
         },


### PR DESCRIPTION
there was an issue where the `title` property was missing in the `Frontmatter` interface, and the `dragPos` property had an incorrect type due to the possibility to use as `Record<string, string>` or `Record<string, string>[]`.

so, this pr resolves these issues and also includes updates to the vscode schemas (which also fix the missing info by adding backticks)
missing info:
![Снимок экрана 2025-02-13 170609](https://github.com/user-attachments/assets/b89a2a73-3b2c-4db0-aaa0-e1d69da49150)

additionally, the docs has been updated.

resolves: #2060