### PR TITLE
fix: prevent square brackets in code from being parsed as title

### DIFF
--- a/packages/slidev/node/syntax/transform/code-wrapper.ts
+++ b/packages/slidev/node/syntax/transform/code-wrapper.ts
@@ -2,7 +2,7 @@ import type { MarkdownTransformContext } from '@slidev/types'
 import { normalizeRangeStr } from './utils'
 
 // eslint-disable-next-line regexp/no-super-linear-backtracking
-export const reCodeBlock = /^```([\w'-]+)?\s*(?:\[(.*?)\])?\s*(?:\{([\w*,|-]+)\}\s*?(\{[^}]*\})?([^\r\n]*))?\r?\n((?:(?!^```)[\s\S])*?)^```$/gm
+export const reCodeBlock = /^```([\w'-]+)?[ \t]*(?:\[(.*?)\])?[ \t]*(?:\{([\w*,|-]+)\}[ \t]*(\{[^}]*\})?([^\r\n]*))?\r?\n((?:(?!^```)[\s\S])*?)^```$/gm
 
 /**
  * Transform code block with wrapper

--- a/test/__snapshots__/transform.test.ts.snap
+++ b/test/__snapshots__/transform.test.ts.snap
@@ -1,5 +1,33 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`code-wrapper with square brackets in code 1`] = `
+"
+
+<CodeBlockWrapper v-bind="{}" :title='""' :ranges='[]'>
+
+\`\`\`csharp
+[Flags]
+enum MyEnum {}
+\`\`\`
+
+</CodeBlockWrapper>
+"
+`;
+
+exports[`code-wrapper with title and square brackets in code 1`] = `
+"
+
+<CodeBlockWrapper v-bind="{}" :title='"MyEnum.cs"' :ranges='[]'>
+
+\`\`\`csharp [MyEnum.cs]
+[Flags]
+enum MyEnum {}
+\`\`\`
+
+</CodeBlockWrapper>
+"
+`;
+
 exports[`external snippet 1`] = `
 "
 \`\`\`ts {2|3|4}{lines:true}

--- a/test/transform.test.ts
+++ b/test/transform.test.ts
@@ -177,3 +177,29 @@ it('external snippet', () => {
 
   expect(ctx.s.toString()).toMatchSnapshot()
 })
+
+it('code-wrapper with square brackets in code', () => {
+  const ctx = createTransformContext(`
+\`\`\`csharp
+[Flags]
+enum MyEnum {}
+\`\`\`
+`)
+
+  transformCodeWrapper(ctx)
+
+  expect(ctx.s.toString()).toMatchSnapshot()
+})
+
+it('code-wrapper with title and square brackets in code', () => {
+  const ctx = createTransformContext(`
+\`\`\`csharp [MyEnum.cs]
+[Flags]
+enum MyEnum {}
+\`\`\`
+`)
+
+  transformCodeWrapper(ctx)
+
+  expect(ctx.s.toString()).toMatchSnapshot()
+})


### PR DESCRIPTION
## Description

Fixes an issue where square brackets on the first line of code blocks were incorrectly interpreted as block titles.

For example, C# attributes like `[Flags]` at the beginning of code blocks were being parsed as the title instead of being treated as part of the code content.

## Changes

- Modified the regex in `code-wrapper.ts` to only match spaces and tabs (not newlines) on the opening line
- Changed `\s*` to `[ \t]*` to prevent matching newlines before parsing optional title brackets
- Added test cases to verify the fix works correctly with and without titles

## Test Cases

1. Code block with square brackets but no title - ensures `[Flags]` stays in code
2. Code block with both a title and square brackets in code - ensures both work correctly

### Before (Current Behavior)

The first test case incorrectly extracts `[Flags]` as the title:

```diff
 exports[`code-wrapper with square brackets in code 1`] = `
 "
 
-<CodeBlockWrapper v-bind="{}" :title='"Flags"' :ranges='[]'>
+<CodeBlockWrapper v-bind="{}" :title='""' :ranges='[]'>
 
-\`\`\`csharp [Flags]
+\`\`\`csharp
+[Flags]
 enum MyEnum {}
 \`\`\`
 
 </CodeBlockWrapper>
 "
 `;
```

## Visual Example

The following C# code demonstrates the issue:

```csharp
[Flags]
public enum Permission
{
    None = 0,    // 0000
    Read = 1,    // 0001
    Write = 2,   // 0010
    Delete = 4   // 0100
}
```

**Before the fix:**

<img width="608" height="291" alt="image" src="https://github.com/user-attachments/assets/63c1272e-a4d0-444b-a3ee-de12bc234c86" />
