### PR TITLE
fix: add duration metadata to recorded WebM files

### DIFF
--- a/packages/client/logic/recording.ts
+++ b/packages/client/logic/recording.ts
@@ -3,6 +3,7 @@ import type { Options as RecorderOptions } from 'recordrtc'
 import type { Ref } from 'vue'
 import { isTruthy } from '@antfu/utils'
 import { useDevicesList, useEventListener, useLocalStorage } from '@vueuse/core'
+import fixWebmDuration from 'fix-webm-duration'
 import { nextTick, ref, shallowRef, watch } from 'vue'
 import { currentCamera, currentMic } from '../state'
 
@@ -78,6 +79,7 @@ export function useRecording() {
   const streamCamera: Ref<MediaStream | undefined> = shallowRef()
   const streamCapture: Ref<MediaStream | undefined> = shallowRef()
   const streamSlides: Ref<MediaStream | undefined> = shallowRef()
+  let recordingStartTime = 0
 
   const config: RecorderOptions = {
     type: 'video',
@@ -183,17 +185,18 @@ export function useRecording() {
     )
 
     recorderSlides.value.startRecording()
+    recordingStartTime = Date.now()
     recording.value = true
   }
 
   async function stopRecording() {
     recording.value = false
+    const duration = Date.now() - recordingStartTime
+
     recorderCamera.value?.stopRecording(() => {
       if (recordCamera.value) {
         const blob = recorderCamera.value!.getBlob()
-        const url = URL.createObjectURL(blob)
-        download(getFilename('camera', config.mimeType), url)
-        window.URL.revokeObjectURL(url)
+        downloadBlob(blob, duration, getFilename('camera', config.mimeType))
       }
       recorderCamera.value = undefined
       if (!showAvatar.value)
@@ -201,13 +204,18 @@ export function useRecording() {
     })
     recorderSlides.value?.stopRecording(() => {
       const blob = recorderSlides.value!.getBlob()
-      const url = URL.createObjectURL(blob)
-      download(getFilename('screen', config.mimeType), url)
-      window.URL.revokeObjectURL(url)
+      downloadBlob(blob, duration, getFilename('screen', config.mimeType))
       closeStream(streamCapture)
       closeStream(streamSlides)
       recorderSlides.value = undefined
     })
+  }
+
+  async function downloadBlob(blob: Blob, duration: number, filename: string) {
+    const fixedBlob = await fixWebmDuration(blob, duration, { logger: false })
+    const url = URL.createObjectURL(fixedBlob)
+    download(filename, url)
+    window.URL.revokeObjectURL(url)
   }
 
   function closeStream(stream: Ref<MediaStream | undefined>) {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -49,6 +49,7 @@
     "ansis": "catalog:prod",
     "drauu": "catalog:frontend",
     "file-saver": "catalog:frontend",
+    "fix-webm-duration": "catalog:frontend",
     "floating-vue": "catalog:frontend",
     "fuse.js": "catalog:frontend",
     "katex": "catalog:frontend",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,6 +120,9 @@ catalogs:
     file-saver:
       specifier: ^2.0.5
       version: 2.0.5
+    fix-webm-duration:
+      specifier: ^1.0.6
+      version: 1.0.6
     floating-vue:
       specifier: ^5.2.2
       version: 5.2.2
@@ -783,6 +786,9 @@ importers:
       file-saver:
         specifier: catalog:frontend
         version: 2.0.5
+      fix-webm-duration:
+        specifier: catalog:frontend
+        version: 1.0.6
       floating-vue:
         specifier: catalog:frontend
         version: 5.2.2(@nuxt/kit@3.13.0(rollup@4.44.1))(vue@3.5.29(typescript@5.9.3))
@@ -4532,6 +4538,9 @@ packages:
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
+
+  fix-webm-duration@1.0.6:
+    resolution: {integrity: sha512-zVAqi4gE+8ywxJuAyV/rlJVX6CMtvyapEbQx6jyoeX9TMjdqAlt/FdG5d7rXSSkDVzTvS0H7CtwzHcH/vh4FPA==}
 
   flat-cache@4.0.1:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
@@ -11017,6 +11026,8 @@ snapshots:
     dependencies:
       locate-path: 6.0.0
       path-exists: 4.0.0
+
+  fix-webm-duration@1.0.6: {}
 
   flat-cache@4.0.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -63,6 +63,7 @@ catalogs:
     '@vueuse/motion': ^3.0.3
     drauu: ^1.0.0
     file-saver: ^2.0.5
+    fix-webm-duration: ^1.0.6
     floating-vue: ^5.2.2
     fuse.js: ^7.1.0
     katex: ^0.16.33


### PR DESCRIPTION
## Summary

- Recorded WebM files from Slidev's presenter recording feature lack duration metadata, causing video players to show unknown duration and preventing seeking
- Added `fix-webm-duration` package to inject correct duration into the WebM blob before download
- Tracks recording start time and computes elapsed duration on stop

Closes #1847

## Changes

- `packages/client/logic/recording.ts`: Import `fix-webm-duration`, track `recordingStartTime`, extract blob download into `downloadBlob()` helper that fixes duration before creating the object URL
- `packages/client/package.json`: Add `fix-webm-duration` dependency (catalog reference)
- `pnpm-workspace.yaml`: Add `fix-webm-duration` to `frontend` catalog

## Test plan

- [ ] Start a Slidev presentation in presenter mode
- [ ] Record a screen capture (with or without camera)
- [ ] Stop recording and download the WebM file
- [ ] Open the file in a video player (VLC, Chrome, etc.) and verify duration is shown and seeking works