### PR TITLE
feat: allow bun as package manager for dep installation

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -65,6 +65,11 @@ npm init slidev@latest
 yarn create slidev
 ```
 
+
+```bash [bun]
+bun create slidev
+```
+
 :::
 
 Follow the prompts to start your slides project. The slides content is in `slides.md`, which initially includes demos of most the Slidev features. For more information about the Markdown syntax, please check <LinkInline link="guide/syntax" />.

--- a/packages/create-app/index.mjs
+++ b/packages/create-app/index.mjs
@@ -117,7 +117,7 @@ async function init() {
       name: 'agent',
       type: 'select',
       message: 'Choose the package manager',
-      choices: ['npm', 'yarn', 'pnpm'].map(i => ({ value: i, title: i })),
+      choices: ['npm', 'yarn', 'pnpm', 'bun'].map(i => ({ value: i, title: i })),
     })
 
     if (!agent)


### PR DESCRIPTION
Hi everyone,
I've really enjoyed using this awesome tool for quite some time, but it's always bothered me that I can't use `bun` during the setup for installing dependencies. 
Bun offers excellent performance for both execution and package management and has very high compatibility with `node` while being significantly faster. 

Anyway, here's a small PR allowing you to use `bun` as the package manager when setting up a new project
