### PR TITLE
feat: add copy button for Shiki Magic Move code block

### DIFF
--- a/packages/parser/src/config.ts
+++ b/packages/parser/src/config.ts
@@ -32,6 +32,7 @@ export function getDefaultConfig(): SlidevConfig {
     drawings: {} as ResolvedDrawingsOptions,
     plantUmlServer: 'https://www.plantuml.com/plantuml',
     codeCopy: true,
+    magicMoveCopy: true,
     author: '',
     record: 'dev',
     css: 'unocss',

--- a/packages/types/src/frontmatter.ts
+++ b/packages/types/src/frontmatter.ts
@@ -53,6 +53,15 @@ export interface HeadmatterConfig extends TransitionOptions {
    */
   codeCopy?: boolean
   /**
+   * Show copy button in magic move code blocks
+   *
+   * `'final'` for only show copy button on the final step
+   * `'always'` or `true` for show copy button on all steps
+   *
+   * @default true
+   */
+  magicMoveCopy?: boolean | 'final' | 'always'
+  /**
    * The author of the slides
    */
   author?: string

--- a/packages/vscode/schema/headmatter.json
+++ b/packages/vscode/schema/headmatter.json
@@ -181,11 +181,15 @@
             },
             {
               "type": "string",
-              "enum": ["final", "always"]
+              "const": "final"
+            },
+            {
+              "type": "string",
+              "const": "always"
             }
           ],
-          "description": "Show copy button in magic move code blocks. false: No copy button, 'final': Only on final step, 'always': On all steps, true: Same as 'always'",
-          "markdownDescription": "Show copy button in magic move code blocks.\n- `false` - No copy button\n- `'final'` - Only show copy button on the final step\n- `'always'` - Show copy button on all steps\n- `true` - Same as `'always'`",
+          "description": "Show copy button in magic move code blocks\n\n`'final'` for only show copy button on the final step `'always'` or `true` for show copy button on all steps",
+          "markdownDescription": "Show copy button in magic move code blocks\n\n`'final'` for only show copy button on the final step\n`'always'` or `true` for show copy button on all steps",
           "default": true
         },
         "author": {

--- a/packages/vscode/schema/headmatter.json
+++ b/packages/vscode/schema/headmatter.json
@@ -174,6 +174,20 @@
           "markdownDescription": "Show a copy button in code blocks",
           "default": true
         },
+        "magicMoveCopy": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string",
+              "enum": ["final", "always"]
+            }
+          ],
+          "description": "Show copy button in magic move code blocks. false: No copy button, 'final': Only on final step, 'always': On all steps, true: Same as 'always'",
+          "markdownDescription": "Show copy button in magic move code blocks.\n- `false` - No copy button\n- `'final'` - Only show copy button on the final step\n- `'always'` - Show copy button on all steps\n- `true` - Same as `'always'`",
+          "default": true
+        },
         "author": {
           "type": "string",
           "description": "The author of the slides",


### PR DESCRIPTION
Added copy button support for Shiki Magic Move code block.

Add new configuration for slides - `magicMoveCopy`:
- `false`: Disable copy button
- `'final'`: Show copy button only on the final step
- `true`/`'always'`: Show copy button on all steps (default)

Copy button in magic move code block respects the global `codeCopy` setting (if `codeCopy` is disabled, the magic move copy button will always be hidden) and it copies the current step's code content.

Hope this helps!

Closes #2255