### PR TITLE
fix: inject headers defined in vite config

### DIFF
--- a/packages/slidev/node/vite/extendConfig.ts
+++ b/packages/slidev/node/vite/extendConfig.ts
@@ -190,6 +190,12 @@ export function createConfigPlugin(options: ResolvedSlidevOptions): Plugin {
       return () => {
         server.middlewares.use(async (req, res, next) => {
           if (req.url === '/index.html') {
+            const headers = server.config.server.headers ?? {}
+
+            for (const header in headers) {
+              res.setHeader(header, headers[header]!)
+            }
+
             res.setHeader('Content-Type', 'text/html')
             res.statusCode = 200
             res.end(options.utils.indexHtml)


### PR DESCRIPTION
Hey there! :wave: Thanks for the amazing project! :star_struck: 

This PR fixes an issue that I've run into when trying to use `@webcontainer/api` with `slidev`. The problem is that `slidev` ignores the `server.headers` configuration when serving the initial page.

After this PR, the `headers` field will now be respected for `vite.config.ts` similar to this:

```ts
import { defineConfig } from 'vite';

export default defineConfig({
  server: {
    headers: {
      'Cross-Origin-Embedder-Policy': 'require-corp',
      'Cross-Origin-Opener-Policy': 'same-origin',
    },
  },
});
```

For applying the headers from that field, I've followed the same logic as `vite` does for static assets. See [here](https://github.com/vitejs/vite/blob/54e0a18773be6f6c35d92db5be7f3e6159c23589/packages/vite/src/node/server/middlewares/static.ts#L53-L58).

Let me know if there's anything I should do! :raised_hands: 