### PR TITLE
Fix race condition in concurrent slidev export

### DIFF
--- a/packages/slidev/node/cli.ts
+++ b/packages/slidev/node/cli.ts
@@ -481,7 +481,7 @@ cli.command(
           },
         )
         await server.listen(candidatePort)
-        const port = getViteServerPort(server) || candidatePort
+        const port = getViteServerPort(server)
         printInfo(options)
         const result = await exportSlides({
           port,
@@ -544,7 +544,7 @@ cli.command(
           },
         )
         await server.listen(candidatePort)
-        const port = getViteServerPort(server) || candidatePort
+        const port = getViteServerPort(server)
 
         printInfo(options)
 
@@ -569,10 +569,11 @@ cli
   .help()
   .parse()
 
-function getViteServerPort(server: ViteDevServer): number | undefined {
+function getViteServerPort(server: ViteDevServer): number {
   const address = server.httpServer?.address()
-  if (typeof address === 'object' && address && typeof address.port === 'number')
+  if (address && typeof address === 'object')
     return address.port
+  throw new Error('Failed to get Vite server port')
 }
 
 function commonOptions(args: Argv<object>) {


### PR DESCRIPTION
## Problem

`slidev export` runs a Vite server, then uses a headless browser to capture slides.  
Under concurrent runs, the CLI could pass a *candidate* port to export logic instead of the *actual bound* port. If Vite moved to another port, the browser could connect to the wrong server.

In practice, one export command could render slides that belonged to another concurrent export target.
The error string below was from the regression test script, which detected that mismatch by checking output counts:

- `Unexpected PNG count in export-concurrency-b: expected 9, got 8`

## How to test

1. Integration test (now in CI smoke workflow for all matrix entries):
```bash
node scripts/test-export-concurrency.mjs ../temp/slidev-project
```

2. Stress loop (local repro helper):
```bash
bash scripts/test-export-concurrency-loop-until-failure.sh ../temp/slidev-project
# optional second arg: max runs
```

The integration test creates two decks (8 and 9 slides), runs two `slidev export --format png` processes in parallel, and verifies each output directory has the expected PNG count.

## Fix

In `slidev export` and `export-notes`, resolve and use the actual Vite listening port instead of assuming the candidate port.

This prevents concurrent exports from rendering another command's slides and makes server cleanup deterministic.
