### PR TITLE
[DRAFT] Add speedrunning-inspired split timing support

### DIFF
--- a/demo/starter/slides.md
+++ b/demo/starter/slides.md
@@ -45,6 +45,7 @@ The last comment block of each slide will be treated as slide notes. It will be 
 
 ---
 transition: fade-out
+split: 30
 ---
 
 # What is Slidev?
@@ -87,6 +88,7 @@ Here is another comment.
 ---
 transition: slide-up
 level: 2
+split: 60
 ---
 
 # Navigation

--- a/packages/client/composables/useNav.ts
+++ b/packages/client/composables/useNav.ts
@@ -5,7 +5,7 @@ import { slides } from '#slidev/slides'
 import { clamp } from '@antfu/utils'
 import { parseRangeString } from '@slidev/parser/utils'
 import { createSharedComposable } from '@vueuse/core'
-import { computed, ref, watch } from 'vue'
+import { computed, ref, toRaw, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { CLICKS_MAX } from '../constants'
 import { configs } from '../env'
@@ -291,6 +291,16 @@ const useNavState = createSharedComposable((): SlidevContextNavState => {
   const currentSlideNo = computed(() => hasPrimarySlide.value ? getSlide(currentRoute.params.no as string)?.no ?? 1 : 1)
   const currentSlideRoute = computed(() => slides.value[currentSlideNo.value - 1])
   const printRange = ref(parseRangeString(slides.value.length, currentRoute?.query?.range as string | undefined))
+
+  watch(currentSlideRoute, () => {
+    window.dispatchEvent(new CustomEvent('slidev-slide-changed', {
+      detail: {
+        slideNumber: currentSlideNo.value,
+        slide: toRaw(currentSlideRoute.value?.meta.slide),
+        frontmatter: toRaw(currentSlideRoute.value?.meta.slide.frontmatter),
+      },
+    }))
+  })
 
   const queryClicksRaw = useRouteQuery<string>('clicks', '0')
 

--- a/packages/client/pages/presenter.vue
+++ b/packages/client/pages/presenter.vue
@@ -88,6 +88,21 @@ const SideEditor = shallowRef<any>()
 if (__DEV__ && __SLIDEV_FEATURE_EDITOR__)
   import('../internals/SideEditor.vue').then(v => SideEditor.value = v.default)
 
+function parseTimerString(timeString: string) {
+  const [seconds, minutes = 0, hours = 0] = timeString.split(':').toReversed().map(n => Number.parseInt(n, 10))
+  return hours * 3600 + minutes * 60 + seconds
+}
+
+window.addEventListener('slidev-slide-changed', (e) => {
+  const timerCounter = parseTimerString(timer.value)
+  const splitCounter = typeof (e as CustomEvent).detail.frontmatter.split === 'string' ? parseTimerString((e as CustomEvent).detail.frontmatter.split) : (e as CustomEvent).detail.frontmatter.split || 0
+
+  if (splitCounter) {
+    const delta = timerCounter - splitCounter
+    console.warn('delta', delta)
+  }
+})
+
 // sync presenter cursor
 onMounted(() => {
   const slidesContainer = main.value!.querySelector('#slide-content')!


### PR DESCRIPTION
## Motivation

When I give talks, I find it hard to know how I am doing for pacing.
The timer helps, but knowing how far off I am at specific points in the presentation would be very helpful.

In the speedrunning community, they use tools that look a bit like this:
<img width="286" height="519" alt="image" src="https://github.com/user-attachments/assets/01461145-f2b0-42fc-a163-cf541ba5bebf" />

## Demo code

This PR is specifically for getting the idea and feature discussed. The implementation is very naively done and I will happily write it in a more idiomatic way rather than the event listener approach.

## Questions

1. Is this a feature that would be accepted (assuming it is implemented better)?
2. Do you have any specific opinions about where in the presenter view this should live?
3. What would be the ideal implementation? A custom `useSplits` hook? This would be useful for a custom component that users may want to put on their slides directly if they don't use presenter view.