### PR TITLE
re-fix: make useIsSlideActive() based on useSlideContext().$nav.currentSlideNo instead of useNav().currentSlideNo

### DIFF
--- a/packages/client/logic/slides.ts
+++ b/packages/client/logic/slides.ts
@@ -1,7 +1,6 @@
 import type { SlideRoute } from '@slidev/types'
 import { slides } from '#slidev/slides'
 import { computed, watch, watchEffect } from 'vue'
-import { useNav } from '../composables/useNav'
 import { useSlideContext } from '../context'
 
 export { slides }
@@ -24,9 +23,9 @@ export function getSlidePath(
 }
 
 export function useIsSlideActive() {
-  const { $page } = useSlideContext()
-  const { currentSlideNo } = useNav()
-  return computed(() => $page.value === currentSlideNo.value)
+  const { $page, $nav } = useSlideContext()
+  // Use `$nav.value.currentSlideNo` rather than `useNav().currentSlideNo` to make it work in print/export mode. See https://github.com/slidevjs/slidev/issues/2310.
+  return computed(() => $page.value === $nav.value.currentSlideNo)
 }
 
 export function onSlideEnter(cb: () => void) {


### PR DESCRIPTION

Reapply the fix of #2311 because it got broken by https://github.com/slidevjs/slidev/commit/72ea8b5553ad4b6ac34ea81c1582bb942a70d635.

This fixes issue #2310 again.


Original text:

Because useNav().currentSlideNo is just a value parsed from the URL route
but useSlideContext().$nav.currentSlideNo is a more controlled value that even works in print/export mode.