### PR TITLE
fix: use computed for clicks initialization in `createFixedClicks`

### DIFF
--- a/packages/client/composables/useClicks.ts
+++ b/packages/client/composables/useClicks.ts
@@ -165,7 +165,7 @@ export function createFixedClicks(
 ): ClicksContext {
   const clicksStart = route?.meta.slide?.frontmatter.clicksStart ?? 0
   return createClicksContextBase(
-    ref(Math.max(toValue(currentInit), clicksStart)),
+    computed(() => Math.max(toValue(currentInit), clicksStart)),
     clicksStart,
     route?.meta?.clicks,
   )


### PR DESCRIPTION
fix #2034