### PR TITLE
fix(slidev/client):  useNav printRange  currentRoute query undefined

### DIFF
--- a/packages/client/composables/useNav.ts
+++ b/packages/client/composables/useNav.ts
@@ -290,7 +290,7 @@ const useNavState = createSharedComposable((): SlidevContextNavState => {
   const hasPrimarySlide = computed(() => !!currentRoute.params.no)
   const currentSlideNo = computed(() => hasPrimarySlide.value ? getSlide(currentRoute.params.no as string)?.no ?? 1 : 1)
   const currentSlideRoute = computed(() => slides.value[currentSlideNo.value - 1])
-  const printRange = ref(parseRangeString(slides.value.length, currentRoute.query.range as string | undefined))
+  const printRange = ref(parseRangeString(slides.value.length, currentRoute?.query?.range as string | undefined))
 
   const queryClicksRaw = useRouteQuery<string>('clicks', '0')
 


### PR DESCRIPTION
slidev 启动时，偶现页面加载失败

const printRange = ref(parseRangeString(slides.value.length, currentRoute.query.range as string | undefined))

提示currentRoute undefined 无法拿到 query

解决方式
const printRange = ref(parseRangeString(slides.value.length, currentRoute?.query?.range as string | undefined))