### PR TITLE
fix: load preparser.ts from theme roots

### DIFF
--- a/packages/slidev/node/setups/preparser.ts
+++ b/packages/slidev/node/setups/preparser.ts
@@ -2,6 +2,7 @@ import type { PreparserSetup } from '@slidev/types'
 import { uniq } from '@antfu/utils'
 import { injectPreparserExtensionLoader } from '@slidev/parser/fs'
 import { resolveAddons } from '../integrations/addons'
+import { resolveTheme } from '../integrations/themes'
 import { getRoots } from '../resolver'
 import { loadSetups } from './load'
 
@@ -10,8 +11,16 @@ export default function setupPreparser() {
     // Ensure addons is an array or an empty array if undefined
     const addons = Array.isArray(headmatter?.addons) ? headmatter.addons as string[] : []
 
+    // Resolve theme from headmatter (matching logic from options.ts)
+    let themeRaw = headmatter?.theme as string | null | undefined
+    themeRaw = themeRaw === null ? 'none' : (themeRaw || 'default')
+
     const { userRoot } = await getRoots()
+    const [, themeRoot] = await resolveTheme(themeRaw, filepath)
+    const themeRoots = themeRoot ? [themeRoot] : []
+
     const roots = uniq([
+      ...themeRoots,
       ...await resolveAddons(addons),
       userRoot,
     ])


### PR DESCRIPTION
Fixes #2402

## Problem

The `setup/preparser.ts` file in themes was being ignored while other setup files like `shiki.ts` were correctly loaded.

## Root Cause

In `packages/slidev/node/setups/preparser.ts`, the roots array only included:
- Addon roots
- User root

But NOT theme roots. Compare with how `setupShiki()` receives `resolved.roots` which includes themes.

## Solution

Resolve the theme root from headmatter (using the same logic as `options.ts`) and include it in the roots array passed to `loadSetups()`.

## Testing

- All 101 existing tests pass
- ESLint passes

## Changes

```diff
import { resolveAddons } from '../integrations/addons'
+import { resolveTheme } from '../integrations/themes'
import { getRoots } from '../resolver'
import { loadSetups } from './load'

export default function setupPreparser() {
  injectPreparserExtensionLoader(async (headmatter, filepath, mode) => {
    const addons = Array.isArray(headmatter?.addons) ? headmatter.addons : []

+   // Resolve theme from headmatter (matching logic from options.ts)
+   let themeRaw = headmatter?.theme as string | null | undefined
+   themeRaw = themeRaw === null ? 'none' : (themeRaw || 'default')

    const { userRoot } = await getRoots()
+   const [, themeRoot] = await resolveTheme(themeRaw, filepath)
+   const themeRoots = themeRoot ? [themeRoot] : []

    const roots = uniq([
+     ...themeRoots,
      ...await resolveAddons(addons),
      userRoot,
    ])
```