### PR TITLE
Correct typo in documentation for PlantUML

### DIFF
--- a/docs/features/plantuml.md
+++ b/docs/features/plantuml.md
@@ -2,7 +2,7 @@
 relates:
   - Plant UML: https://plantuml.com/
   - Plant UML Live Editor: https://plantuml.com/plantuml
-  - Example slide: https://sli.dev/demo/starter/12
+  - Example Slide: https://sli.dev/demo/starter/12
   - features/mermaid
 tags: [diagram]
 description: |


### PR DESCRIPTION
Correct the typo `side` to `slide` in the documentation for [PlantUML](https://sli.dev/features/plantuml).