### PR TITLE
feat!: support emoji syntax

### DIFF
--- a/packages/slidev/node/syntax/markdown-it/index.ts
+++ b/packages/slidev/node/syntax/markdown-it/index.ts
@@ -2,6 +2,7 @@ import type { ResolvedSlidevOptions } from '@slidev/types'
 import type MagicString from 'magic-string'
 import type { MarkdownItAsync } from 'markdown-it-async'
 import { taskLists as MarkdownItTaskList } from '@hedgedoc/markdown-it-plugins'
+import { full as MarkdownItEmoji } from 'markdown-it-emoji'
 // @ts-expect-error missing types
 import MarkdownItFootnote from 'markdown-it-footnote'
 import MarkdownItMdc from 'markdown-it-mdc'
@@ -27,4 +28,5 @@ export async function useMarkdownItPlugins(md: MarkdownItAsync, options: Resolve
   md.use(MarkdownItVDrag, markdownTransformMap)
   if (config.mdc)
     md.use(MarkdownItMdc)
+  md.use(MarkdownItEmoji)
 }

--- a/packages/slidev/package.json
+++ b/packages/slidev/package.json
@@ -82,6 +82,7 @@
     "magic-string": "catalog:",
     "magic-string-stack": "catalog:",
     "markdown-it": "catalog:",
+    "markdown-it-emoji": "catalog:",
     "markdown-it-footnote": "catalog:",
     "markdown-it-mdc": "catalog:",
     "mlly": "catalog:",
@@ -120,6 +121,7 @@
   },
   "devDependencies": {
     "@hedgedoc/markdown-it-plugins": "catalog:",
+    "@types/markdown-it-emoji": "catalog:",
     "@types/picomatch": "catalog:",
     "@types/plantuml-encoder": "catalog:"
   }

--- a/patches/markdown-it-mdc.patch
+++ b/patches/markdown-it-mdc.patch
@@ -1,0 +1,72 @@
+diff --git a/dist/index.mjs b/dist/index.mjs
+index 7673b034c94b8e6b63363a9b0632bb98e402d3e4..8b19e7ecc7099f821f943c7274e8ad8cb29d2e21 100644
+--- a/dist/index.mjs
++++ b/dist/index.mjs
+@@ -142,32 +142,32 @@ const MarkdownItMdcBlock = (md) => {
+   const min_markers = 2;
+   const marker_str = ":";
+   const marker_char = marker_str.charCodeAt(0);
+-  md.block.ruler.before(
+-    "fence",
+-    "mdc_block_shorthand",
+-    // eslint-disable-next-line prefer-arrow-callback
+-    function mdc_block_shorthand(state, startLine, endLine, silent) {
+-      const line = state.src.slice(state.bMarks[startLine] + state.tShift[startLine], state.eMarks[startLine]);
+-      if (!line.match(/^:\w/))
+-        return false;
+-      const {
+-        name,
+-        props
+-      } = parseBlockParams(line.slice(1));
+-      state.lineMax = startLine + 1;
+-      if (!silent) {
+-        const token = state.push("mdc_block_shorthand", name, 0);
+-        props?.forEach(([key, value]) => {
+-          if (key === "class")
+-            token.attrJoin(key, value);
+-          else
+-            token.attrSet(key, value);
+-        });
+-      }
+-      state.line = startLine + 1;
+-      return true;
+-    }
+-  );
++  // md.block.ruler.before(
++  //   "fence",
++  //   "mdc_block_shorthand",
++  //   // eslint-disable-next-line prefer-arrow-callback
++  //   function mdc_block_shorthand(state, startLine, endLine, silent) {
++  //     const line = state.src.slice(state.bMarks[startLine] + state.tShift[startLine], state.eMarks[startLine]);
++  //     if (!line.match(/^:\w/))
++  //       return false;
++  //     const {
++  //       name,
++  //       props
++  //     } = parseBlockParams(line.slice(1));
++  //     state.lineMax = startLine + 1;
++  //     if (!silent) {
++  //       const token = state.push("mdc_block_shorthand", name, 0);
++  //       props?.forEach(([key, value]) => {
++  //         if (key === "class")
++  //           token.attrJoin(key, value);
++  //         else
++  //           token.attrSet(key, value);
++  //       });
++  //     }
++  //     state.line = startLine + 1;
++  //     return true;
++  //   }
++  // );
+   md.block.ruler.before(
+     "fence",
+     "mdc_block",
+@@ -548,7 +548,7 @@ const MarkdownItMdc = (md, options = {}) => {
+     blockComponent = true,
+     inlineProps = true,
+     inlineSpan = true,
+-    inlineComponent = true
++    inlineComponent = false
+   } = options.syntax || {};
+   if (blockComponent)
+     md.use(MarkdownItMdcBlock);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -414,9 +414,9 @@ overrides:
   vite: ^6.2.1
 
 patchedDependencies:
-  '@hedgedoc/markdown-it-plugins@2.1.4':
-    hash: 49e14003b6caa0b7d164cbe71da573809d375babb2012c0a5ac943573e063c90
-    path: patches/@hedgedoc__markdown-it-plugins@2.1.4.patch
+  markdown-it-mdc:
+    hash: 426a74e1d91fcb1a0bc1418e5ffdd394a23a9579c00ca32b0ea673044f7e9c69
+    path: patches/markdown-it-mdc.patch
 
 importers:
 
@@ -963,7 +963,7 @@ importers:
         version: 4.0.0
       markdown-it-mdc:
         specifier: 'catalog:'
-        version: 0.2.5(@types/markdown-it@14.1.2)(markdown-it@14.1.0)
+        version: 0.2.5(patch_hash=426a74e1d91fcb1a0bc1418e5ffdd394a23a9579c00ca32b0ea673044f7e9c69)(@types/markdown-it@14.1.2)(markdown-it@14.1.0)
       mlly:
         specifier: 'catalog:'
         version: 1.7.4
@@ -1069,7 +1069,7 @@ importers:
     devDependencies:
       '@hedgedoc/markdown-it-plugins':
         specifier: 'catalog:'
-        version: 2.1.4(patch_hash=49e14003b6caa0b7d164cbe71da573809d375babb2012c0a5ac943573e063c90)(markdown-it@14.1.0)
+        version: 2.1.4(markdown-it@14.1.0)
       '@types/picomatch':
         specifier: 'catalog:'
         version: 3.0.2
@@ -2108,51 +2108,61 @@ packages:
     resolution: {integrity: sha512-mrA0v3QMy6ZSvEuLs0dMxcO2LnaCONs1Z73GUDBHWbY8tFFocM6yl7YyMu7rz4zS81NDSqhrUuolyZXGi8TEqg==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.35.0':
     resolution: {integrity: sha512-DnYhhzcvTAKNexIql8pFajr0PiDGrIsBYPRvCKlA5ixSS3uwo/CWNZxB09jhIapEIg945KOzcYEAGGSmTSpk7A==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.35.0':
     resolution: {integrity: sha512-uagpnH2M2g2b5iLsCTZ35CL1FgyuzzJQ8L9VtlJ+FckBXroTwNOaD0z0/UF+k5K3aNQjbm8LIVpxykUOQt1m/A==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.35.0':
     resolution: {integrity: sha512-XQxVOCd6VJeHQA/7YcqyV0/88N6ysSVzRjJ9I9UA/xXpEsjvAgDTgH3wQYz5bmr7SPtVK2TsP2fQ2N9L4ukoUg==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.35.0':
     resolution: {integrity: sha512-5pMT5PzfgwcXEwOaSrqVsz/LvjDZt+vQ8RT/70yhPU06PTuq8WaHhfT1LW+cdD7mW6i/J5/XIkX/1tCAkh1W6g==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.35.0':
     resolution: {integrity: sha512-c+zkcvbhbXF98f4CtEIP1EBA/lCic5xB0lToneZYvMeKu5Kamq3O8gqrxiYYLzlZH6E3Aq+TSW86E4ay8iD8EA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.35.0':
     resolution: {integrity: sha512-s91fuAHdOwH/Tad2tzTtPX7UZyytHIRR6V4+2IGlV0Cej5rkG0R61SX4l4y9sh0JBibMiploZx3oHKPnQBKe4g==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.35.0':
     resolution: {integrity: sha512-hQRkPQPLYJZYGP+Hj4fR9dDBMIM7zrzJDWFEMPdTnTy95Ljnv0/4w/ixFw3pTBMEuuEuoqtBINYND4M7ujcuQw==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.35.0':
     resolution: {integrity: sha512-Pim1T8rXOri+0HmV4CdKSGrqcBWX0d1HoPnQ0uw0bdp1aP5SdQVNBy8LjYncvnLgu3fnnCt17xjWGd4cqh8/hA==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.35.0':
     resolution: {integrity: sha512-QysqXzYiDvQWfUiTm8XmJNO2zm9yC9P/2Gkrwg2dH9cxotQzunBHYr6jk4SujCTqnfGxduOmQcI7c2ryuW8XVg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.35.0':
     resolution: {integrity: sha512-OUOlGqPkVJCdJETKOCEf1mw848ZyJ5w50/rZ/3IBQVdLfR5jk/6Sr5m3iO2tdPgwo0x7VcncYuOvMhBWZq8ayg==}
@@ -7550,7 +7560,7 @@ snapshots:
 
   '@floating-ui/utils@0.2.7': {}
 
-  '@hedgedoc/markdown-it-plugins@2.1.4(patch_hash=49e14003b6caa0b7d164cbe71da573809d375babb2012c0a5ac943573e063c90)(markdown-it@14.1.0)':
+  '@hedgedoc/markdown-it-plugins@2.1.4(markdown-it@14.1.0)':
     dependencies:
       '@mrdrogdrog/optional': 1.2.1
       html-entities: 2.5.2
@@ -10987,7 +10997,7 @@ snapshots:
 
   markdown-it-footnote@4.0.0: {}
 
-  markdown-it-mdc@0.2.5(@types/markdown-it@14.1.2)(markdown-it@14.1.0):
+  markdown-it-mdc@0.2.5(patch_hash=426a74e1d91fcb1a0bc1418e5ffdd394a23a9579c00ca32b0ea673044f7e9c69)(@types/markdown-it@14.1.2)(markdown-it@14.1.0):
     dependencies:
       '@types/markdown-it': 14.1.2
       js-yaml: 4.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ catalogs:
     '@types/markdown-it':
       specifier: ^14.1.2
       version: 14.1.2
+    '@types/markdown-it-emoji':
+      specifier: ^3.0.1
+      version: 3.0.1
     '@types/node':
       specifier: ^22.13.10
       version: 22.13.10
@@ -234,6 +237,9 @@ catalogs:
     markdown-it:
       specifier: ^14.1.0
       version: 14.1.0
+    markdown-it-emoji:
+      specifier: ^3.0.0
+      version: 3.0.0
     markdown-it-footnote:
       specifier: ^4.0.0
       version: 4.0.0
@@ -414,7 +420,10 @@ overrides:
   vite: ^6.2.1
 
 patchedDependencies:
-  markdown-it-mdc:
+  '@hedgedoc/markdown-it-plugins@2.1.4':
+    hash: 49e14003b6caa0b7d164cbe71da573809d375babb2012c0a5ac943573e063c90
+    path: patches/@hedgedoc__markdown-it-plugins@2.1.4.patch
+  markdown-it-mdc@0.2.5:
     hash: 426a74e1d91fcb1a0bc1418e5ffdd394a23a9579c00ca32b0ea673044f7e9c69
     path: patches/markdown-it-mdc.patch
 
@@ -958,6 +967,9 @@ importers:
       markdown-it:
         specifier: 'catalog:'
         version: 14.1.0
+      markdown-it-emoji:
+        specifier: 'catalog:'
+        version: 3.0.0
       markdown-it-footnote:
         specifier: 'catalog:'
         version: 4.0.0
@@ -1069,7 +1081,10 @@ importers:
     devDependencies:
       '@hedgedoc/markdown-it-plugins':
         specifier: 'catalog:'
-        version: 2.1.4(markdown-it@14.1.0)
+        version: 2.1.4(patch_hash=49e14003b6caa0b7d164cbe71da573809d375babb2012c0a5ac943573e063c90)(markdown-it@14.1.0)
+      '@types/markdown-it-emoji':
+        specifier: 'catalog:'
+        version: 3.0.1
       '@types/picomatch':
         specifier: 'catalog:'
         version: 3.0.2
@@ -2393,6 +2408,9 @@ packages:
 
   '@types/linkify-it@5.0.0':
     resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
+
+  '@types/markdown-it-emoji@3.0.1':
+    resolution: {integrity: sha512-cz1j8R35XivBqq9mwnsrP2fsz2yicLhB8+PDtuVkKOExwEdsVBNI+ROL3sbhtR5occRZ66vT0QnwFZCqdjf3pA==}
 
   '@types/markdown-it@14.1.2':
     resolution: {integrity: sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==}
@@ -4889,6 +4907,9 @@ packages:
 
   markdown-it-async@2.0.0:
     resolution: {integrity: sha512-jBthmQR5MwXR9Y8Y0teRoZAenaKQMdjuTfpbNARqMBSRPvyzyXCVduHZHakyyhL3ugIacCobXJrO07t277sIjw==}
+
+  markdown-it-emoji@3.0.0:
+    resolution: {integrity: sha512-+rUD93bXHubA4arpEZO3q80so0qgoFJEKRkRbjKX8RTdca89v2kfyF+xR3i2sQTwql9tpPZPOQN5B+PunspXRg==}
 
   markdown-it-footnote@4.0.0:
     resolution: {integrity: sha512-WYJ7urf+khJYl3DqofQpYfEYkZKbmXmwxQV8c8mO/hGIhgZ1wOe7R4HLFNwqx7TjILbnC98fuyeSsin19JdFcQ==}
@@ -7560,7 +7581,7 @@ snapshots:
 
   '@floating-ui/utils@0.2.7': {}
 
-  '@hedgedoc/markdown-it-plugins@2.1.4(markdown-it@14.1.0)':
+  '@hedgedoc/markdown-it-plugins@2.1.4(patch_hash=49e14003b6caa0b7d164cbe71da573809d375babb2012c0a5ac943573e063c90)(markdown-it@14.1.0)':
     dependencies:
       '@mrdrogdrog/optional': 1.2.1
       html-entities: 2.5.2
@@ -8099,6 +8120,10 @@ snapshots:
   '@types/katex@0.16.7': {}
 
   '@types/linkify-it@5.0.0': {}
+
+  '@types/markdown-it-emoji@3.0.1':
+    dependencies:
+      '@types/markdown-it': 14.1.2
 
   '@types/markdown-it@14.1.2':
     dependencies:
@@ -10994,6 +11019,8 @@ snapshots:
     dependencies:
       '@types/markdown-it': 14.1.2
       markdown-it: 14.1.0
+
+  markdown-it-emoji@3.0.0: {}
 
   markdown-it-footnote@4.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,7 @@ packages:
   - docs
 patchedDependencies:
   '@hedgedoc/markdown-it-plugins@2.1.4': patches/@hedgedoc__markdown-it-plugins@2.1.4.patch
+  markdown-it-mdc@0.2.5: patches/markdown-it-mdc.patch
 catalog:
   '@antfu/eslint-config': ^4.8.1
   '@antfu/ni': ^24.1.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -44,6 +44,7 @@ catalog:
   '@types/semver': ^7.5.8
   '@types/vscode': ^1.89.0
   '@types/yargs': ^17.0.33
+  '@types/markdown-it-emoji': ^3.0.1
   '@typescript/ata': ^0.9.7
   '@unhead/vue': ^1.11.20
   '@unocss/extractor-mdc': ^66.0.0
@@ -88,6 +89,7 @@ catalog:
   markdown-it: ^14.1.0
   markdown-it-footnote: ^4.0.0
   markdown-it-mdc: ^0.2.5
+  markdown-it-emoji: ^3.0.0
   mermaid: ^11.4.1
   picomatch: ^4.0.2
   minimist: ^1.2.8


### PR DESCRIPTION
Able to use emoji syntax like GitHub.

For example, `:laughing:` will be rendered as :laughing:.

![image](https://github.com/user-attachments/assets/d2090557-5f7f-471b-984f-dc2eea0bd943)

NOTE: This brings a breaking change: MDC block components shorthand and inline components are not supported anymore.

Closes #2044