### PR TITLE
fix: visual clue when pressing `r`

### DIFF
--- a/packages/slidev/node/cli.ts
+++ b/packages/slidev/node/cli.ts
@@ -224,7 +224,7 @@ cli.command(
         name: 'r',
         fullname: 'restart',
         action() {
-          initServer()
+          restartServer()
         },
       },
       {


### PR DESCRIPTION
fix #2049