### PR TITLE
fix: import order with import.meta.glob

### DIFF
--- a/packages/slidev/node/virtual/styles.ts
+++ b/packages/slidev/node/virtual/styles.ts
@@ -11,12 +11,12 @@ export const templateStyle: VirtualModuleTemplate = {
     }
 
     const imports: string[] = [
-      `import "${resolveUrlOfClient('styles/vars.css')}"`,
-      `import "${resolveUrlOfClient('styles/index.css')}"`,
-      `import "${resolveUrlOfClient('styles/code.css')}"`,
-      `import "${resolveUrlOfClient('styles/katex.css')}"`,
-      `import "${resolveUrlOfClient('styles/transitions.css')}"`,
-    ]
+      'styles/vars.css',
+      'styles/index.css',
+      'styles/code.css',
+      'styles/katex.css',
+      'styles/transitions.css',
+    ].map(path => makeAbsoluteImportGlob(userRoot, [join(clientRoot, path)]))
 
     for (const root of roots) {
       imports.push(makeAbsoluteImportGlob(userRoot, [


### PR DESCRIPTION
fix #2412, fix #2439

Somehow vite always moves resolved `import.meta.glob` imports to the top of the file.