### PR TITLE
fix: clear idle cursor timeout when disabling the option or changing to the presenter mode

### DIFF
--- a/packages/client/composables/useHideCursorIdle.ts
+++ b/packages/client/composables/useHideCursorIdle.ts
@@ -17,17 +17,30 @@ export function useHideCursorIdle(
     document.body.style.cursor = ''
   }
 
-  // If disabled, immediately show the cursor
+  let timer: ReturnType<typeof setTimeout> | null = null
+
+  // If disabled, immediately show the cursor and stop the timer
   watch(
     shouldHide,
     (value) => {
-      if (!value)
+      if (!value) {
         show()
+        if (timer) {
+          clearTimeout(timer)
+        }
+        timer = null
+      }
     },
   )
-  onScopeDispose(show)
 
-  let timer: ReturnType<typeof setTimeout> | null = null
+  onScopeDispose(() => {
+    show()
+    if (timer) {
+      clearTimeout(timer)
+    }
+    timer = null
+  })
+
   useEventListener(
     document.body,
     ['pointermove', 'pointerdown'],


### PR DESCRIPTION
Fixes #2146

With this change the timer gets cleared in two scenarios:
1. **Entering the presenter mode with `shouldHide` enabled.** Before the change the timer started in the play mode would finish after switching to the presenter mode and the cursor got stuck in the hidden mode indefinitely.
1. **When the `shouldHide` is disabled via keyboard.** In this scenario the pointer event listener isn't called, so the cursor would hide after disabling the option—this happened only once per toggle, though.