### PR TITLE
fix: broken author link and repository URL in docs for Penguin theme

### DIFF
--- a/docs/.vitepress/themes.ts
+++ b/docs/.vitepress/themes.ts
@@ -253,9 +253,9 @@ export const community: ThemeInfo[] = [
     description: 'A Penguin theme for Slidev',
     author: {
       name: 'Alvaro Saburido',
-      link: 'https://github.com/alvarosaburido',
+      link: 'https://github.com/alvarosabu',
     },
-    repo: 'https://github.com/alvarosaburido/slidev-theme-penguin',
+    repo: 'https://github.com/alvarosabu/slidev-theme-penguin',
     previews: [
       'https://cdn.jsdelivr.net/gh/alvarosaburido/slidev-theme-penguin@master/screenshots/dark/01.png',
       'https://cdn.jsdelivr.net/gh/alvarosaburido/slidev-theme-penguin@master/screenshots/light/02.png',


### PR DESCRIPTION
Small fix in the community theme section. The two links were outdated, one was still redirecting the other was broken. Adjusted both of them to be safe.