### PR TITLE
docs: use LaTeX/KaTeX logo in starter demo

### DIFF
--- a/demo/starter/slides.md
+++ b/demo/starter/slides.md
@@ -451,9 +451,9 @@ const final = {
 
 ---
 
-# LaTeX
+# $\LaTeX$
 
-LaTeX is supported out-of-box. Powered by [KaTeX](https://katex.org/).
+$\LaTeX$ is supported out-of-box. Powered by [$\KaTeX$](https://katex.org/).
 
 <div h-3 />
 


### PR DESCRIPTION
This PR updates the starter demo (`demo/starter/slides.md`) to use the official logo commands for LaTeX/KaTeX in the math section.

- `LaTeX` -> `$\LaTeX$`
- `KaTeX` -> `$\KaTeX$`

Since Slidev supports math rendering out of the box, showing the logo syntax directly in the starter slides better demonstrates how inline math works and matches the official branding of LaTeX/KaTeX.

No behavior changes other than the rendered text on the demo slide.