### PR TITLE
docs: add japanese entry

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -157,5 +157,9 @@ export default defineConfig({
       label: '简体中文',
       link: 'https://cn.sli.dev/',
     },
+    ja: {
+      label: '日本語',
+      link: 'https://ja.sli.dev/',
+    },
   },
 })


### PR DESCRIPTION
Added i18n entry to the Japanese documentation.

ref: https://github.com/slidevjs/docs-ja/pull/8?notification_referrer_id=NT_kwDOA-cgWLQyMDc3MTQ0MTY2NDo2NTQ3ODc0NA&notifications_query=is%3Adone#issuecomment-3587650088