### PR TITLE
fix: note style

### DIFF
--- a/packages/client/styles/code.css
+++ b/packages/client/styles/code.css
@@ -123,11 +123,17 @@ html:not(.dark) .shiki span {
 }
 
 /* Inline Code */
+.slidev-note :not(pre) > code,
 .slidev-layout :not(pre) > code {
   font-size: 0.9em;
   background: var(--slidev-code-background);
   border-radius: var(--slidev-code-radius);
   --uno: font-light py-0.5 px-1.5;
+}
+
+.slidev-note :not(pre) > code:after,
+.slidev-note :not(pre) > code:before {
+  content: '';
 }
 
 .slidev-layout :not(pre) > code:before {

--- a/packages/client/uno.config.ts
+++ b/packages/client/uno.config.ts
@@ -53,7 +53,14 @@ export default defineConfig({
   presets: [
     presetWind3(),
     presetAttributify(),
-    presetTypography(),
+    presetTypography({
+      cssExtend: {
+        ul: {
+          'margin': '0',
+          'line-height': 1.75,
+        },
+      },
+    }),
     /* Preset Icons is added in ../node/setups/unocss.ts */
   ],
   transformers: [


### PR DESCRIPTION
resolve #2145
resolve #1712

## Description
This PR fix `lists` and `code block` render styles on presenter notes.

### Before

![before](https://github.com/user-attachments/assets/14483dfb-736b-43da-9370-b1715bae3ec1)

### After

![after](https://github.com/user-attachments/assets/c83adaf8-1344-4e23-b460-6b0bd868dc9c)
