### PR TITLE
feat: auto generated open graph image respect options

### DIFF
--- a/packages/slidev/node/commands/build.ts
+++ b/packages/slidev/node/commands/build.ts
@@ -94,7 +94,7 @@ export async function build(
         height: Math.round(options.data.config.canvasWidth / options.data.config.aspectRatio),
         routerMode: options.data.config.routerMode,
         waitUntil: 'networkidle',
-        timeout: 30000,
+        timeout: args.timeout || 30000,
         perSlide: true,
         omitBackground: false,
       })

--- a/packages/slidev/node/commands/build.ts
+++ b/packages/slidev/node/commands/build.ts
@@ -97,6 +97,7 @@ export async function build(
         timeout: args.timeout || 30000,
         perSlide: true,
         omitBackground: false,
+        dark: args.dark,
       })
 
       const tempFiles = await fs.readdir(tempDir)


### PR DESCRIPTION
auto generated open graph image respect : 

* `--dark` flag
* `--timeout` option

Closes #2265