### PR TITLE
Fix scaling in export view

### DIFF
--- a/packages/client/pages/export.vue
+++ b/packages/client/pages/export.vue
@@ -351,6 +351,10 @@ h2 {
 #export-content {
   --uno: pointer-events-none;
 }
+
+#export-container {
+  --slidev-slide-container-scale: var(--slidev-slide-scale);
+}
 </style>
 
 <style>


### PR DESCRIPTION
This fixes a visual bug in the export view. As the export view does not use the same `SlideWrapper` component the scaling is not provided correctly. This can be notices at the rough notations for instance:

---

<img style="border: black 1px solid" width="696" height="248" alt="Screenshot from 2026-04-14 20-19-40" src="https://github.com/user-attachments/assets/4d4d56e4-12f1-456e-9fdb-4f61a246c0f7" />
<img width="651" height="248" alt="Screenshot from 2026-04-14 20-20-40" src="https://github.com/user-attachments/assets/8d1fa598-e037-436b-8205-5e89bdc07e43" />

---

By adding the container `--slidev-slide-container-scale` the scale is provided during export render fixing the visuals:

---

<img width="651" height="248" alt="Screenshot from 2026-04-14 20-20-17" src="https://github.com/user-attachments/assets/a7d07699-fff2-4403-a660-4968323d81ba" />
<img width="651" height="248" alt="Screenshot from 2026-04-14 20-20-27" src="https://github.com/user-attachments/assets/82b67946-4777-48a8-a648-bfb7490ffb2c" />

---