### PR TITLE
fix: fix broken cli (v52.7.0 regression)

### DIFF
--- a/packages/slidev/bin/slidev.mjs
+++ b/packages/slidev/bin/slidev.mjs
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
 'use strict'
-import ('../dist/cli.js')
+import('../dist/cli.mjs')


### PR DESCRIPTION
Release 52.7.0 broke slidev's cli because build now creates `.mjs` files, but `bin/slidev.mjs` still attempts to import `../dist/cli.js`.

This PR updates the import to fix it.

Fixes #2335