### PR TITLE
Add warning for using `<<<` in code

### DIFF
--- a/docs/features/import-snippet.md
+++ b/docs/features/import-snippet.md
@@ -54,5 +54,5 @@ If you need to use `<<<` in your code without loading a code snippet, simply add
 For example:
 
 ```md
- <<< This line will not load a code snippet.
+<<< This line will not load a code snippet.
 ```


### PR DESCRIPTION
# Description

It's not a real bug, but it might require a note in the documentation.

When Slidev encounters a `<<<` in the code, it tries to load a file.
That is fine. However, sometimes you need to display a piece of code that contains a `<<<` (see https://sli.dev/features/import-snippet#import-code-snippets).

For example, a snippet of a Git conflict may look like this:

```
```javascript
function calculate(items) {
<<<<<<< HEAD (Current Change)
  const ...
=======
  const ...
>>>>>>> feature (Incoming Change)
}
```

This code will result in an error like this one in the console:

```
[vite] (client) Pre-transform error: ENOENT: no such file or directory, stat '/.../slides/pages/<<<< HEAD (Current'
```

This happens because

```
<<< <<<< HEAD (Current
^   ^
\   \
 \   \_ file searched
  \
   \_ the first three left carets also mean "import snippet"
```

## Workaround
Since the Slidev function [`transformSnippet`](https://github.com/slidevjs/slidev/blob/main/packages/slidev/node/syntax/transform/snippet.ts#L117) relies on this regex

```js
s.replace(/^<<<[ \t]*(\S.*?)(#[\w-]+)?[ \t]*(?:[ \t](\S+?))?[ \t]*(\{.*)?$/gm, (full, filepath = "", regionName = "", lang = "", meta = "") => {
```

you can add one or more spaces at the beginning, but it's not trivial to find.

---
## Commit

Added a warning about how to use `<<<` in
code without loading a fragment.

## Changed:
- Added a warning to clarify that it is possible to use characters such as a space at the beginning of the line to avoid loading a code fragment.

## Example:
- Provided a practical example to illustrate correct usage.