### PR TITLE
fix: stop the timerbar when timer paused

### DIFF
--- a/packages/client/composables/useTimer.ts
+++ b/packages/client/composables/useTimer.ts
@@ -16,6 +16,8 @@ export function useTimer() {
     interval.counter.value
     if (state.value.status === 'stopped' || !state.value.startedAt)
       return 0
+    if (state.value.status === 'paused')
+      return state.value.pausedAt - state.value.startedAt
     return Date.now() - state.value.startedAt
   })
   const passed = computed(() => passedMs.value / 1000)


### PR DESCRIPTION
This pull request introduces a small but important improvement to the `useTimer` composable. The main change ensures that when the timer is paused, the elapsed time calculation correctly reflects the duration between the start and pause events, rather than continuing to increment.

- Timer pause logic:
  * In `useTimer.ts`, the computed `passedMs` now returns the difference between `pausedAt` and `startedAt` when the timer status is `'paused'`, ensuring accurate elapsed time reporting during pauses.

resolves #2399 