### PR TITLE
fix: next slide preview

### DIFF
--- a/packages/client/pages/presenter.vue
+++ b/packages/client/pages/presenter.vue
@@ -2,7 +2,7 @@
 import { useHead } from '@unhead/vue'
 import { useLocalStorage, useMouse, useWindowFocus } from '@vueuse/core'
 import { computed, onMounted, reactive, ref, shallowRef, watch } from 'vue'
-import { createFixedClicks } from '../composables/useClicks'
+import { createClicksContextBase } from '../composables/useClicks'
 import { useDrawings } from '../composables/useDrawings'
 import { useNav } from '../composables/useNav'
 import { useSwipeControls } from '../composables/useSwipeControls'
@@ -57,7 +57,7 @@ const { timer, isTimerActive, resetTimer, toggleTimer } = useTimer()
 const clicksCtxMap = computed(() => slides.value.map((route) => {
   const clicks = ref(0)
   return {
-    context: createFixedClicks(route, clicks),
+    context: createClicksContextBase(clicks, route?.meta.slide?.frontmatter.clicksStart ?? 0, route?.meta.clicks),
     clicks,
   }
 }))


### PR DESCRIPTION
resolve #2192

## Description

The `clicksContext` for next slide preview should not be fixed. This will cause click system not work normally.


| *          | Inspect the `next preview` container |
| ---------- | ------------------------------------ |
| **Before** | ![before](https://github.com/user-attachments/assets/fba998f1-b9d7-4322-8a51-d2a38e1192d3)|
| **After**  | ![after](https://github.com/user-attachments/assets/871b29ee-09c8-47ae-8176-babbbc299ed0) |


