### PR TITLE
fix: `exportFilename` generates PDF outside dist folder and creates incorrect download links

### DIFF
--- a/packages/slidev/node/commands/build.ts
+++ b/packages/slidev/node/commands/build.ts
@@ -138,10 +138,11 @@ export async function build(
       }),
     )
     server.listen(port)
+    const filename = options.data.config.exportFilename || 'slidev-exported'
     await exportSlides({
       port,
       base: config.base,
-      ...getExportOptions(args, options, join(outDir, 'slidev-exported.pdf')),
+      ...getExportOptions(args, options, join(outDir, `${filename}.pdf`)),
     })
     server.close()
   }

--- a/packages/slidev/node/commands/export.ts
+++ b/packages/slidev/node/commands/export.ts
@@ -587,7 +587,7 @@ export function getExportOptions(args: ExportArgs, options: ResolvedSlidevOption
     scale,
     omitBackground,
   } = config
-  outFilename = output || options.data.config.exportFilename || outFilename || `${path.basename(entry, '.md')}-export`
+  outFilename = output || outFilename || options.data.config.exportFilename || `${path.basename(entry, '.md')}-export`
   return {
     output: outFilename,
     slides: options.data.slides,


### PR DESCRIPTION
This PR proposes a fix for issue #2312 

The computation of the PDF path is now centralized in the `packages/slidev/node/commands/build.ts` file. This applies whether the filename is the default one or set via `exportFilename`. Previously, this computation was only performed for the default filename.