### PR TITLE
fix(cli): keyboard shortcuts stop working after server restart

### DIFF
--- a/packages/slidev/node/cli.ts
+++ b/packages/slidev/node/cli.ts
@@ -295,9 +295,6 @@ cli.command(
       }
 
       process.stdin.on('keypress', onKeyPress)
-      server?.httpServer?.on('close', () => {
-        process.stdin.off('keypress', onKeyPress)
-      })
     }
 
     const { roots } = await initServer()


### PR DESCRIPTION
Remove the listener that unregisters keyboard shortcuts on server close. The bindShortcut() function is only called once during initialization, so removing the keypress listener on server restart would cause shortcuts to stop working permanently. The listener should persist across restarts.

Fixes: Keyboard shortcuts (r, o, e, q, c) become unresponsive after the server restarts (theme change, config change, or pressing 'r').