### PR TITLE
fix: reorder color conditions

### DIFF
--- a/packages/client/internals/TimerBar.vue
+++ b/packages/client/internals/TimerBar.vue
@@ -25,10 +25,10 @@ const color = computed(() => {
   if (timer.status === 'paused')
     return 'bg-blue'
 
-  if (timer.percentage > 80)
-    return 'bg-yellow'
-  else if (timer.percentage > 100)
+  if (timer.percentage > 100)
     return 'bg-red'
+  else if (timer.percentage > 80)
+    return 'bg-yellow'
   else
     return 'bg-green'
 })

--- a/packages/client/internals/TimerInlined.vue
+++ b/packages/client/internals/TimerInlined.vue
@@ -10,10 +10,10 @@ const color = computed(() => {
   if (status.value === 'paused')
     return 'text-blue6 dark:text-blue3'
 
-  if (percentage.value > 80)
-    return 'text-yellow6 dark:text-yellow3'
-  else if (percentage.value > 100)
+  if (percentage.value > 100)
     return 'text-red6 dark:text-red3'
+  else if (percentage.value > 80)
+    return 'text-yellow6 dark:text-yellow3'
   else
     return 'text-green6 dark:text-green3'
 })


### PR DESCRIPTION
This pull request updates the logic for determining the color status of timers in both the `TimerBar.vue` and `TimerInlined.vue` components. The main change is reordering the conditional checks so that the "overdue" (red) status takes precedence over the "warning" (yellow) status, ensuring that timers exceeding 100% are always shown as red.

Timer color logic update:

* Changed the order of conditional checks in the `color` computed property in `TimerBar.vue` so that timers with a percentage over 100 are assigned the "bg-red" class before checking for the "bg-yellow" warning state.
* Updated the `color` computed property in `TimerInlined.vue` to apply the "text-red6 dark:text-red3" class when the percentage is over 100 before checking for the yellow warning state, matching the intended priority.