### PR TITLE
fix(slidev,vscode): use `property` for slidev meta entry in head

### DIFF
--- a/packages/slidev/node/setups/indexHtml.ts
+++ b/packages/slidev/node/setups/indexHtml.ts
@@ -78,7 +78,7 @@ export default async function setupIndexHtml({ mode, entry, clientRoot, userRoot
         meta: [
           { 'http-equiv': 'Content-Type', 'content': 'text/html; charset=UTF-8' },
           { property: 'slidev:version', content: version },
-          { charset: 'slidev:entry', content: mode === 'dev' && slash(entry) },
+          { property: 'slidev:entry', content: mode === 'dev' && slash(entry) },
           { name: 'description', content: description },
           { name: 'author', content: author ? toAttrValue(author) : null },
           { name: 'keywords', content: keywords ? toAttrValue(Array.isArray(keywords) ? keywords.join(', ') : keywords) : null },

--- a/packages/vscode/src/composables/useServerDetector.ts
+++ b/packages/vscode/src/composables/useServerDetector.ts
@@ -1,8 +1,8 @@
 import type { Ref } from 'reactive-vscode'
 import { reactive, watch } from 'reactive-vscode'
 
-const versionRE = /<meta name="slidev:version" content="([^"]+)">/
-const entryRE = /<meta charset="slidev:entry" content="([^"]+)">/
+const versionRE = /<meta (name|property)="slidev:version" content="([^"]+)">/
+const entryRE = /<meta (property|charset)="slidev:entry" content="([^"]+)">/
 
 export function useServerDetector(port: Ref<number | null>, ensureEntry?: string) {
   const state = reactive({


### PR DESCRIPTION
this had been troubling me for a bit

<img width="532" height="142" alt="SCR-20250920-hlmm" src="https://github.com/user-attachments/assets/9ae219fb-f271-43e6-84e8-02c12a708694" />

you may have had a reason for using `charset` that I'm not aware of, however!