### PR TITLE
docs: fix typo in addon usage instructions

### DIFF
--- a/docs/guide/write-addon.md
+++ b/docs/guide/write-addon.md
@@ -45,4 +45,4 @@ Addons should follow the following conventions:
 - Package name should start with `slidev-addon-`. For example, `slidev-addon-name` or `@scope/slidev-addon-name`
 - Add `"slidev-addon"` and `"slidev"` in the `keywords` field of your `package.json`
 
-Addon can be used locally without publishing to NPM. If your addon is only for personal use, you can simply use it as a local addon, or publish it as a private scoped package. However, it is recommended to publish it to the NPM registry if you want to share it with others.
+Addons can be used locally without publishing to NPM. If your addon is only for personal use, you can simply use it as a local addon, or publish it as a private scoped package. However, it is recommended to publish it to the NPM registry if you want to share it with others.

--- a/docs/guide/write-addon.md
+++ b/docs/guide/write-addon.md
@@ -45,4 +45,4 @@ Addons should follow the following conventions:
 - Package name should start with `slidev-addon-`. For example, `slidev-addon-name` or `@scope/slidev-addon-name`
 - Add `"slidev-addon"` and `"slidev"` in the `keywords` field of your `package.json`
 
-Theme can be used locally without publishing to NPM. If your addon is only for personal use, you can simply use it as a local addon, or publish it as a private scoped package. However, it is recommended to publish it to the NPM registry if you want to share it with others.
+Addon can be used locally without publishing to NPM. If your addon is only for personal use, you can simply use it as a local addon, or publish it as a private scoped package. However, it is recommended to publish it to the NPM registry if you want to share it with others.


### PR DESCRIPTION
# summary

Replace "Theme" to "Addon" in addon guide.