### PR TITLE
docs: fix magic move block with file name example

### DIFF
--- a/docs/features/shiki-magic-move.md
+++ b/docs/features/shiki-magic-move.md
@@ -59,11 +59,11 @@ const add = () => count += 1
 You can add a title bar to magic move blocks by specifying a filename in the opening fence of each step:
 
 `````md
-````md magic-move
-```js [app.js]
+````md magic-move [app.js]
+```js
 console.log('Step 1')
 ```
-```js [app.js]
+```js
 console.log('Step 2')
 ```
 ````


### PR DESCRIPTION
The parser regex in `node/syntax/transform/magic-move.ts` captures the title from the outer fence only:

```
/^````(?:md|markdown) magic-move(?: *\[([^\]]*)\])?(?: *(\{[^}]*\}))? *([^\n]*)\n([\s\S]+?)^````\s*?$/gm
```

Group 1 (`\[([^\]]*)\]`) matches `[title]` immediately after `magic-move` on the opening fence. The inner code blocks are parsed separately by `reCodeBlock`, which does not extract a `[filename]` into the title prop.

The generated Vue component receives the title from the outer fence:

```js
return `<ShikiMagicMove ... :title='${JSON.stringify(title)}' ... />`;
```

Where `title` is the capture group from the outer fence regex.