### PR TITLE
fix: transition should be optional in schema

### DIFF
--- a/packages/vscode/schema/headmatter.json
+++ b/packages/vscode/schema/headmatter.json
@@ -498,10 +498,7 @@
           "description": "Default frontmatter options applied to all slides",
           "markdownDescription": "Default frontmatter options applied to all slides"
         }
-      },
-      "required": [
-        "transition"
-      ]
+      }
     },
     "BuiltinLayouts": {
       "type": "string",


### PR DESCRIPTION
https://sli.dev/guide/animations#slide-transitions says that

> You can enable it by setting the transition frontmatter option.

which implies that not setting this option disables slide transitions, so it should not be considered a required property of the Headmatter in schema.