### PR TITLE
feat: add pause-by-duration control for SlidevVideo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,103 +1,44 @@
-<br>
-<p align="center">
-<a href="https://sli.dev" target="_blank">
-<img src="https://sli.dev/logo-title.png" alt="Slidev" height="250" width="250"/>
-</a>
-</p>
+# 🎬 SlidevVideo Playback Demo
 
-<p align="center">
-Presentation <b>slide</b>s for <b>dev</b>elopers 🧑‍💻👩‍💻👨‍💻
-</p>
+A simple demo showcasing **multi-step controlled video playback** using `pause` prop.
 
-<p align="center">
-<a href="https://www.npmjs.com/package/@slidev/cli" target="__blank"><img src="https://img.shields.io/npm/v/@slidev/cli?color=2B90B6&label=" alt="NPM version"></a>
-<a href="https://www.npmjs.com/package/@slidev/cli" target="__blank"><img alt="NPM Downloads" src="https://img.shields.io/npm/dm/@slidev/cli?color=349dbe&label="></a>
-<a href="https://sli.dev/" target="__blank"><img src="https://img.shields.io/static/v1?label=&message=docs%20%26%20demos&color=45b8cd" alt="Docs & Demos"></a>
-<a href="https://sli.dev/resources/theme-gallery" target="__blank"><img src="https://img.shields.io/static/v1?label=&message=themes&color=4ec5d4" alt="Themes"></a>
-<br>
-<a href="https://github.com/slidevjs/slidev" target="__blank"><img alt="GitHub stars" src="https://img.shields.io/github/stars/slidevjs/slidev?style=social"></a>
-</p>
+透過 `pause` 參數控制影片分段播放，支援數值與 `'end'`，可用於教學投影片互動控制。
 
-<p align="center">
-  <a href="https://twitter.com/antfu7/status/1389604687502995457">Video Preview</a> | <a href="https://sli.dev">Documentation</a>
-</p>
+---
 
-<div align="center">
-<table>
-<tbody>
-<td align="center">
-<img width="2000" height="0" alt="" aria-hiden><br>
-<sub>Made possible by my <a href="https://github.com/sponsors/antfu">Sponsor Program 💖</a></sub><br>
-<img width="2000" height="0" alt="" aria-hiden>
-</td>
-</tbody>
-</table>
-</div>
-
-## Features
-
-- 📝 [**Markdown-based**](https://sli.dev/guide/syntax) - focus on content and use your favorite editor
-- 🧑‍💻 [**Developer Friendly**](https://sli.dev/guide/syntax#code-blocks) - built-in code highlighting, live coding, etc.
-- 🎨 [**Themable**](https://sli.dev/resources/theme-gallery) - theme can be shared and used with npm packages
-- 🌈 [**Stylish**](https://sli.dev/guide/syntax#embedded-styles) - on-demand utilities via [UnoCSS](https://github.com/unocss/unocss).
-- 🤹 [**Interactive**](https://sli.dev/custom/directory-structure#components) - embedding Vue components seamlessly
-- 🎙 [**Presenter Mode**](https://sli.dev/guide/ui#presenter-mode) - use another window, or even your phone to control your slides
-- 🎨 [**Drawing**](https://sli.dev/features/drawing) - draw and annotate on your slides
-- 🧮 [**LaTeX**](https://sli.dev/features/latex) - built-in LaTeX math equations support
-- 📰 [**Diagrams**](https://sli.dev/guide/syntax#diagrams) - creates diagrams using textual descriptions with [Mermaid](https://mermaid.js.org/)
-- 🌟 [**Icons**](https://sli.dev/features/icons) - access to icons from any icon set directly
-- 💻 [**Editor**](https://sli.dev/guide/index#editor) - integrated editor, or the [VSCode extension](https://sli.dev/features/vscode-extension)
-- 🎥 [**Recording**](https://sli.dev/features/recording) - built-in recording and camera view
-- 📤 [**Portable**](https://sli.dev/guide/exporting) - export into PDF, PNGs, or PPTX
-- ⚡️ [**Fast**](https://vitejs.dev) - instant reloading powered by [Vite](https://vitejs.dev)
-- 🛠 [**Hackable**](https://sli.dev/custom/) - using Vite plugins, Vue components, or any npm packages
-
-## Getting Started
-
-### Try it Online ⚡️
-
-[sli.dev/new](https://sli.dev/new)
-
-[![](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://sli.dev/new)
-
-### Init Project Locally
-
-Install [Node.js >=18](https://nodejs.org/) and run the following command:
+## 🚀 How to Run
 
 ```bash
-npm init slidev
+pnpm install
+pnpm dev
 ```
 
-Documentation:
-**[English](https://sli.dev)** | [中文文档](https://cn.sli.dev) | [Français](https://fr.sli.dev) | [Español](https://es.sli.dev) | [Русский](https://ru.sli.dev) | [Português-BR](https://br.sli.dev)
+Then open [http://localhost:3030](http://localhost:3030)
 
-Discord: [chat.sli.dev](https://chat.sli.dev)
+---
 
-For a full example, you can check the [demo](https://github.com/slidevjs/slidev/blob/main/demo) folder, which is also the source file for [my previous talk](https://antfu.me/posts/composable-vue-vueday-2021).
+## 🌐 Slide Demos | 投影片展示
 
-## Tech Stack
+- 👉 [Home Page](/dev.md)
 
-- [Vite](https://vitejs.dev) - An extremely fast frontend tooling
-- [Vue 3](https://v3.vuejs.org/) powered [Markdown](https://daringfireball.net/projects/markdown/syntax) - Focus on the content while having the power of HTML and Vue components whenever needed
-- [UnoCSS](https://github.com/unocss/unocss) - On-demand utility-first CSS engine, style your slides at ease
-- [Shiki](https://github.com/shikijs/shiki), [Monaco Editor](https://github.com/Microsoft/monaco-editor) - First-class code snippets support with live coding capability
-- [RecordRTC](https://recordrtc.org) - Built-in recording and camera view
-- [VueUse](https://vueuse.org) family - [`@vueuse/core`](https://github.com/vueuse/vueuse), [`@vueuse/motion`](https://github.com/vueuse/motion), etc.
-- [Iconify](https://iconify.design/) - Icon sets collection.
-- [Drauu](https://github.com/antfu/drauu) - Drawing and annotations support
-- [KaTeX](https://katex.org/) - LaTeX math rendering.
-- [Mermaid](https://mermaid-js.github.io/mermaid) - Textual Diagrams.
+---
 
-## Sponsors
+## 💡 Example
 
-This project is made possible by all the sponsors supporting my work:
+```vue
+<SlidevVideo :pause="[3.5, 2.5, 3]" controls>
+  <source src="https://www.w3schools.com/html/mov_bbb.mp4" />
+</SlidevVideo>
+```
 
-<p align="center">
-  <a href="https://github.com/sponsors/antfu">
-    <img src='https://cdn.jsdelivr.net/gh/antfu/static/sponsors.svg' alt="Logos from Sponsors" />
-  </a>
-</p>
+Will play **3.5s**, then pause, then **2.5s**, then pause, then **3s**, then pause, then end.
 
-## License
+---
 
-MIT License © 2021 [Anthony Fu](https://github.com/antfu)
+## 🧩 Credit
+
+Based on [`Slidev`](https://github.com/slidevjs/slidev), with custom `SlidevVideo` component.
+
+```
+
+```

--- a/dev.md
+++ b/dev.md
@@ -1,0 +1,88 @@
+# 🎬 SlidevVideo Demo
+
+> A demo for multi-step controlled playback using `pause=[1, 2, 3, 'end']`  
+> 使用 `pause=[1, 2, 3, 'end']` 控制多段播放的展示
+
+<br>
+<br>
+<br>
+
+### 🌐 Choose Language | 選擇語言
+
+<Link to="2">English</Link>
+<br>
+<Link to="6">中文</Link>
+
+---
+
+# SlidevVideo 1.0 Test: Pause with Decimal Durations
+
+This slide demonstrates the new `pause` feature in `SlidevVideo`:
+
+- ✅ Supports multiple controlled playback segments
+- ✅ Accepts decimal values for pause durations (e.g., `3.5` seconds)
+- ✅ `'end'` is optional — without it, the last segment will stop naturally
+
+---
+
+## Playback Test Example
+
+<SlidevVideo :pause="[3.5, 2.5, 3]" controls>
+  <source src="https://www.w3schools.com/html/mov_bbb.mp4" type="video/mp4" />
+</SlidevVideo>
+
+---
+
+### ⏱️ Expected Playback Flow
+
+1. First click: plays 3.5 seconds, then auto-pauses
+2. Second click: plays 2.5 seconds, then auto-pauses
+3. Third click: plays 3 seconds, then auto-pauses
+4. Fourth click: continues playing until the video ends
+
+---
+
+### Notes
+
+- `'end'` is optional — if omitted, the last segment just ends playback naturally
+- To force a final uninterrupted play-to-end segment, append `'end'` manually:
+  ```html
+  <SlidevVideo :pause="[3.5, 2.5, 3, 'end']"></SlidevVideo>
+  ```
+
+---
+
+# 測試 SlidevVideo 1.0：Pause 支援小數點時間
+
+這頁展示了 `SlidevVideo` 新增的 `pause` 支援：
+
+- ✅ 多段播放控制：每點一次播放指定秒數
+- ✅ 支援小數點秒數（例如 `3.5` 秒）
+- ✅ 可選擇是否加入 `'end'`，若未加則播放到最後自動停止
+
+---
+
+## 播放測試範例
+
+<SlidevVideo :pause="[3.5, 2.5, 3]" controls>
+  <source src="https://www.w3schools.com/html/mov_bbb.mp4" type="video/mp4" />
+</SlidevVideo>
+
+---
+
+### ⏱️ 播放節奏預期
+
+1. 點第一下：播放 3.5 秒後自動暫停
+2. 點第二下：播放 2.5 秒後自動暫停
+3. 點第三下：播放 3 秒後自動暫停
+4. 第四下：會繼續播放到結尾（或結束整段）
+
+---
+
+### 備註
+
+- 可以不必加 `'end'`，預設最後一段播放完就不會卡住
+- 若要強制到最後自動播放到結尾，可明確加 `'end'`：
+  ```html
+  <SlidevVideo :pause="[3.5, 2.5, 3, 'end']"></SlidevVideo>
+  ```


### PR DESCRIPTION
This PR adds support for `pause=[1,2,3,'end']` format in SlidevVideo component.

The video now plays segment-by-segment with user click between segments.
Supports fractional seconds like `[3.5, 2.5, 3]`
Ends with autoplay or manually controlled 'end' keyword.

Fixes #2177 - Clickable Video
