### PR TITLE
feat: make magic move duration configurable

### DIFF
--- a/packages/client/builtin/ShikiMagicMove.vue
+++ b/packages/client/builtin/ShikiMagicMove.vue
@@ -36,7 +36,7 @@ const props = defineProps({
   },
   duration: {
     type: Number,
-    default: 800,
+    default: configs.magicMoveDuration,
   },
 })
 

--- a/packages/client/constants.ts
+++ b/packages/client/constants.ts
@@ -85,4 +85,5 @@ export const HEADMATTER_FIELDS = [
   'wakeLock',
   'seoMeta',
   'notesAutoRuby',
+  'magicMoveDuration',
 ]

--- a/packages/parser/src/config.ts
+++ b/packages/parser/src/config.ts
@@ -49,6 +49,7 @@ export function getDefaultConfig(): SlidevConfig {
     notesAutoRuby: {},
     duration: '30min',
     timer: 'stopwatch',
+    magicMoveDuration: 800,
   }
 }
 

--- a/packages/types/src/frontmatter.ts
+++ b/packages/types/src/frontmatter.ts
@@ -299,6 +299,12 @@ export interface HeadmatterConfig extends TransitionOptions {
    * @default 'stopwatch'
    */
   timer?: 'stopwatch' | 'countdown'
+  /**
+   * Duration for shiki magic move transitions in milliseconds
+   *
+   * @default 800
+   */
+  magicMoveDuration?: number
 }
 
 export interface Frontmatter extends TransitionOptions {

--- a/packages/vscode/schema/headmatter.json
+++ b/packages/vscode/schema/headmatter.json
@@ -539,6 +539,12 @@
           "markdownDescription": "Timer mode",
           "default": "stopwatch"
         },
+        "magicMoveDuration": {
+          "type": "number",
+          "description": "Duration for shiki magic move transitions in milliseconds",
+          "markdownDescription": "Duration for shiki magic move transitions in milliseconds",
+          "default": 800
+        },
         "defaults": {
           "$ref": "#/definitions/Frontmatter",
           "description": "Default frontmatter options applied to all slides",


### PR DESCRIPTION
- Add the `magicMoveDuration` headmatter config to set shiki magic move duration (800ms by default)
- Add the `duration` prop to `ShikiMagicMove` (defaults to `magicMoveDuration` config)