### PR TITLE
fix: encode entry path URI in indexHtml setup

### DIFF
--- a/packages/slidev/node/setups/indexHtml.ts
+++ b/packages/slidev/node/setups/indexHtml.ts
@@ -92,7 +92,7 @@ export default async function setupIndexHtml({ mode, entry, clientRoot, userRoot
   const baseInDev = mode === 'dev' && base ? base.slice(0, -1) : ''
 
   main = main
-    .replace('__ENTRY__', baseInDev + toAtFS(join(clientRoot, 'main.ts')))
+    .replace('__ENTRY__', baseInDev + encodeURI(toAtFS(join(clientRoot, 'main.ts'))))
     .replace('<!-- body -->', body)
 
   const html = await transformHtmlTemplate(unhead, main)


### PR DESCRIPTION
The existing code works fine for standard paths but encounters issues when handling paths containing Unicode characters.  This PR addresses the problem by encoding the paths containing Unicode characters.

fix #2154 