### PR TITLE
chore: ignore ai config in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ packages/slidev/skills
 packages/vscode/syntaxes/codeblock-patch.json
 slides-export.md
 *slides-export.pptx
+.agents
+.claude


### PR DESCRIPTION
Suppose we're using skills. If we use skills it generally creates two folders with many files. I think we can ignore it in gitignore.