### PR TITLE
fix(vscode): remove transition from required fields in Headmatter schema

### DIFF
--- a/packages/vscode/schema/headmatter.json
+++ b/packages/vscode/schema/headmatter.json
@@ -584,7 +584,10 @@
           "description": "Default frontmatter options applied to all slides",
           "markdownDescription": "Default frontmatter options applied to all slides"
         }
-      }
+      },
+      "required": [
+        "transition"
+      ]
     },
     "BuiltinLayouts": {
       "type": "string",


### PR DESCRIPTION
Closes #2532

Remove "transition" from the required fields in the Headmatter JSON schema by explicitly declaring it as optional in the TypeScript interface, preventing VS Code from warning about missing property.