### PR TITLE
fix: exclude `local` fonts from webfonts to fetch

### DIFF
--- a/packages/parser/src/config.ts
+++ b/packages/parser/src/config.ts
@@ -147,10 +147,8 @@ export function resolveFonts(fonts: FontOptions = {}): ResolvedFontOptions {
   const webfonts = fonts.webfonts
     ? fonts.webfonts
     : fallbacks
-      ? uniq([...sans, ...serif, ...mono, ...custom])
+      ? uniq([...sans, ...serif, ...mono, ...custom]).filter(i => !local.includes(i))
       : []
-
-  webfonts.filter(i => local.includes(i))
 
   function toQuoted(font: string) {
     if (/^(['"]).*\1$/.test(font))


### PR DESCRIPTION
Currently, `local` fonts specified in headmatter is not reflected as documented in https://sli.dev/custom/config-fonts.html.

This commit fixes the bug and exclude fonts specified as `local` in headmatter from `webfonts` to fetch.