### PR TITLE
fix: make `v-click` work with LightOrDark by wrapping slots in a div

### DIFF
--- a/packages/client/builtin/LightOrDark.vue
+++ b/packages/client/builtin/LightOrDark.vue
@@ -3,6 +3,8 @@ import { isDark } from '../logic/dark'
 </script>
 
 <template>
-  <slot v-if="isDark" name="dark" />
-  <slot v-else name="light" />
+  <div>
+    <slot v-if="isDark" name="dark" />
+    <slot v-else name="light" />
+  </div>
 </template>


### PR DESCRIPTION
The `v-click` directive did not work on the `LightOrDark` component. Wrapping the slots in a <div> inside `LightOrDark` ensures `v-click` attaches to a real DOM element.

In fact, we could simply write

```vue
<div v-click>
  <LightOrDark>
    <template #dark>Dark theme in use</template>
    <template #light>Light theme in use</template>
  </LightOrDark>
</div>
```

to achieve the same effect, so I’m not sure if this change is meaningful enough. However, it does make usage involving LightOrDark a bit more concise.

Fixes #2271