### PR TITLE
fix(cli): skip keyboard shortcut binding when stdin is not a TTY

### DIFF
--- a/packages/slidev/node/cli.ts
+++ b/packages/slidev/node/cli.ts
@@ -271,6 +271,8 @@ cli.command(
     ]
 
     function bindShortcut() {
+      if (!process.stdin.isTTY)
+        return
       process.stdin.resume()
       process.stdin.setEncoding('utf8')
       readline.emitKeypressEvents(process.stdin)


### PR DESCRIPTION
Closes #2497 

## Change

Add a `process.stdin.isTTY` guard at the top of `bindShortcut()`.