### PR TITLE
docs: add `bun` package manager to code-groups

### DIFF
--- a/docs/features/icons.md
+++ b/docs/features/icons.md
@@ -35,6 +35,10 @@ npm install @iconify-json/[the-collection-you-want]
 yarn add @iconify-json/[the-collection-you-want]
 ```
 
+```bash [bun]
+bun add @iconify-json/[the-collection-you-want]
+```
+
 :::
 
 We use [Iconify](https://iconify.design) as our data source of icons. You need to install the corresponding icon-set in `dependencies` by following the `@iconify-json/*` pattern. For example, `@iconify-json/mdi` for [Material Design Icons](https://materialdesignicons.com/), `@iconify-json/tabler` for [Tabler](https://tabler-icons.io/). You can refer to [Icônes](https://icones.js.org/) or [Iconify](https://icon-sets.iconify.design/) for all the collections available.

--- a/docs/features/prettier-plugin.md
+++ b/docs/features/prettier-plugin.md
@@ -28,6 +28,10 @@ pnpm i -D prettier prettier-plugin-slidev
 yarn add -D prettier prettier-plugin-slidev
 ```
 
+```bash [bun]
+bun add -D prettier prettier-plugin-slidev
+```
+
 :::
 
 ## 2. Activate the plugin

--- a/docs/features/remote-access.md
+++ b/docs/features/remote-access.md
@@ -29,6 +29,11 @@ yarn dev --remote
 # i.e. slidev --remote
 ```
 
+```bash [bun]
+bun dev --remote
+# i.e. slidev --remote
+```
+
 :::
 
 ## Password Protection
@@ -53,6 +58,11 @@ npm run dev -- --remote --tunnel
 
 ```bash [yarn]
 yarn dev --remote --tunnel
+# i.e. slidev --remote --tunnel
+```
+
+```bash [bun]
+bun dev --remote --tunnel
 # i.e. slidev --remote --tunnel
 ```
 

--- a/docs/guide/exporting.md
+++ b/docs/guide/exporting.md
@@ -38,6 +38,10 @@ $ npm i -D playwright-chromium
 $ yarn add -D playwright-chromium
 ```
 
+```bash [bun]
+$ bun add -D playwright-chromium
+```
+
 :::
 
 ## Formats

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -92,6 +92,10 @@ npm i -g @slidev/cli
 yarn global add @slidev/cli
 ```
 
+```bash [bun]
+bun i -g @slidev/cli
+```
+
 :::
 
 Then, you can create and start a single file slides via:

--- a/docs/guide/write-theme.md
+++ b/docs/guide/write-theme.md
@@ -20,6 +20,10 @@ $ npm init slidev-theme@latest
 $ yarn create slidev-theme
 ```
 
+```bash [bun]
+$ bun create slidev-theme
+```
+
 :::
 
 Then you can modify and play with it. You can also refer to the [official themes](../resources/theme-gallery#official-themes) as examples.


### PR DESCRIPTION
## Description

Follow up #2098.

[Bun](https://bun.sh/) is a fast JavaScript all-in-one toolkit.
It's useful for many users to use `bun` command.
Therefore, I added the `bun` scripts to code-groups.