### PR TITLE
fix: make useIsSlideActive() based on useSlideContext().$nav.currentSlideNo instead of useNav().currentSlideNo

### DIFF
--- a/packages/client/logic/slides.ts
+++ b/packages/client/logic/slides.ts
@@ -24,7 +24,7 @@ export function getSlidePath(
 
 export function useIsSlideActive() {
   const { $page, $nav } = useSlideContext()
-  return computed(() => $page.value === $nav.value.currentSlideNo)
+  return computed(() => $page.value === $nav.value.currentSlideNo) // Use `$nav.value.currentSlideNo` rather than `useNav().currentSlideNo` to make it work in print/export mode. See https://github.com/slidevjs/slidev/issues/2310.
 }
 
 export function onSlideEnter(cb: () => void) {


### PR DESCRIPTION
Because useNav().currentSlideNo is just a value parsed from the URL route but useSlideContext().$nav.currentSlideNo is a more controlled value that even works in print/export mode.

Fixes #2310

Let me create this PR before the discussion in #2310 is settled just for dumping and proposing my current idea. Plz decline it if it's not appropriate.