### PR TITLE
fix(client): make drawing stroke-width control clickable

### DIFF
--- a/packages/client/internals/DrawingControls.vue
+++ b/packages/client/internals/DrawingControls.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Menu } from 'floating-vue'
+import { computed, ref } from 'vue'
 import { useDrawings } from '../composables/useDrawings'
 import Draggable from './Draggable.vue'
 import IconButton from './IconButton.vue'
@@ -18,6 +18,15 @@ const {
   brushColors,
 } = useDrawings()
 
+const strokePopoverOpen = ref(false)
+const strokeBtnRef = ref<HTMLElement>()
+const strokePopoverStyle = computed(() => {
+  const el = strokeBtnRef.value
+  if (!el)
+    return {}
+  const rect = el.getBoundingClientRect()
+  return { top: `${rect.bottom + 4}px`, left: `${rect.left}px` }
+})
 function undo() {
   drauu.undo()
 }
@@ -71,25 +80,26 @@ function setBrushColor(color: string) {
 
     <VerticalDivider />
 
-    <Menu>
-      <IconButton title="Adjust stroke width" :class="{ shallow: drawingMode === 'eraseLine' }">
+    <div ref="strokeBtnRef">
+      <IconButton title="Adjust stroke width" :class="{ shallow: drawingMode === 'eraseLine' }" @click="strokePopoverOpen = !strokePopoverOpen">
         <svg viewBox="0 0 32 32" width="1.2em" height="1.2em">
           <line x1="2" y1="15" x2="22" y2="4" stroke="currentColor" stroke-width="1" stroke-linecap="round" />
           <line x1="2" y1="24" x2="28" y2="10" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
           <line x1="7" y1="31" x2="29" y2="19" stroke="currentColor" stroke-width="3" stroke-linecap="round" />
         </svg>
       </IconButton>
-      <template #popper>
-        <div class="flex bg-main p-2">
+      <Teleport to="body">
+        <div v-if="strokePopoverOpen" class="fixed inset-0" style="z-index: 9998" @click="strokePopoverOpen = false" />
+        <div v-if="strokePopoverOpen" class="fixed bg-main p-2 rounded-md shadow-lg border border-main" style="z-index: 9999" :style="strokePopoverStyle">
           <div class="inline-block w-7 text-center">
             {{ brush.size }}
           </div>
           <div class="pt-.5">
-            <input v-model="brush.size" type="range" min="1" max="15" @change="drawingMode = lastDrawingMode">
+            <input v-model="brush.size" type="range" min="1" max="15" @change="drawingMode = lastDrawingMode; strokePopoverOpen = false">
           </div>
         </div>
-      </template>
-    </Menu>
+      </Teleport>
+    </div>
     <IconButton
       v-for="color of brushColors"
       :key="color"
@@ -132,9 +142,3 @@ function setBrushColor(color: string) {
     </IconButton>
   </Draggable>
 </template>
-
-<style>
-.v-popper--theme-menu .v-popper__arrow-inner {
-  --uno: border-main;
-}
-</style>


### PR DESCRIPTION
Closes #2550.

## Summary

This makes the drawing toolbar's stroke-width control open as an interactive popover when clicked/tapped.

On current `main`, the control is implemented with floating-vue `Menu`, which is hover-oriented. In practice, clicking the button does nothing on desktop, and tapping it does nothing on touch devices.

## What changed

- replace the current hover/menu-based stroke-width control with a small local popover
- open it on click/tap
- render the popover and backdrop via `Teleport` so they remain interactive above the toolbar
- close it when clicking the backdrop or after changing the slider

## Scope

This PR intentionally stays to a single file:

- `packages/client/internals/DrawingControls.vue`

It only fixes the stroke-width control interaction bug and does not change drawing behavior itself.

## Verification

- `pnpm -r --filter="./packages/**" --parallel run build`
- verified locally that the control:
  - opens on desktop click
  - opens on mobile/touch tap
  - allows interacting with the slider
  - closes via the backdrop
