### PR TITLE
fix: add optional chain to prevent nullish broken

### DIFF
--- a/packages/client/composables/useNav.ts
+++ b/packages/client/composables/useNav.ts
@@ -277,7 +277,7 @@ const useNavState = createSharedComposable((): SlidevContextNavState => {
 
   const query = computed(() => {
     // eslint-disable-next-line ts/no-unused-expressions
-    router.currentRoute.value.query
+    router?.currentRoute?.value?.query
     return new URLSearchParams(location.search)
   })
   const isPrintMode = computed(() => query.value.has('print') || currentRoute.name === 'export')


### PR DESCRIPTION
I have encountered this issue in my own PPT project (which can be a reproduction repo): https://github.com/ShenQingchuan/vue-vine-ppt-2025

![image](https://github.com/user-attachments/assets/b6dc34fa-fe21-4b71-a882-19c48528ccf8)

But it'll be OK after restarting the slidev dev server.

I think it might be caused by my Vue Vine plugin using in setup/main.ts, maybe it's applied before Vue Router and the router instance was not initialized at that moment? I'm not quite sure ...

But I've tried and approved that this line of change works as expected, which is adding optional chain operators.

fix #2047