### PR TITLE
feat: onSlideEnter/Leave after mounted + pass idx

### DIFF
--- a/docs/features/slide-hook.md
+++ b/docs/features/slide-hook.md
@@ -15,11 +15,11 @@ import { onSlideEnter, onSlideLeave, useIsSlideActive } from '@slidev/client'
 
 const isActive = useIsSlideActive()
 
-onSlideEnter(() => {
+onSlideEnter((to, from) => {
   /* Called whenever the slide becomes active */
 })
 
-onSlideLeave(() => {
+onSlideLeave((to, from) => {
   /* Called whenever the slide becomes inactive */
 })
 ```

--- a/docs/guide/global-context.md
+++ b/docs/guide/global-context.md
@@ -38,8 +38,8 @@ const { $slidev } = useSlideContext()
 const { currentPage, currentLayout, currentSlideRoute } = useNav()
 const { isDark } = useDarkMode()
 const isActive = useIsSlideActive()
-onSlideEnter(() => { /* ... */ })
-onSlideLeave(() => { /* ... */ })
+onSlideEnter((to, from) => { /* ... */ })
+onSlideLeave((to, from) => { /* ... */ })
 // ...
 </script>
 ```

--- a/packages/client/logic/slides.ts
+++ b/packages/client/logic/slides.ts
@@ -47,6 +47,6 @@ export function onSlideLeave(cb: (to: number, from: number | undefined) => any) 
     watch(() => $nav.value.currentSlideNo, (to, from) => {
       if ($page.value === from)
         cb(to, from)
-    }, { immediate: true })
+    })
   })
 }

--- a/packages/client/logic/slides.ts
+++ b/packages/client/logic/slides.ts
@@ -1,6 +1,6 @@
 import type { SlideRoute } from '@slidev/types'
 import { slides } from '#slidev/slides'
-import { computed, watch, watchEffect } from 'vue'
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useSlideContext } from '../context'
 
 export { slides }
@@ -28,12 +28,30 @@ export function useIsSlideActive() {
   return computed(() => $page.value === $nav.value.currentSlideNo)
 }
 
-export function onSlideEnter(cb: () => void) {
-  const isActive = useIsSlideActive()
-  watchEffect(() => isActive.value && cb())
+export function useIsMounted() {
+  const ismounted = ref<boolean>(false)
+  onMounted(() => {
+    ismounted.value = true
+  })
+  onUnmounted(() => {
+    ismounted.value = false
+  })
+  return ismounted
 }
 
-export function onSlideLeave(cb: () => void) {
-  const isActive = useIsSlideActive()
-  watch(isActive, () => !isActive.value && cb())
+export function onSlideEnter(cb: (to: number, from: number | undefined) => any) {
+  const ismounted = useIsMounted()
+  const { $page, $nav } = useSlideContext()
+
+  // Note: using watch + immediate rather than watchEffect since the latter could have
+  //   unexpected reloads triggered by references used in `cb`
+  // Note: using `ismounted` to make sure `onSliderEnter` is only called after `onMounted`
+  watch(() => [$nav.value.currentSlideNo, ismounted.value], ([to, mounted], from) =>
+    $page.value === to && mounted && cb(to, from ? from[0] as number : undefined), { immediate: true, flush: 'post' })
+}
+
+export function onSlideLeave(cb: (to: number, from: number | undefined) => any) {
+  const { $page, $nav } = useSlideContext()
+  watch(() => $nav.value.currentSlideNo, (to, from) =>
+    $page.value === from && cb(to, from))
 }

--- a/packages/client/logic/slides.ts
+++ b/packages/client/logic/slides.ts
@@ -1,6 +1,7 @@
 import type { SlideRoute } from '@slidev/types'
 import { slides } from '#slidev/slides'
-import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+import { tryOnMounted } from '@vueuse/core'
+import { computed, watch } from 'vue'
 import { useSlideContext } from '../context'
 
 export { slides }
@@ -28,30 +29,24 @@ export function useIsSlideActive() {
   return computed(() => $page.value === $nav.value.currentSlideNo)
 }
 
-export function useIsMounted() {
-  const ismounted = ref<boolean>(false)
-  onMounted(() => {
-    ismounted.value = true
-  })
-  onUnmounted(() => {
-    ismounted.value = false
-  })
-  return ismounted
-}
-
 export function onSlideEnter(cb: (to: number, from: number | undefined) => any) {
-  const ismounted = useIsMounted()
   const { $page, $nav } = useSlideContext()
 
-  // Note: using watch + immediate rather than watchEffect since the latter could have
-  //   unexpected reloads triggered by references used in `cb`
-  // Note: using `ismounted` to make sure `onSliderEnter` is only called after `onMounted`
-  watch(() => [$nav.value.currentSlideNo, ismounted.value], ([to, mounted], from) =>
-    $page.value === to && mounted && cb(to, from ? from[0] as number : undefined), { immediate: true, flush: 'post' })
+  tryOnMounted(() => {
+    watch(() => $nav.value.currentSlideNo, (to, from) => {
+      if ($page.value === to)
+        cb(to, from)
+    }, { immediate: true })
+  })
 }
 
 export function onSlideLeave(cb: (to: number, from: number | undefined) => any) {
   const { $page, $nav } = useSlideContext()
-  watch(() => $nav.value.currentSlideNo, (to, from) =>
-    $page.value === from && cb(to, from))
+
+  tryOnMounted(() => {
+    watch(() => $nav.value.currentSlideNo, (to, from) => {
+      if ($page.value === from)
+        cb(to, from)
+    }, { immediate: true })
+  })
 }

--- a/skills/slidev/references/api-slide-hooks.md
+++ b/skills/slidev/references/api-slide-hooks.md
@@ -14,11 +14,11 @@ import { onSlideEnter, onSlideLeave, useIsSlideActive } from '@slidev/client'
 
 const isActive = useIsSlideActive()
 
-onSlideEnter(() => {
+onSlideEnter((to, from) => {
   // Called when slide becomes active
 })
 
-onSlideLeave(() => {
+onSlideLeave((to, from) => {
   // Called when slide becomes inactive
 })
 ```

--- a/skills/slidev/references/core-global-context.md
+++ b/skills/slidev/references/core-global-context.md
@@ -113,12 +113,12 @@ const { $page, $clicks, $frontmatter } = useSlideContext()
 ```ts
 import { onSlideEnter, onSlideLeave } from '@slidev/client'
 
-onSlideEnter(() => {
+onSlideEnter((to, from) => {
   // Slide became active
   startAnimation()
 })
 
-onSlideLeave(() => {
+onSlideLeave((to, from) => {
   // Slide became inactive
   cleanup()
 })


### PR DESCRIPTION
This PR refactors the `onSlideEnter` and `onSlideLeave` functions providing 3 contributions

### 1. replace `watchEffect` with `watch` 

Using `watchEffect` for the definition of `onSlideEnter` would cause unintended invocations triggered by arbitrary references used inside the callback. I would consider this a bug in the previous implementation, which was fixed by replacing it with a plain `watch` which only triggers based on the explicitly provided dependencies.

To retain the initial invocation on slide load I configured `{ immediate: true }`, though I think it is not necessary anymore since the hook should always be set up before mounting and thus will be triggered by `ismouted.value = true` anyhow.

### 2. make sure `onSlideEnter` is (always) called after `onMounted`

AFAICT this guarantee only provides benefits. I would argue that most of the use cases of `onSlideEnter`/`onSlideLeave` want to do some setup/DOM configurations and are thus expecting this ordering already, even though it is currently not guaranteed.

The new version of `onSlideEnter` uses a dependency on `ismounted` to get as close as possible to the desired ordering. However, I am still not entirely sure whether the ordering is actually guaranteed now, as the Vue documentation is not as explicit as I would like it to be.

Maybe one should consider adding `nextTick`? But I'd argue that it is already good enough.


### 3. passing the current / previous slide number to `onSlideEnter`/`onSlideLeave`

In my personal developments I found these arguments to be quite handy, so I decided to include them here as well. Sure, one could argue that one of the parameters is useless as it just mirrors `$page.value`, but that didn't really matter to me.