### PR TITLE
fix: prevent hotkeys when typing in monaco editor

### DIFF
--- a/packages/client/logic/shortcuts.ts
+++ b/packages/client/logic/shortcuts.ts
@@ -6,11 +6,11 @@ import { and, not } from '@vueuse/math'
 import { watch } from 'vue'
 import { useNav } from '../composables/useNav'
 import setupShortcuts from '../setup/shortcuts'
-import { fullscreen, isInputting, isOnFocus, magicKeys, shortcutsEnabled } from '../state'
+import { fullscreen, isInputting, isOnFocus, magicKeys, shortcutsEnabled, shortcutsLocked } from '../state'
 
 export function registerShortcuts() {
   const { isPrintMode } = useNav()
-  const enabled = and(not(isInputting), not(isOnFocus), not(isPrintMode), shortcutsEnabled)
+  const enabled = and(not(isInputting), not(isOnFocus), not(isPrintMode), shortcutsEnabled, not(shortcutsLocked))
 
   const allShortcuts = setupShortcuts()
   const shortcuts = new Map<string | Ref<boolean>, ShortcutOptions>(

--- a/packages/client/setup/monaco.ts
+++ b/packages/client/setup/monaco.ts
@@ -20,7 +20,7 @@ import { SyncDescriptor } from 'monaco-editor/esm/vs/platform/instantiation/comm
 import ts from 'typescript'
 import { watchEffect } from 'vue'
 import { isDark } from '../logic/dark'
-import { lockShortcuts, releaseShortcuts } from '../state'
+import { lockShortcuts } from '../state'
 
 window.MonacoEnvironment = {
   getWorker(_, label) {
@@ -100,15 +100,13 @@ const setup = createSingletonPromise(async () => {
 
   // Disable shortcuts when focusing Monaco editor.
   monaco.editor.onDidCreateEditor((editor) => {
-    let lock: symbol | null = null
+    let release: (() => void) | null = null
     editor.onDidFocusEditorWidget(() => {
-      lock = lockShortcuts()
+      release = lockShortcuts()
     })
     editor.onDidBlurEditorWidget(() => {
-      if (lock != null) {
-        releaseShortcuts(lock)
-        lock = null
-      }
+      release?.()
+      release = null
     })
   })
 

--- a/packages/client/state/storage.ts
+++ b/packages/client/state/storage.ts
@@ -1,6 +1,6 @@
 import type { DragElementState } from '../composables/useDragElements'
 import { breakpointsTailwind, isClient, useActiveElement, useBreakpoints, useFullscreen, useLocalStorage, useMagicKeys, useToggle, useWindowSize } from '@vueuse/core'
-import { computed, ref, shallowRef } from 'vue'
+import { computed, reactive, ref, shallowRef } from 'vue'
 import { slideAspect } from '../env'
 
 export const showRecordingDialog = ref(false)
@@ -15,28 +15,26 @@ export const showOverview = ref(false)
 export const hmrSkipTransition = ref(false)
 export const disableTransition = ref(false)
 
-const mutableShortcutsEnabled = ref(true)
+export const shortcutsEnabled = ref(true)
+
 /**
  * Whether the keyboard shortcuts are enabled. Readonly,
  * use `lockShortcuts` and `releaseShortcuts` to modify.
  */
-export const shortcutsEnabled = computed(() => mutableShortcutsEnabled.value)
 
 // Use a locking mechanism to support multiple simultaneous locks
 // and avoid race conditions. Race conditions may occur, for example,
 // when locking shortcuts on editor focus and moving from one editor
 // to another, as blur events can be triggered after focus.
-const shortcutsLocks = new Set<symbol>()
+const shortcutsLocks = reactive(new Set<symbol>())
+
+export const shortcutsLocked = computed(() => shortcutsLocks.size > 0)
+
 export function lockShortcuts() {
   const lock = Symbol('shortcuts lock')
   shortcutsLocks.add(lock)
-  mutableShortcutsEnabled.value = false
-  return lock
-}
-export function releaseShortcuts(lock: symbol) {
-  shortcutsLocks.delete(lock)
-  if (shortcutsLocks.size === 0) {
-    mutableShortcutsEnabled.value = true
+  return () => {
+    shortcutsLocks.delete(lock)
   }
 }
 


### PR DESCRIPTION
Prevent Slidev hotkeys from triggering when typing in the editor in Chromium-based browsers.

Fixes #2297.