### PR TITLE
fix(docs): fix GitHub edit links to point to slidev repo in docs files

### DIFF
--- a/docs/.vitepress/showcases.ts
+++ b/docs/.vitepress/showcases.ts
@@ -293,7 +293,7 @@ export const showcases: ShowCaseInfo[] = [
       name: '',
     },
     at: 'Submit your talk/presentation to be list here!',
-    slidesLink: 'https://github.com/slidevjs/docs/edit/main/.vitepress/showcases.ts',
+    slidesLink: 'https://github.com/slidevjs/slidev/edit/main/docs/.vitepress/showcases.ts',
     cover: `${import.meta.env.BASE_URL}theme-placeholder.png`,
     datetime: '2020-1-1',
   },

--- a/docs/.vitepress/themes.ts
+++ b/docs/.vitepress/themes.ts
@@ -514,7 +514,7 @@ export const community: ThemeInfo[] = [
   // Add yours here!
   {
     id: '',
-    link: 'https://github.com/slidevjs/docs/edit/main/.vitepress/themes.ts',
+    link: 'https://github.com/slidevjs/slidev/edit/main/docs/.vitepress/themes.ts',
     name: 'Yours?',
     description: 'Click here to submit your theme :)',
     author: {


### PR DESCRIPTION
docs repo is mirror, so should link to slidev repo.