### PR TITLE
feat: tree-shake mermaid and katex when no mermaid diagrams are present

### DIFF
--- a/packages/client/builtin/Mermaid.vue
+++ b/packages/client/builtin/Mermaid.vue
@@ -16,7 +16,6 @@ pie
 import { getCurrentInstance, ref, watch, watchEffect } from 'vue'
 import ShadowRoot from '../internals/ShadowRoot.vue'
 import { isDark } from '../logic/dark'
-import { renderMermaid } from '../modules/mermaid'
 
 const props = defineProps<{
   codeLz: string
@@ -30,12 +29,16 @@ const error = ref<string | null>(null)
 const html = ref('')
 
 watchEffect(async (onCleanup) => {
+  if (!__SLIDEV_FEATURE_MERMAID__)
+    return
+
   let disposed = false
   onCleanup(() => {
     disposed = true
   })
   error.value = null
   try {
+    const { renderMermaid } = await import('../modules/mermaid')
     const svg = await renderMermaid(
       props.codeLz || '',
       {

--- a/packages/slidev/node/options.ts
+++ b/packages/slidev/node/options.ts
@@ -125,6 +125,7 @@ function getDefine(options: Omit<ResolvedSlidevOptions, 'utils'>): Record<string
       __SLIDEV_FEATURE_DRAWINGS__: matchMode(options.data.config.drawings.enabled),
       __SLIDEV_FEATURE_EDITOR__: options.mode === 'dev' && options.data.config.editor !== false,
       __SLIDEV_FEATURE_DRAWINGS_PERSIST__: !!options.data.config.drawings.persist,
+      __SLIDEV_FEATURE_MERMAID__: !!options.data.features.mermaid,
       __SLIDEV_FEATURE_RECORD__: matchMode(options.data.config.record),
       __SLIDEV_FEATURE_PRESENTER__: matchMode(options.data.config.presenter),
       __SLIDEV_FEATURE_PRINT__: options.mode === 'export' || (options.mode === 'build' && [true, 'true', 'auto'].includes(options.data.config.download)),

--- a/shim.d.ts
+++ b/shim.d.ts
@@ -6,6 +6,7 @@ declare global {
   const __SLIDEV_FEATURE_DRAWINGS__: boolean
   const __SLIDEV_FEATURE_DRAWINGS_PERSIST__: boolean
   const __SLIDEV_FEATURE_EDITOR__: boolean
+  const __SLIDEV_FEATURE_MERMAID__: boolean
   const __SLIDEV_FEATURE_RECORD__: boolean
   const __SLIDEV_FEATURE_PRESENTER__: boolean
   const __SLIDEV_FEATURE_PRINT__: boolean
@@ -22,6 +23,7 @@ declare module '@vue/runtime-core' {
     __SLIDEV_FEATURE_DRAWINGS__: boolean
     __SLIDEV_FEATURE_DRAWINGS_PERSIST__: boolean
     __SLIDEV_FEATURE_EDITOR__: boolean
+    __SLIDEV_FEATURE_MERMAID__: boolean
     __SLIDEV_FEATURE_RECORD__: boolean
     __SLIDEV_FEATURE_PRESENTER__: boolean
     __SLIDEV_FEATURE_PRINT__: boolean


### PR DESCRIPTION
Closes / Related to #1515

## Changes
- Add `__SLIDEV_FEATURE_MERMAID__` compile-time define flag driven by auto-detected `data.features.mermaid`
- Declare the flag in [shim.d.ts](cci:7://file:///d:/Code/slidev/shim.d.ts:0:0-0:0) (global + ComponentCustomProperties)
- Guard dynamic import of `modules/mermaid` in [Mermaid.vue](cci:7://file:///d:/Code/slidev/packages/client/builtin/Mermaid.vue:0:0-0:0) with the flag, enabling full tree-shaking of mermaid + its transitive katex dependency when no mermaid diagrams are present

## How it works
`features.mermaid` is auto-detected by scanning slide content for ` ```mermaid ` blocks (no user config needed). When false, the entire mermaid module graph (~2MB+ chunks) and the katex chunk pulled in by mermaid are eliminated from the build.

## Impact
Without mermaid diagrams in slides:
- Eliminated chunks: `mermaid` (558KB), `treemap` (500KB), `architectureDiagram` (152KB), `sequenceDiagram` (98KB), `katex` (270KB gzip: 79KB), and 15+ more diagram chunks
- Build time: ~10.9s → ~5.5s