### PR TITLE
fix: resolver should prioritize prefixed addons/themes again

### DIFF
--- a/packages/slidev/node/resolver.ts
+++ b/packages/slidev/node/resolver.ts
@@ -151,7 +151,7 @@ export function createResolver(type: 'theme' | 'addon', officials: Record<string
       const possiblePkgNames = [name]
 
       if (!name.includes('/') && !name.startsWith('@')) {
-        possiblePkgNames.push(
+        possiblePkgNames.unshift(
           `@slidev/${type}-${name}`,
           `slidev-${type}-${name}`,
         )


### PR DESCRIPTION
Previously the logic for resolving addons and themes was selecting the package that looked like `slidev-{type}-{name}` or `@slidev/{type}-{name}` and falling back to `{name}` if not found, so users can specify `xyz` to use for instance an addon called  `slidev-addon-xyz`. 

But in https://github.com/slidevjs/slidev/commit/c53794bc051892e4427552c38674bc8e2c63a2c4 this behavior was changed to first check `{name}` over the others.

I have an extension called `slidev-addon-tldraw` that is dependent on `tldraw`. Since that change, the `tldraw` package is mistakenly loaded as addon, which is a no-op, but breaks the expected addon behavior.

This PR reverts to the old prioritization behavior as I think this is an unwanted regression.