### PR TITLE
feat(parser): transform slide notes

### DIFF
--- a/docs/custom/config-parser.md
+++ b/docs/custom/config-parser.md
@@ -51,6 +51,7 @@ This example systematically replaces any `@@@` line with a line with `hello`. It
 - An extension can contain:
   - a `transformRawLines(lines)` function that runs just after parsing the headmatter of the md file and receives a list of all lines (from the md file). The function can mutate the list arbitrarily.
   - a `transformSlide(content, frontmatter)` function that is called for each slide, just after splitting the file, and receives the slide content as a string and the frontmatter of the slide as an object. The function can mutate the frontmatter and must return the content string (possibly modified, possibly `undefined` if no modifications have been done).
+  - a `transformNote(note, frontmatter)` function that is called for each slide, just after splitting the file, and receives the slide note as a string or undefined and the frontmatter of the slide as an object. The function can mutate the frontmatter and must return the note string (possibly modified, possibly `undefined` if no modifications have been done).
   - a `name`
 
 ## Example Preparser Extensions

--- a/docs/custom/config-parser.md
+++ b/docs/custom/config-parser.md
@@ -180,3 +180,57 @@ export default definePreparserSetup(() => {
 ```
 
 And that's it.
+
+
+
+### Use case 3: using custom frontmatter to transform note
+
+Imagine a case where you want to replace the slides default notes with custom notes.
+For instance, you might want to write your `slides.md` as follows:
+
+<!-- eslint-skip -->
+
+```md
+---
+layout: quote
+_note: notes/note.md
+---
+
+# Welcome
+
+> great!
+
+<!--
+Default slide notes
+-->
+```
+
+Here we used an underscore in `_note` to avoid possible conflicts with existing frontmatter properties.
+
+To handle this `_note: ...` syntax in the frontmatter, create a `./setup/preparser.ts` file with the following content:
+
+```ts twoslash
+import { definePreparserSetup } from '@slidev/types'
+import fs from 'fs'
+import { promises as fsp } from 'fs'
+
+export default definePreparserSetup(() => {
+  return [
+    {
+      async transformNote(note, frontmatter) {
+        if ('_note' in frontmatter && fs.existsSync(frontmatter._note)) {
+          try {
+            const newNote = await fsp.readFile(frontmatter._note, 'utf8')
+            return newNote
+          } catch (err) {
+          }
+        }
+
+        return note
+      },
+    },
+  ]
+})
+```
+
+And that's it.

--- a/packages/parser/src/core.ts
+++ b/packages/parser/src/core.ts
@@ -155,6 +155,12 @@ export async function parse(
             slide.level = slide.frontmatter.level
           }
         }
+
+        if (e.transformNote) {
+          const newNote = await e.transformNote(slide.note, slide.frontmatter)
+          if (newNote !== undefined)
+            slide.note = newNote
+        }
       }
     }
     slides.push(slide)

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -122,6 +122,7 @@ export interface SlidevPreparserExtension {
   name?: string
   transformRawLines?: (lines: string[]) => Promise<void> | void
   transformSlide?: (content: string, frontmatter: any) => Promise<string | undefined>
+  transformNote?: (note: string | undefined, frontmatter: any) => Promise<string | undefined>
 }
 
 export type PreparserExtensionLoader = (headmatter: Record<string, unknown>, filepath: string, mode?: string) => Promise<SlidevPreparserExtension[]>


### PR DESCRIPTION
## Description

This pull request introduces a new feature to extend the functionality of the Slidev parser. The main addition is the ability to transform slide notes using a new `transformNote` function in the preparser extensions.

### New Feature: Transform Slide Notes

* [`docs/custom/config-parser.md`](diffhunk://#diff-747ec0f013ea2f8a79c740f2e4943b0fdb9f8e3b199e2a1f2b5652840da6965dR54): Added documentation for the `transformNote` function, which allows mutation of slide notes and frontmatter.
* [`packages/parser/src/core.ts`](diffhunk://#diff-9f10be93f50786b3cc60692df26b1049accf4e72b86a1ee97cc7c3111cb550a8R158-R163): Implemented the `transformNote` function to process slide notes during the parsing phase.
* [`packages/types/src/types.ts`](diffhunk://#diff-d504dca5634eaddee93d2c8d0cfad5eb813a89643e13c80f44fdf3a837b3c562R125): Updated the `SlidevPreparserExtension` interface to include the new `transformNote` function.

## Related issue
- #2134

## Notes
As I am not well versed in JS/TS development, I was not able to provide tests for the new functionality. Please feel free to use this PR to add the necessary tests. Thank you for consideration.