### PR TITLE
feat(build): add --router-mode flag for build command

### DIFF
--- a/packages/slidev/node/cli.ts
+++ b/packages/slidev/node/cli.ts
@@ -352,6 +352,11 @@ cli.command(
       type: 'boolean',
       describe: 'exclude speaker notes from the built output',
     })
+    .option('router-mode', {
+      type: 'string',
+      choices: ['hash', 'history'],
+      describe: 'override routerMode in the built output (hash for subdirectory deploys like GitHub Pages)',
+    })
     .option('inspect', {
       default: false,
       type: 'boolean',
@@ -360,11 +365,11 @@ cli.command(
     .strict()
     .help(),
   async (args) => {
-    const { entry, theme, base, download, out, inspect, 'without-notes': withoutNotes } = args
+    const { entry, theme, base, download, out, inspect, 'without-notes': withoutNotes, 'router-mode': routerMode } = args
     const { build } = await import('./commands/build')
 
     for (const entryFile of entry as unknown as string[]) {
-      const options = await resolveOptions({ entry: entryFile, theme, inspect, download, base, withoutNotes }, 'build')
+      const options = await resolveOptions({ entry: entryFile, theme, inspect, download, base, withoutNotes, routerMode: routerMode as 'hash' | 'history' | undefined }, 'build')
 
       printInfo(options)
       await build(

--- a/packages/slidev/node/options.ts
+++ b/packages/slidev/node/options.ts
@@ -38,6 +38,9 @@ export async function resolveOptions(
   if (entryOptions.download)
     config.download ||= entryOptions.download
 
+  if (entryOptions.routerMode)
+    config.routerMode = entryOptions.routerMode
+
   debug({
     ...rootsInfo,
     ...entryOptions,

--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -46,6 +46,11 @@ export interface SlidevEntryOptions {
    * Exclude speaker notes from the built output
    */
   withoutNotes?: boolean
+
+  /**
+   * Override routerMode at build time
+   */
+  routerMode?: 'hash' | 'history'
 }
 
 export interface ResolvedSlidevOptions extends RootsInfo, SlidevEntryOptions {


### PR DESCRIPTION
## Summary

Adds a `--router-mode=hash|history` flag to `slidev build`, fixing #2542. Users deploying to a GitHub Pages subdirectory (where hash routing is required) no longer need to edit their `slides.md` headmatter as part of the build pipeline.

## Why this matters

From the issue: "Manually updating slides.md in the build pipeline seems dangerous." Permanent headmatter edits for deploy-target-specific routing is exactly the kind of config that belongs behind a CLI flag. Slidev already accepts overrides for `--theme`, `--base`, `--download`, `--without-notes` at build time; `--router-mode` fills an obvious gap.

## Changes

Three files, ~15 lines net:

- `packages/types/src/options.ts` — adds optional `routerMode?: 'hash' | 'history'` to `SlidevEntryOptions` with a short JSDoc comment, following the existing field pattern.
- `packages/slidev/node/options.ts` — in `resolveOptions()`, if `entryOptions.routerMode` is set, assigns it to `config.routerMode`. Uses `=` (not `||=`) because an explicit CLI flag should override the headmatter value rather than fall back to it. Placed next to the existing `if (entryOptions.download)` override.
- `packages/slidev/node/cli.ts` — adds `.option('router-mode', { type: 'string', choices: ['hash', 'history'], … })` to the `build` command's args chain (between `without-notes` and `inspect`), destructures it in the handler, and passes it through `resolveOptions`. A one-line `as 'hash' | 'history' | undefined` cast keeps TypeScript happy with yargs' runtime-narrowed `choices`.

Dev and export commands aren't covered by this PR per the issue's explicit scope ("A new flag `--router-mode=hash` in `slidev build`"). Easy follow-up if wanted.

## Testing

- `pnpm install` succeeds.
- `pnpm -F slidev build` — clean build, no new errors.
- `pnpm typecheck` — the only errors are pre-existing VitePress-in-docs TS7016 warnings unrelated to this PR. The `cli.ts` line that was initially flagged TS2322 after the first pass is now resolved via the choices cast.

## Usage

```bash
# Hash routing (for GH Pages subdirectory deploys)
slidev build --router-mode=hash slides.md

# History routing (usually the default)
slidev build --router-mode=history slides.md
```

If the flag is omitted, the headmatter's `routerMode` value is used unchanged.

Closes #2542

This contribution was developed with AI assistance (Codex).
