### PR TITLE
fix: export respect page range

### DIFF
--- a/packages/slidev/node/commands/export.ts
+++ b/packages/slidev/node/commands/export.ts
@@ -420,10 +420,17 @@ export async function exportSlides({
     await go('print')
     const slideContainers = page.locator('.print-slide-container')
     const count = await slideContainers.count()
+
     for (let i = 0; i < count; i++) {
-      progress.update(i + 1)
       const id = (await slideContainers.nth(i).getAttribute('id')) || ''
       const slideNo = +id.split('-')[0]
+
+      // Only process slides that are in the specified range
+      if (!pages.includes(slideNo))
+        continue
+
+      progress.update(result.length + 1)
+
       const buffer = await slideContainers.nth(i).screenshot({
         omitBackground,
       })
@@ -476,12 +483,15 @@ export async function exportSlides({
 
   async function genPageMd() {
     const pngs = await genPagePng(dirname(output))
-    const content = slides.map(({ title, index, note }) =>
-      pngs.filter(({ slideIndex }) => slideIndex === index)
-        .map(({ filename }) => `![${title || (index + 1)}](./${filename})\n\n`)
-        .join('')
-        + (note ? `${note.trim()}\n\n` : ''),
-    ).join('---\n\n')
+    const content = slides
+      .filter(({ index }) => pages.includes(index + 1))
+      .map(({ title, index, note }) =>
+        pngs.filter(({ slideIndex }) => slideIndex === index)
+          .map(({ filename }) => `![${title || (index + 1)}](./${filename})\n\n`)
+          .join('')
+          + (note ? `${note.trim()}\n\n` : ''),
+      )
+      .join('---\n\n')
     await fs.writeFile(ensureSuffix('.md', output), content)
   }
 


### PR DESCRIPTION
<!-- AI_TEMPLATE_START: This is a structured PR description template for AI processing -->

## Summary

<!-- AI_INSTRUCTION: Provide a clear, concise explanation of what changed and why. Focus on the business value and technical impact. -->

This PR fixes a bug in the export functionality where the `--range` parameter was not properly respected during slide export. Previously, when users specified a page range for export (e.g., `--range 1-5`), the export process would iterate through all slides but only filter the range when determining which pages to export. This resulted in incorrect progress tracking and unnecessary processing of slides outside the specified range.

The fix ensures that only slides within the specified page range are processed and exported, improving both performance and accuracy of the export functionality.

Fix #2227

### Key Changes

<!-- AI_INSTRUCTION: List the most important changes made in this PR. Use bullet points for clarity. -->

- **PNG/Screenshot Export**: Modified the screenshot capture loop in `exportSlides` to skip slides outside the specified range before processing, preventing unnecessary screenshot operations (`packages/slidev/node/commands/export.ts:428-430`)
- **Progress Tracking**: Updated progress counter to accurately reflect the number of slides being processed (based on filtered results) rather than total slide count (`packages/slidev/node/commands/export.ts:432`)
- **Markdown Export**: Added filtering in `genPageMd()` to only include slides within the specified page range when generating markdown output (`packages/slidev/node/commands/export.ts:486`)

## Type of Change

<!-- AI_INSTRUCTION: Check ALL applicable boxes based on the code changes. Use [x] to mark selected items. -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] ♻️ Refactoring (no functional changes)
- [ ] 🎨 Style/formatting changes
- [ ] 🧪 Test improvements
- [ ] 🔧 Configuration changes

## Test Plan

<!-- AI_INSTRUCTION: Provide specific testing instructions. Include both manual and automated testing steps. -->

### Manual Testing

- Export slides with a specific page range (e.g., `slidev export --range 1-3`) and verify that only slides 1-3 are included in the output
- Export slides to PNG format with range parameter and confirm that only the specified slides generate PNG files
- Export slides to markdown format with range parameter and verify the markdown output only contains the specified slides
- Test edge cases: single slide range (`--range 5`), non-contiguous ranges (`--range 1-3,7-9`), and full range to ensure backward compatibility

## Breaking Changes

<!-- AI_INSTRUCTION: If this is a breaking change, provide detailed migration instructions. If no breaking changes, write "None" -->

None

## Checklist

<!-- AI_INSTRUCTION: Check ALL completed items. Ensure all items are addressed before marking as ready for review. -->

- [x] 📝 Code follows the style guidelines
- [x] 👀 Self-review has been performed
- [ ] 🧪 Tests have been added/updated
- [ ] 📖 Documentation has been updated

<!-- AI_TEMPLATE_END -->