### PR TITLE
feat: allow to set title/level from preparser via frontmatter keys

### DIFF
--- a/packages/parser/src/core.ts
+++ b/packages/parser/src/core.ts
@@ -148,6 +148,12 @@ export async function parse(
           const newContent = await e.transformSlide(slide.content, slide.frontmatter)
           if (newContent !== undefined)
             slide.content = newContent
+          if (typeof slide.frontmatter.title === 'string') {
+            slide.title = slide.frontmatter.title
+          }
+          if (typeof slide.frontmatter.level === 'number') {
+            slide.level = slide.frontmatter.level
+          }
         }
       }
     }


### PR DESCRIPTION
I went with this solution as it doesn't change the `transformSlide` function signature. Otherwise, the change would either be breaking or we need to add the SlideInfo as redundant function argument (it also contains `content` and `frontmatter`). Having the whole SlideInfo might enable more use cases, but also might have the potential for modifications that shouldn't be done.

Closes #2095.