### PR TITLE
fix: make sure `at` prop is greater than 0

### DIFF
--- a/packages/client/composables/useClicks.ts
+++ b/packages/client/composables/useClicks.ts
@@ -15,6 +15,10 @@ export function normalizeSingleAtValue(at: RawSingleAtValue): NormalizedSingleCl
     console.error(`Invalid "at" prop value: ${at}`)
     return null
   }
+  if (v <= 0) {
+    console.warn(`[Slidev] "at" prop value must be greater than 0, but got ${at}, has been set to 1`)
+    return 1
+  }
   return v
 }
 


### PR DESCRIPTION
resolve #1611 

## Description

On `shiki-magic-move` and `VSwitch`, when set `at` prop less than 1, the behavior is strange. This PR make sure the `at` prop always greater than 0, and will print a warning message on console when `at` prop less than 1.

|    *   | *   |
| ------ | ---- |
| **Before** | ![CleanShot 2025-05-30 at 15 09 12](https://github.com/user-attachments/assets/947d2e39-4da3-4721-9aac-2800a33df6bc) |
| **After**  | ![CleanShot 2025-05-30 at 15 11 53](https://github.com/user-attachments/assets/058dd6fd-7a83-460d-a46e-8af3bb2bc1fe) |




<details>
<summary>slide content {at:0}</summary>

`````md

---
theme: default
highlighter: shiki
layout: two-cols
layoutClass: gap-10
---

````md magic-move {at:0}
```js
cosnole.log('step 1')
```

```js
cosnole.log('step 2')
```

```js
cosnole.log('step 3')
```
````

::right::

<v-switch at="0">
<template #0>
step 1
</template>
<template #1>
step 2
</template>
<template #2>
step 3
</template>
</v-switch>

---


`````

</details>

