### PR TITLE
fix: do not unmount slide too far away

### DIFF
--- a/packages/client/internals/SlidesShow.vue
+++ b/packages/client/internals/SlidesShow.vue
@@ -87,7 +87,6 @@ function onAfterLeave() {
   >
     <template v-for="route of loadedRoutes" :key="route.no">
       <SlideWrapper
-        v-if="Math.abs(route.no - currentSlideRoute.no) <= 20"
         v-show="route === currentSlideRoute"
         :clicks-context="isPrintMode && !isPrintWithClicks ? createFixedClicks(route, CLICKS_MAX) : getPrimaryClicks(route)"
         :route="route"


### PR DESCRIPTION
The line removed in this PR was added by me, which I thought could improve the performance by limiting the number of DOM nodes. But this will cause the nodes to frequently unmount and remount. I am not sure about the best way to do this.

Also resolves #1961.