### PR TITLE
fix: should reshow cursor when switching out playing page

### DIFF
--- a/packages/client/composables/useHideCursorIdle.ts
+++ b/packages/client/composables/useHideCursorIdle.ts
@@ -1,6 +1,6 @@
 import type { Ref } from 'vue'
 import { useEventListener } from '@vueuse/core'
-import { computed, watch } from 'vue'
+import { computed, onScopeDispose, watch } from 'vue'
 import { hideCursorIdle } from '../state'
 
 const TIMEOUT = 2000
@@ -17,8 +17,6 @@ export function useHideCursorIdle(
     document.body.style.cursor = ''
   }
 
-  let timer: ReturnType<typeof setTimeout> | null = null
-
   // If disabled, immediately show the cursor
   watch(
     shouldHide,
@@ -27,7 +25,9 @@ export function useHideCursorIdle(
         show()
     },
   )
+  onScopeDispose(show)
 
+  let timer: ReturnType<typeof setTimeout> | null = null
   useEventListener(
     document.body,
     ['pointermove', 'pointerdown'],
@@ -35,9 +35,12 @@ export function useHideCursorIdle(
       show()
       if (timer)
         clearTimeout(timer)
-      if (!shouldHide.value)
-        return
-      timer = setTimeout(hide, TIMEOUT)
+      if (shouldHide.value) {
+        timer = setTimeout(hide, TIMEOUT)
+      }
+      else {
+        timer = null
+      }
     },
     { passive: true },
   )

--- a/packages/client/pages/play.vue
+++ b/packages/client/pages/play.vue
@@ -15,7 +15,7 @@ import { onContextMenu } from '../logic/contextMenu'
 import { registerShortcuts } from '../logic/shortcuts'
 import { editorHeight, editorWidth, isEditorVertical, isScreenVertical, showEditor, viewerCssFilter, viewerCssFilterDefaults } from '../state'
 
-const { next, prev, isPrintMode, isPresenter } = useNav()
+const { next, prev, isPrintMode, isPlaying, isEmbedded } = useNav()
 const { isDrawing } = useDrawings()
 
 const root = ref<HTMLDivElement>()
@@ -36,7 +36,7 @@ useSwipeControls(root)
 registerShortcuts()
 if (__SLIDEV_FEATURE_WAKE_LOCK__)
   useWakeLock()
-useHideCursorIdle(computed(() => !isPresenter.value && !isPrintMode.value))
+useHideCursorIdle(computed(() => isPlaying.value && !isEmbedded.value && !showEditor.value))
 
 if (import.meta.hot) {
   useStyleTag(computed(() => showEditor.value


### PR DESCRIPTION
The cursor sometimes hides after I switch to the export page.