### PR TITLE
fix(create-theme): support background prop in cover and intro layouts

### DIFF
--- a/packages/create-theme/template/example.md
+++ b/packages/create-theme/template/example.md
@@ -1,5 +1,6 @@
 ---
 theme: ./
+background: https://cover.sli.dev
 ---
 
 # Slidev Theme Starter

--- a/packages/create-theme/template/layouts/cover.vue
+++ b/packages/create-theme/template/layouts/cover.vue
@@ -1,5 +1,19 @@
+<script setup lang="ts">
+import { handleBackground } from '@slidev/client/layoutHelper'
+import { computed } from 'vue'
+
+const props = defineProps({
+  background: {
+    type: String,
+    default: undefined,
+  },
+})
+
+const style = computed(() => handleBackground(props.background))
+</script>
+
 <template>
-  <div class="slidev-layout cover">
+  <div class="slidev-layout cover" :style="style">
     <div class="my-auto w-full">
       <slot />
     </div>

--- a/packages/create-theme/template/layouts/intro.vue
+++ b/packages/create-theme/template/layouts/intro.vue
@@ -1,5 +1,19 @@
+<script setup lang="ts">
+import { handleBackground } from '@slidev/client/layoutHelper'
+import { computed } from 'vue'
+
+const props = defineProps({
+  background: {
+    type: String,
+    default: undefined,
+  },
+})
+
+const style = computed(() => handleBackground(props.background))
+</script>
+
 <template>
-  <div class="slidev-layout intro">
+  <div class="slidev-layout intro" :style="style">
     <div class="my-auto">
       <slot />
     </div>


### PR DESCRIPTION
Closes #2441
The default theme template's cover.vue and intro.vue layouts were missing support for the background frontmatter prop, so background images had no effect when creating a new theme.
Instead of manually computing backgroundImage inline (as suggested in the issue), this fix uses the existing handleBackground() utility from @slidev/client/layoutHelper — the same utility used by all built-in Slidev layouts like image-right and image-left. This correctly handles colors vs images, resolves local asset paths, and applies the right CSS defaults automatically.
Also added background: https://cover.sli.dev to example.md so new theme authors immediately see it working out of the box.