### PR TITLE
Add Window Mockup addon to the addon gallery

### DIFF
--- a/docs/.vitepress/addons.ts
+++ b/docs/.vitepress/addons.ts
@@ -192,6 +192,17 @@ export const community: AddonInfo[] = [
     },
     repo: 'https://github.com/AlbertBrand/slidev-addon-hls-player',
   },
+  {
+    id: 'slidev-addon-window-mockup',
+    name: 'Window Mockup',
+    description: 'Styled window frames',
+    tags: ['Component'],
+    author: {
+      name: 'whitphx',
+      link: 'https://github.com/whitphx',
+    },
+    repo: 'https://github.com/whitphx/slidev-addon-window-mockup',
+  },
   // Add yours here!
   {
     id: '',

--- a/packages/vscode/schema/headmatter.json
+++ b/packages/vscode/schema/headmatter.json
@@ -498,7 +498,10 @@
           "description": "Default frontmatter options applied to all slides",
           "markdownDescription": "Default frontmatter options applied to all slides"
         }
-      }
+      },
+      "required": [
+        "transition"
+      ]
     },
     "BuiltinLayouts": {
       "type": "string",


### PR DESCRIPTION
I created https://github.com/whitphx/slidev-addon-window-mockup so plz let me add it to the gallery.