### PR TITLE
feat: use strict mode in monaco run (configurable)

### DIFF
--- a/packages/client/constants.ts
+++ b/packages/client/constants.ts
@@ -66,6 +66,7 @@ export const HEADMATTER_FIELDS = [
   'monacoTypesSource',
   'monacoTypesAdditionalPackages',
   'monacoRunAdditionalDeps',
+  'monacoRunUseStrict',
   'remoteAssets',
   'selectable',
   'record',

--- a/packages/client/setup/code-runners.ts
+++ b/packages/client/setup/code-runners.ts
@@ -5,6 +5,7 @@ import deps from '#slidev/monaco-run-deps'
 import setups from '#slidev/setups/code-runners'
 import { createSingletonPromise } from '@antfu/utils'
 import { ref } from 'vue'
+import { configs } from '../env'
 
 export default createSingletonPromise(async () => {
   const runners: Record<string, CodeRunner> = {
@@ -63,6 +64,7 @@ function runJavaScript(code: string): CodeRunnerOutputs {
   vmConsole.clear = () => result.value.length = 0
   try {
     const safeJS = `return async (console, __slidev_import, __slidev_on_error) => {
+    ${configs.monacoRunUseStrict ? `"use strict";` : ''}
       try {
         ${sanitizeJS(code)}
       } catch (e) {

--- a/packages/parser/src/config.ts
+++ b/packages/parser/src/config.ts
@@ -14,6 +14,7 @@ export function getDefaultConfig(): SlidevConfig {
     monacoTypesAdditionalPackages: [],
     monacoTypesIgnorePackages: [],
     monacoRunAdditionalDeps: [],
+    monacoRunUseStrict: true,
     download: false,
     export: {} as ResolvedExportOptions,
     info: false,

--- a/packages/types/src/frontmatter.ts
+++ b/packages/types/src/frontmatter.ts
@@ -265,6 +265,12 @@ export interface HeadmatterConfig extends TransitionOptions {
    */
   monacoRunAdditionalDeps?: string[]
   /**
+   * Whether to run monaco runnable code in strict mode
+   *
+   * @default true
+   */
+  monacoRunUseStrict?: boolean
+  /**
    * Seo meta tags settings
    *
    * @default {}

--- a/packages/vscode/schema/headmatter.json
+++ b/packages/vscode/schema/headmatter.json
@@ -505,6 +505,12 @@
           "markdownDescription": "Additional local modules to load as dependencies of monaco runnable",
           "default": []
         },
+        "monacoRunUseStrict": {
+          "type": "boolean",
+          "description": "Whether to run monaco runnable code in strict mode",
+          "markdownDescription": "Whether to run monaco runnable code in strict mode",
+          "default": true
+        },
         "seoMeta": {
           "$ref": "#/definitions/SeoMeta",
           "description": "Seo meta tags settings",


### PR DESCRIPTION
This PR adds the `monacoRunUseStrict` headmatter config that is `true` by default.

When `monacorRunUseStrict` is `true`, monaco js runner runs code in strict mode (it used to be loose). This is done by (optionally) adding `"use strict";` at the beginning of the created function.

This can be tested with the following snippet in a run monaco editor:
```js
function getThis(){
  return this;
}
console.log(typeof getThis());  // 'undefined' in strict mode, 'object' in loose mode
```

**Rational:** I'm using slidev to teach JS, including dealing with `this`. I don't teach loose mode, I tell students to use strict.

**Breaking change:** monaco now runs in strict mode by default (I find it makes more sense than loose by default, but that may be changed in `packages/parser/src/config.ts` if avoiding a breaking change is preferred).