### PR TITLE
fix(client): removed the editor button in ContextMenu when not developing

### DIFF
--- a/packages/client/internals/ContextMenu.vue
+++ b/packages/client/internals/ContextMenu.vue
@@ -67,7 +67,7 @@ const top = computed(() => {
   >
     <template v-for="item, index of currentContextMenu.items.value" :key="index">
       <div v-if="item === 'separator'" :key="index" class="w-full my1 border-t border-main" />
-      <template v-else-if="item.show">
+      <template v-else-if="item.show ?? true">
         <div
           v-if="item.small"
           class="p-2 w-[40px] h-[40px] inline-block text-center cursor-pointer rounded flex"

--- a/packages/client/internals/ContextMenu.vue
+++ b/packages/client/internals/ContextMenu.vue
@@ -67,31 +67,33 @@ const top = computed(() => {
   >
     <template v-for="item, index of currentContextMenu.items.value" :key="index">
       <div v-if="item === 'separator'" :key="index" class="w-full my1 border-t border-main" />
-      <div
-        v-else-if="item.small"
-        class="p-2 w-[40px] h-[40px] inline-block text-center cursor-pointer rounded flex"
-        :class="item.disabled ? `op40` : `hover:bg-active`"
-        :title="(item.label as string)"
-        @click="item.action"
-      >
-        <div v-if="typeof item.icon === 'string'" :class="item.icon" class="text-1.2em ma" />
-        <component :is="item.icon" v-else />
-      </div>
-      <div
-        v-else
-        class="w-full grid grid-cols-[35px_1fr] p-2 pl-0 cursor-pointer rounded"
-        :class="item.disabled ? `op40` : `hover:bg-active`"
-        @click="item.action"
-      >
-        <div class="mx-auto flex">
+      <template v-else-if="item.show">
+        <div
+          v-if="item.small"
+          class="p-2 w-[40px] h-[40px] inline-block text-center cursor-pointer rounded flex"
+          :class="item.disabled ? `op40` : `hover:bg-active`"
+          :title="(item.label as string)"
+          @click="item.action"
+        >
           <div v-if="typeof item.icon === 'string'" :class="item.icon" class="text-1.2em ma" />
           <component :is="item.icon" v-else />
         </div>
-        <div v-if="typeof item.label === 'string'">
-          {{ item.label }}
+        <div
+          v-else
+          class="w-full grid grid-cols-[35px_1fr] p-2 pl-0 cursor-pointer rounded"
+          :class="item.disabled ? `op40` : `hover:bg-active`"
+          @click="item.action"
+        >
+          <div class="mx-auto flex">
+            <div v-if="typeof item.icon === 'string'" :class="item.icon" class="text-1.2em ma" />
+            <component :is="item.icon" v-else />
+          </div>
+          <div v-if="typeof item.label === 'string'">
+            {{ item.label }}
+          </div>
+          <component :is="item.label" v-else />
         </div>
-        <component :is="item.label" v-else />
-      </div>
+      </template>
     </template>
     <template v-if="!isExplicitEnabled">
       <div class="w-full my1 border-t border-main" />

--- a/packages/client/setup/context-menu.ts
+++ b/packages/client/setup/context-menu.ts
@@ -73,6 +73,7 @@ export default () => {
         icon: 'i-carbon:text-annotation-toggle', // IconTextNotationToggle,
         label: showEditor.value ? 'Hide editor' : 'Show editor',
         action: () => (showEditor.value = !showEditor.value),
+        show: __DEV__,
       },
       {
         icon: 'i-carbon:pen',

--- a/packages/types/src/context-menu.ts
+++ b/packages/types/src/context-menu.ts
@@ -3,6 +3,7 @@ import type { Component } from 'vue'
 type ContextMenuOption = {
   action: () => void
   disabled?: boolean
+  show?: boolean
 } & (
   | {
     small?: false


### PR DESCRIPTION
### Problem
The editor button in `ContextMenu.vue` are still visible when `slidev build` (`__DEV__ = false`), but it can't be used after build (it should be a hidden like the button in `NavControls.vue`).

### Solution
1. Extend `ContextMenuOption` type with `show` field
2. Added show field in `contextMenu.ts` for editor item
3. Process rendering in `ContextMenu.vue` with `v-if`

### Impact
- The actions are the same in `ContextMenu.vue` and `NavControls.vue`
- No breaking changes (additive type field)