### PR TITLE
feat: support `.svg` file icon in code block titles

### DIFF
--- a/packages/client/internals/TitleIcon.vue
+++ b/packages/client/internals/TitleIcon.vue
@@ -61,6 +61,7 @@ const builtinIcons: Record<string, string> = {
   '.yml': 'i-vscode-icons:file-type-light-yaml',
   '.yaml': 'i-vscode-icons:file-type-light-yaml',
   '.php': 'i-vscode-icons:file-type-php',
+  '.svg': 'i-vscode-icons:file-type-svg',
 }
 
 function matchIcon(title: string) {


### PR DESCRIPTION
Enables SVG file icon display when using `[file.svg]` syntax in code blocks.

````md
```html [vue.svg]
<svg xmlns="http://www.w3.org/2000/svg" width="37.07" height="36" viewBox="0 0 256 198">
  <path fill="#41B883" d="m0 0l128 220.8L256 0h-51.2L128 132.48L50.56 0H0Z"></path>
  <path fill="#35495E" d="M50.56 0L128 133.12L204.8 0h-47.36L128 51.2L97.92 0H50.56Z"></path>
</svg>
```
````

**Before**
<img width="399" height="286" alt="截圖 2025-11-01 下午4 17 16" src="https://github.com/user-attachments/assets/07baebd8-581e-4a90-832b-89ec05b7383b" />

**After**
<img width="400" height="270" alt="截圖 2025-11-01 下午4 21 48" src="https://github.com/user-attachments/assets/115ad2de-369c-43a0-a14c-6f263570ca85" />
