### PR TITLE
docs: rename `preset-uno` to `preset-wind3`

### DIFF
--- a/docs/custom/config-unocss.md
+++ b/docs/custom/config-unocss.md
@@ -6,7 +6,7 @@
 
 By default, Slidev enables the following presets out-of-box:
 
-- [@unocss/preset-uno](https://unocss.dev/presets/uno) - Tailwind / Windi CSS compatible utilities
+- [@unocss/preset-wind3](https://unocss.dev/presets/wind3) - Tailwind / Windi CSS compatible utilities
 - [@unocss/preset-attributify](https://unocss.dev/presets/attributify) - Attributify mode
 - [@unocss/preset-icons](https://unocss.dev/presets/icons) - Use any icons as class
 - [@unocss/preset-web-fonts](https://unocss.dev/presets/web-fonts) - Use web fonts at ease

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -65,7 +65,6 @@ npm init slidev@latest
 yarn create slidev
 ```
 
-
 ```bash [bun]
 bun create slidev
 ```


### PR DESCRIPTION
## Description

UnoCSS [Wind3 preset document](https://unocss.dev/presets/wind3) says

> [!NOTE]
> `@unocss/preset-wind` and `@unocss/preset-uno` are deprecated and renamed to `@unocss/preset-wind3`. This preset inherits from [@unocss/preset-mini](https://unocss.dev/presets/mini).

In [Configure UnoCSS docs](https://sli.dev/custom/config-unocss), the old name and link remain.
This PR fixed them.