### PR TITLE
docs: add `slidev-addon-stem` to the list of addons

### DIFF
--- a/docs/.vitepress/addons.ts
+++ b/docs/.vitepress/addons.ts
@@ -137,6 +137,17 @@ export const community: AddonInfo[] = [
     },
     repo: 'https://github.com/kaakaa/slidev-addon-rabbit',
   },
+  {
+    id: 'slidev-addon-stem',
+    name: 'slidev-addon-stem',
+    description: 'Slidev addon for scientific presentation',
+    tags: ['Component', 'Layout'],
+    author: {
+      name: 'yutaka-shoji',
+      link: 'https://github.com/yutaka-shoji',
+    },
+    repo: 'https://github.com/yutaka-shoji/slidev-addon-stem',
+  },
   // Add yours here!
   {
     id: '',


### PR DESCRIPTION
Please add my addon [`slidev-addon-stem`](https://github.com/yutaka-shoji/slidev-addon-stem) to [Addon Gallery | Slidev](https://sli.dev/resources/addon-gallery).