### PR TITLE
docs: add slidev-theme-field-manual to theme gallery

### DIFF
--- a/docs/.vitepress/themes.ts
+++ b/docs/.vitepress/themes.ts
@@ -587,7 +587,6 @@ export const community: ThemeInfo[] = [
       'princeton',
     ],
   },
-  // Add yours here!
   {
     id: 'slidev-theme-field-manual',
     name: 'Field Manual',
@@ -639,6 +638,7 @@ export const community: ThemeInfo[] = [
       'military',
     ],
   },
+  // Add yours here!
   {
     id: '',
     link: 'https://github.com/slidevjs/slidev/edit/main/docs/.vitepress/themes.ts',


### PR DESCRIPTION
Add community theme entry for slidev-theme-field-manual, a presentation theme modeled on vintage military field manuals (FM series, 1950s–1980s).

Published on npm at v0.1.0. Includes 24 layouts (cover, section, TOC, code panels, image layouts, charts, timeline, dashboard), a paper-toned light/dark palette, and typographic conventions drawn from the FM series.