### PR TITLE
docs: toggle vite-plugin-llms by document language

### DIFF
--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -7,6 +7,9 @@ import { defineConfig } from 'vite'
 import Inspect from 'vite-plugin-inspect'
 import { groupIconVitePlugin } from 'vitepress-plugin-group-icons'
 import llmstxt from 'vitepress-plugin-llms'
+import config from './.vitepress/config'
+
+const IS_ROOT_ENGLISH_DOC = config.locales?.root.label.includes('English') || false
 
 export default defineConfig({
   optimizeDeps: {
@@ -22,7 +25,7 @@ export default defineConfig({
     },
   },
   plugins: [
-    llmstxt({
+    IS_ROOT_ENGLISH_DOC && llmstxt({
       ignoreFiles: [
         'index.md',
         'README.md',


### PR DESCRIPTION
This pull request introduces a conditional plugin loading mechanism in the Vite configuration for the documentation site. The main change ensures that the `llmstxt` plugin is only loaded when the root locale label includes "English", optimizing the build process for different language documents.

**Plugin loading improvements:**

* Added logic to check if the root locale label includes "English" by importing the config and evaluating `config.locales?.root.label` in `docs/vite.config.ts`.
* Updated the plugins array to load the `llmstxt` plugin only when the documentation is in English, preventing unnecessary plugin execution for other locales. (https://github.com/okineadev/vitepress-plugin-llms/blob/1b5aeadb0274836e72d63e48b8aaa0075c0905fc/README.md?plain=1#L49-L51)

ref: https://github.com/slidevjs/docs-ja/issues/10