### PR TITLE
feat: add __SLIDEV_FEATURE_MONACO__ compile-time flag to tree-shake Monaco when disabled

### DIFF
--- a/packages/client/builtin/Monaco.vue
+++ b/packages/client/builtin/Monaco.vue
@@ -99,6 +99,9 @@ const stopWatchTypesLoading = whenever(
 )
 
 onMounted(async () => {
+  if (!__SLIDEV_FEATURE_MONACO__)
+    return
+
   // Lazy load monaco, so it will be bundled in async chunk
   const { default: setup } = await import('../setup/monaco')
   const { ata, monaco, editorOptions } = await setup()

--- a/packages/client/setup/shiki-options.ts
+++ b/packages/client/setup/shiki-options.ts
@@ -39,7 +39,12 @@ export function resolveShikiOptions(options: (ShikiSetupReturn | void)[]) {
   const themeOption = extractThemeName(mergedOptions.theme) || extractThemeNames(mergedOptions.themes || {})
   const themeNames = typeof themeOption === 'string' ? [themeOption] : Object.values(themeOption)
 
-  const themeInput: Record<string, ThemeInput> = Object.assign({}, bundledThemes)
+  const themeInput: Record<string, ThemeInput> = {}
+  for (const name of themeNames) {
+    const bundled = (bundledThemes as Record<string, ThemeInput>)[name]
+    if (bundled)
+      themeInput[name] = bundled
+  }
   if (typeof mergedOptions.theme === 'object' && mergedOptions.theme?.name) {
     themeInput[mergedOptions.theme.name] = mergedOptions.theme
   }

--- a/packages/slidev/node/options.ts
+++ b/packages/slidev/node/options.ts
@@ -125,6 +125,7 @@ function getDefine(options: Omit<ResolvedSlidevOptions, 'utils'>): Record<string
       __SLIDEV_FEATURE_DRAWINGS__: matchMode(options.data.config.drawings.enabled),
       __SLIDEV_FEATURE_EDITOR__: options.mode === 'dev' && options.data.config.editor !== false,
       __SLIDEV_FEATURE_DRAWINGS_PERSIST__: !!options.data.config.drawings.persist,
+      __SLIDEV_FEATURE_MONACO__: matchMode(options.data.config.monaco ?? true),
       __SLIDEV_FEATURE_RECORD__: matchMode(options.data.config.record),
       __SLIDEV_FEATURE_PRESENTER__: matchMode(options.data.config.presenter),
       __SLIDEV_FEATURE_PRINT__: options.mode === 'export' || (options.mode === 'build' && [true, 'true', 'auto'].includes(options.data.config.download)),

--- a/packages/slidev/node/vite/extendConfig.ts
+++ b/packages/slidev/node/vite/extendConfig.ts
@@ -7,18 +7,19 @@ import { createResolve } from 'mlly'
 import { mergeConfig } from 'vite'
 import { isInstalledGlobally, resolveImportPath, toAtFS } from '../resolver'
 
-const INCLUDE_GLOBAL = [
-  '@typescript/ata',
+const INCLUDE_GLOBAL_BASE = [
   'file-saver',
   'lz-string',
   'recordrtc',
-  'typescript',
   'yaml',
   'pptxgenjs',
   'ansis',
 ]
 
-const INCLUDE_LOCAL = INCLUDE_GLOBAL.map(i => `@slidev/cli > @slidev/client > ${i}`)
+const INCLUDE_GLOBAL_MONACO = [
+  '@typescript/ata',
+  'typescript',
+]
 
 // @keep-sorted
 const EXCLUDE_GLOBAL = [
@@ -60,6 +61,11 @@ const ASYNC_MODULES = [
   '@vue',
 ]
 
+function isMonacoEnabled(options: ResolvedSlidevOptions): boolean {
+  const monaco = options.data.config.monaco ?? true
+  return monaco === true || (typeof monaco === 'string' && monaco === options.mode)
+}
+
 export function createConfigPlugin(options: ResolvedSlidevOptions): Plugin {
   const resolveClientDep = createResolve({
     // Same as Vite's default resolve conditions
@@ -90,7 +96,7 @@ export function createConfigPlugin(options: ResolvedSlidevOptions): Plugin {
               replacement: await resolveImportPath('vue/dist/vue.esm-bundler.js', true),
             },
             ...(isInstalledGlobally.value
-              ? await Promise.all(INCLUDE_GLOBAL.map(async dep => ({
+              ? await Promise.all([...INCLUDE_GLOBAL_BASE, ...(isMonacoEnabled(options) ? INCLUDE_GLOBAL_MONACO : [])].map(async dep => ({
                   find: dep,
                   replacement: fileURLToPath(await resolveClientDep(dep)),
                 })))
@@ -99,16 +105,22 @@ export function createConfigPlugin(options: ResolvedSlidevOptions): Plugin {
           ],
           dedupe: ['vue'],
         },
-        optimizeDeps: isInstalledGlobally.value
-          ? {
-              exclude: EXCLUDE_GLOBAL,
-              include: INCLUDE_GLOBAL,
-            }
-          : {
-              // We need to specify the full deps path for non-hoisted modules
-              exclude: EXCLUDE_LOCAL,
-              include: INCLUDE_LOCAL,
-            },
+        optimizeDeps: (() => {
+          const monacoEnabled = isMonacoEnabled(options)
+          const include = [
+            ...INCLUDE_GLOBAL_BASE,
+            ...(monacoEnabled ? INCLUDE_GLOBAL_MONACO : []),
+          ]
+          return isInstalledGlobally.value
+            ? {
+                exclude: EXCLUDE_GLOBAL,
+                include,
+              }
+            : {
+                exclude: EXCLUDE_LOCAL,
+                include: include.map(i => `@slidev/cli > @slidev/client > ${i}`),
+              }
+        })(),
         css: {
           postcss: {
             plugins: [

--- a/packages/slidev/node/vite/index.ts
+++ b/packages/slidev/node/vite/index.ts
@@ -20,11 +20,17 @@ import { createStaticCopyPlugin } from './staticCopy'
 import { createUnocssPlugin } from './unocss'
 import { createVuePlugin } from './vue'
 
+function isMonacoEnabled(options: ResolvedSlidevOptions): boolean {
+  const monaco = options.data.config.monaco ?? true
+  return monaco === true || (typeof monaco === 'string' && monaco === options.mode)
+}
+
 export function ViteSlidevPlugin(
   options: ResolvedSlidevOptions,
   pluginOptions: SlidevPluginOptions = {},
   serverOptions: SlidevServerOptions = {},
 ): Promise<PluginOption[]> {
+  const monacoEnabled = isMonacoEnabled(options)
   return Promise.all([
     createSlidesLoader(options, serverOptions),
     createMarkdownPlugin(options, pluginOptions),
@@ -37,13 +43,13 @@ export function ViteSlidevPlugin(
     createRemoteAssetsPlugin(options, pluginOptions),
     createServerRefPlugin(options, pluginOptions),
     createConfigPlugin(options),
-    createMonacoTypesLoader(options),
-    createMonacoWriterPlugin(options),
+    monacoEnabled && createMonacoTypesLoader(options),
+    monacoEnabled && createMonacoWriterPlugin(options),
     createVueCompilerFlagsPlugin(options),
     createUnocssPlugin(options, pluginOptions),
     createStaticCopyPlugin(options, pluginOptions),
     createInspectPlugin(options, pluginOptions),
-    createPatchMonacoSourceMapPlugin(),
+    monacoEnabled && createPatchMonacoSourceMapPlugin(),
 
     setupVitePlugins(options),
   ])

--- a/shim.d.ts
+++ b/shim.d.ts
@@ -6,6 +6,7 @@ declare global {
   const __SLIDEV_FEATURE_DRAWINGS__: boolean
   const __SLIDEV_FEATURE_DRAWINGS_PERSIST__: boolean
   const __SLIDEV_FEATURE_EDITOR__: boolean
+  const __SLIDEV_FEATURE_MONACO__: boolean
   const __SLIDEV_FEATURE_RECORD__: boolean
   const __SLIDEV_FEATURE_PRESENTER__: boolean
   const __SLIDEV_FEATURE_PRINT__: boolean
@@ -22,6 +23,7 @@ declare module '@vue/runtime-core' {
     __SLIDEV_FEATURE_DRAWINGS__: boolean
     __SLIDEV_FEATURE_DRAWINGS_PERSIST__: boolean
     __SLIDEV_FEATURE_EDITOR__: boolean
+    __SLIDEV_FEATURE_MONACO__: boolean
     __SLIDEV_FEATURE_RECORD__: boolean
     __SLIDEV_FEATURE_PRESENTER__: boolean
     __SLIDEV_FEATURE_PRINT__: boolean


### PR DESCRIPTION
Closes / Related to #1515

## Changes

- Add `__SLIDEV_FEATURE_MONACO__` compile-time define flag (driven by the existing `monaco` frontmatter config)
- Declare the flag in [shim.d.ts](cci:7://file:///d:/Code/slidev/shim.d.ts:0:0-0:0) (both global and [ComponentCustomProperties](cci:2://file:///d:/Code/slidev/shim.d.ts:18:2-32:3))
- Guard `setup/monaco` dynamic import in [Monaco.vue](cci:7://file:///d:/Code/slidev/packages/client/builtin/Monaco.vue:0:0-0:0) with the flag, enabling full tree-shaking of Monaco + TypeScript workers when disabled
- Skip registering `monacoTypes`, `monacoWrite`, and `patchMonacoSourceMap` Vite plugins when Monaco is disabled
- Conditionally include `typescript` and `@typescript/ata` in `optimizeDeps` only when Monaco is enabled
- Optimize `themeInput` in [shiki-options.ts](cci:7://file:///d:/Code/slidev/packages/client/setup/shiki-options.ts:0:0-0:0) to only register the themes actually used (instead of all bundled themes)

## Impact

With `monaco: false` in headmatter:

| Metric | Before | After |
|--------|--------|-------|
| Modules transformed | 2439 | 609 |
| Build time | ~58s | ~10s |
| [ts.worker](cci:1://file:///d:/Code/slidev/packages/slidev/node/options.ts:97:6-112:7) bundle | 7 MB | removed |
| `monaco/bundled-types` | 9.8 MB | removed |
| `modules/shiki` chunk | 9.6 MB | 49 KB |

## Usage

```yaml
---
monaco: false   # disable Monaco entirely (default: true)
monaco: dev     # enable only in dev mode
monaco: build   # enable only in production build
---