### PR TITLE
fix: incorrect code snippet regex match

### DIFF
--- a/packages/slidev/node/syntax/transform/snippet.ts
+++ b/packages/slidev/node/syntax/transform/snippet.ts
@@ -87,7 +87,7 @@ export function transformSnippet({ s, slide, options }: MarkdownTransformContext
 
   s.replace(
     // eslint-disable-next-line regexp/no-super-linear-backtracking
-    /^<<<\s*(\S.*?)(#[\w-]+)?\s*(?:\s(\S+?))?\s*(\{.*)?$/gm,
+    /^<<<[ \t]*(\S.*?)(#[\w-]+)?[ \t]*(?:[ \t](\S+?))?[ \t]*(\{.*)?$/gm,
     (full, filepath = '', regionName = '', lang = '', meta = '') => {
       const src = slash(
         /^@\//.test(filepath)

--- a/test/__snapshots__/transform-all.test.ts.snap
+++ b/test/__snapshots__/transform-all.test.ts.snap
@@ -96,5 +96,6 @@ function _foo() {
 
 </CodeBlockWrapper>
 
+
 </template>"
 `;


### PR DESCRIPTION
resolve #2087 

## Description

When the code snippet syntax does not specify a specific language, the content below will be incorrectly matched, for example:

````md

<<< @/file-a.js

```bash
# Testing
```

````

Before match result:

<img width="1066" alt="image" src="https://github.com/user-attachments/assets/05449e94-2a1f-450b-8c31-c58a53c1d2ee" />

After this PR:

<img width="1095" alt="image" src="https://github.com/user-attachments/assets/a36901bd-da44-4a8a-a049-55dba3b6380c" />


