### PR TITLE
feat: `two-col` layout should accept `left` slot for consistency

### DIFF
--- a/packages/client/layouts/two-cols.vue
+++ b/packages/client/layouts/two-cols.vue
@@ -34,6 +34,7 @@ const props = defineProps({
   <div class="slidev-layout two-columns w-full h-full grid grid-cols-2" :class="props.layoutClass">
     <div class="col-left" :class="props.class">
       <slot />
+      <slot name="left" />
     </div>
     <div class="col-right" :class="props.class">
       <slot name="right" />


### PR DESCRIPTION
<img width="955" height="417" alt="image" src="https://github.com/user-attachments/assets/aa667b5b-4e9b-411b-a5d4-4384fd4858f2" />


`two-cols-header` requires the left part to be in `#left`, but `two-cols` requires it to be in the default slot, which was inconsistent. 