### PR TITLE
fix(client): prevent word breaking in ShikiEditor

### DIFF
--- a/packages/client/internals/ShikiEditor.vue
+++ b/packages/client/internals/ShikiEditor.vue
@@ -43,7 +43,8 @@ textarea {
   font-variation-settings: normal;
   font-size: 1em;
   text-wrap: wrap;
-  word-break: break-all;
+  word-break: normal;
+  overflow-wrap: break-word;
   display: block;
   width: 100%;
 }


### PR DESCRIPTION
## Description

Changes the text wrapping behavior in ShikiEditor to preserve word integrity instead of breaking words mid-character.

## Changes

- Changed `word-break: break-all` to `word-break: normal` so words wrap at natural boundaries (spaces, hyphens)
- Added `overflow-wrap: break-word` as a fallback for long unbreakable strings (e.g., URLs) to prevent horizontal overflow

## Before

Words could be split at any character, making text harder to read:

This is a lon
g word that g
ets broken

## After

Words wrap naturally to the next line:

This is a
long word
that gets
broken