### PR TITLE
fix: Use `openInEditor()` instead of `openInEditor`

### DIFF
--- a/demo/starter/slides.md
+++ b/demo/starter/slides.md
@@ -31,7 +31,7 @@ Presentation slides for developers
 </div>
 
 <div class="abs-br m-6 text-xl">
-  <button @click="$slidev.nav.openInEditor" title="Open in Editor" class="slidev-icon-btn">
+  <button @click="$slidev.nav.openInEditor()" title="Open in Editor" class="slidev-icon-btn">
     <carbon:edit />
   </button>
   <a href="https://github.com/slidevjs/slidev" target="_blank" class="slidev-icon-btn">


### PR DESCRIPTION
In the `demo/starter/slides.md` file, the click event for the "Open in Editor" button should use `@click="$slidev.nav.openInEditor()"` instead of `@click="$slidev.nav.openInEditor"`!

Because the `openInEditor` method takes an optional URL string parameter. Using `@click="$slidev.nav.openInEditor"` would end up passing the $event object as the `url` parameter.

In the end, clicking the button will seem like nothing happens (only the network will fail with `/__open-in-editor?file=xxx`requests).

```ts
  async function openInEditor(url?: string) {
    if (!__DEV__)
      return false
    if (url == null) {
      const slide = currentSlideRoute.value?.meta?.slide
      if (!slide)
        return false
      url = `${slide.filepath}:${slide.start}`
    }
    await fetch(`/__open-in-editor?file=${encodeURIComponent(url)}`)
    return true
  }
```
