### PR TITLE
build(docs): implement interpolation for multilingual docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ dist
 dist-ssr
 docs/.vitepress/@slidev
 docs/.vitepress/cache
+docs-*
 node_modules
 cypress/downloads
 packages/create-app/template/pages

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "lint": "eslint . --cache",
     "lint:fix": "nr lint --fix",
     "typecheck": "vue-tsc --noEmit",
-    "docs": "pnpm -C docs run dev",
-    "docs:build": "pnpm run --filter=\"./docs...\" build && pnpm demo:build",
+    "docs": "node scripts/docs.mjs",
+    "docs:build": "node scripts/docs.mjs build && pnpm demo:build",
     "release": "bumpp package.json packages/*/package.json docs/package.json --all -x \"zx scripts/update-versions.mjs\"",
     "test": "vitest test",
     "prepare": "simple-git-hooks"

--- a/scripts/docs.mjs
+++ b/scripts/docs.mjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+import { existsSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { execSync } from 'node:child_process'
+
+const rootDir = resolve(import.meta.dirname, '..')
+
+// Parse parameters: pnpm docs [lang] [command]
+// For example: pnpm docs cn, pnpm docs cn build, pnpm docs
+let lang = process.argv[2] || process.env.DOCS_LANG || ''
+let command = process.argv[3] || 'dev'
+
+// Determine document directory
+let docsDir = 'docs' // Default English
+
+if (lang && !['dev', 'build'].includes(lang)) {
+  // Direct concatenation: cn -> docs-cn, jp -> docs-jp
+  docsDir = lang.startsWith('docs-') ? lang : `docs-${lang}`
+} else if (lang === 'dev' || lang === 'build') {
+  // If the first parameter is a command, use the default docs
+  command = lang
+  docsDir = 'docs'
+}
+
+const targetDir = resolve(rootDir, docsDir)
+
+// Check if directory exists
+if (!existsSync(targetDir)) {
+  console.warn(`⚠️  Directory "${docsDir}" not found, falling back to "docs"`)
+  const fallbackDir = resolve(rootDir, 'docs')
+  
+  if (!existsSync(fallbackDir)) {
+    console.error('❌ Default "docs" directory not found')
+    process.exit(1)
+  }
+  
+  docsDir = 'docs'
+}
+
+// Execute document command
+console.log(`📚 Running docs ${command} from: ${docsDir}`)
+try {
+  execSync(`pnpm -C ${docsDir} run ${command}`, { stdio: 'inherit', cwd: rootDir })
+} catch (error) {
+  process.exit(error.status || 1)
+}


### PR DESCRIPTION
### Summary

This PR introduces a flexible documentation development script that allows developers to easily work with localized documentation repositories (e.g., `docs-cn`, `docs-jp`, `docs-fr`) without polluting the git working directory.

### Motivation

Previously, when working on localized documentation, developers had to manually modify `package.json` to point to their local docs directory (e.g., changing `docs` to `docs-cn`). This modification would always show up as an uncommitted change in git, requiring manual cleanup before committing.

### Changes

#### 1. New Script: `scripts/docs.mjs`
- Intelligent documentation development script
- Supports parameterized language selection
- Automatically falls back to default `docs` directory if specified directory doesn't exist
- Supports both `dev` and `build` commands

#### 2. Updated `package.json`
```diff
- "docs": "pnpm -C docs-cn run dev",
+ "docs": "node scripts/docs.mjs",
- "docs:build": "pnpm run --filter=\"./docs\"... build && pnpm demo:build",
+ "docs:build": "node scripts/docs.mjs build && pnpm demo:build",
```

#### 3. Updated `.gitignore`
- Added `docs-*` pattern to ignore all localized documentation directories

### Usage

**Default (English docs):**
```bash
pnpm docs
```

**Localized docs:**
```bash
pnpm docs cn    # Chinese (docs-cn)
pnpm docs jp    # Japanese (docs-jp)
pnpm docs fr    # French (docs-fr)
```

**Build:**
```bash
pnpm docs cn build
```

**Environment variable (optional):**
```bash
DOCS_LANG=cn pnpm docs
```

### Benefits

- ✅ **Zero configuration**: No need for local config files
- ✅ **Clean git status**: No uncommitted changes in `package.json`
- ✅ **Flexible**: Supports any language code via simple concatenation (`cn` → `docs-cn`)
- ✅ **Maintainable**: No hardcoded language list to maintain
- ✅ **Backward compatible**: Default behavior unchanged (uses `docs` directory)

### Testing

```bash
# Test default behavior
pnpm docs

# Test with localized docs (if you have docs-cn cloned)
pnpm docs cn

# Test fallback (non-existent directory)
pnpm docs xyz  # Falls back to docs
```

