### PR TITLE
fix: code block error match when includes `twoslash`

### DIFF
--- a/packages/vscode/schema/headmatter.json
+++ b/packages/vscode/schema/headmatter.json
@@ -498,10 +498,7 @@
           "description": "Default frontmatter options applied to all slides",
           "markdownDescription": "Default frontmatter options applied to all slides"
         }
-      },
-      "required": [
-        "transition"
-      ]
+      }
     },
     "BuiltinLayouts": {
       "type": "string",


### PR DESCRIPTION
resolve #2243

## Before
<img width="1184" height="376" alt="image" src="https://github.com/user-attachments/assets/f8576aa1-e82a-46d2-9ca9-f1a6deaeef09" />


## After

<img width="1097" height="352" alt="image" src="https://github.com/user-attachments/assets/f0b401f3-5993-4d66-b084-e99f499c6f57" />
