### PR TITLE
feat: load preparser also from theme

### DIFF
--- a/packages/parser/src/fs.ts
+++ b/packages/parser/src/fs.ts
@@ -61,7 +61,7 @@ export async function load(
       hm = lines.slice(1, hEnd).join('\n')
     }
     const o = YAML.parse(hm) as Record<string, unknown> ?? {}
-    extensions = await preparserExtensionLoader(o, filepath, mode)
+    extensions = await preparserExtensionLoader(options.roots, o, filepath, mode)
   }
 
   const markdownFiles: Record<string, SlidevMarkdown> = {}

--- a/packages/parser/src/fs.ts
+++ b/packages/parser/src/fs.ts
@@ -1,4 +1,11 @@
-import type { PreparserExtensionLoader, SlideInfo, SlidevData, SlidevMarkdown, SlidevPreparserExtension, SourceSlideInfo } from '@slidev/types'
+import type {
+  PreparserExtensionLoader,
+  SlideInfo,
+  SlidevData,
+  SlidevMarkdown,
+  SlidevPreparserExtension,
+  SourceSlideInfo,
+} from '@slidev/types'
 import { existsSync } from 'node:fs'
 import { readFile, writeFile } from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
@@ -19,6 +26,11 @@ export function injectPreparserExtensionLoader(fn: PreparserExtensionLoader) {
   preparserExtensionLoader = fn
 }
 
+export interface LoadRootsInfo {
+  roots: string[]
+  userRoot: string
+}
+
 /**
  * Slidev data without config and themeMeta,
  * because config and themeMeta depends on the theme to be loaded.
@@ -26,7 +38,7 @@ export function injectPreparserExtensionLoader(fn: PreparserExtensionLoader) {
 export type LoadedSlidevData = Omit<SlidevData, 'config' | 'themeMeta'>
 
 export async function load(
-  userRoot: string,
+  options: LoadRootsInfo,
   filepath: string,
   sources: Record<string, string> | ((path: string) => Promise<string>) = {},
   mode?: string,
@@ -93,7 +105,7 @@ export async function load(
       const [rawPath, rangeRaw] = slide.frontmatter.src.split('#')
       const path = slash(
         rawPath.startsWith('/')
-          ? resolve(userRoot, rawPath.substring(1))
+          ? resolve(options.userRoot, rawPath.substring(1))
           : resolve(dirname(slide.filepath), rawPath),
       )
 

--- a/packages/slidev/node/cli.ts
+++ b/packages/slidev/node/cli.ts
@@ -18,7 +18,7 @@ import { createServer } from './commands/serve'
 import { getThemeMeta, resolveTheme } from './integrations/themes'
 import { resolveOptions } from './options'
 import { parser } from './parser'
-import { getRoots, isInstalledGlobally, resolveEntry } from './resolver'
+import { isInstalledGlobally, resolveEntry } from './resolver'
 import setupPreparser from './setups/preparser'
 import { updateFrontmatterPatch } from './utils'
 
@@ -158,7 +158,7 @@ cli.command(
         {
           async loadData(loadedSource) {
             const { data: oldData, entry } = options
-            const loaded = await parser.load(options.userRoot, entry, loadedSource, 'dev')
+            const loaded = await parser.load(options, entry, loadedSource, 'dev')
 
             const themeRaw = theme || loaded.headmatter.theme as string || 'default'
             if (options.themeRaw !== themeRaw) {
@@ -411,8 +411,8 @@ cli.command(
           }),
         async ({ entry: entryRaw, dir, theme: themeInput }) => {
           const entry = await resolveEntry(entryRaw)
-          const roots = await getRoots(entry)
-          const data = await parser.load(roots.userRoot, entry)
+          const options = await resolveOptions({ entry }, 'dev')
+          const data = await parser.load(options, entry)
           let themeRaw = themeInput || data.headmatter.theme as string | null | undefined
           themeRaw = themeRaw === null ? 'none' : (themeRaw || 'default')
           if (themeRaw === 'none') {

--- a/packages/slidev/node/options.ts
+++ b/packages/slidev/node/options.ts
@@ -22,7 +22,7 @@ export async function resolveOptions(
 ): Promise<ResolvedSlidevOptions> {
   const entry = await resolveEntry(entryOptions.entry)
   const rootsInfo = await getRoots(entry)
-  const loaded = await parser.load(rootsInfo.userRoot, entry, undefined, mode)
+  const loaded = await parser.load({ userRoot: rootsInfo.userRoot, roots: [rootsInfo.userRoot] }, entry, undefined, mode)
 
   // Load theme data first, because it may affect the config
   let themeRaw = entryOptions.theme || loaded.headmatter.theme as string | null | undefined

--- a/packages/slidev/node/setups/preparser.ts
+++ b/packages/slidev/node/setups/preparser.ts
@@ -6,7 +6,7 @@ import { getRoots } from '../resolver'
 import { loadSetups } from './load'
 
 export default function setupPreparser() {
-  injectPreparserExtensionLoader(async (headmatter: Record<string, unknown>, filepath: string, mode?: string) => {
+  injectPreparserExtensionLoader(async (_: string[], headmatter: Record<string, unknown>, filepath: string, mode?: string) => {
     // Ensure addons is an array or an empty array if undefined
     const addons = Array.isArray(headmatter?.addons) ? headmatter.addons as string[] : []
 

--- a/packages/slidev/node/setups/preparser.ts
+++ b/packages/slidev/node/setups/preparser.ts
@@ -1,21 +1,9 @@
 import type { PreparserSetup } from '@slidev/types'
-import { uniq } from '@antfu/utils'
 import { injectPreparserExtensionLoader } from '@slidev/parser/fs'
-import { resolveAddons } from '../integrations/addons'
-import { getRoots } from '../resolver'
 import { loadSetups } from './load'
 
 export default function setupPreparser() {
-  injectPreparserExtensionLoader(async (_: string[], headmatter: Record<string, unknown>, filepath: string, mode?: string) => {
-    // Ensure addons is an array or an empty array if undefined
-    const addons = Array.isArray(headmatter?.addons) ? headmatter.addons as string[] : []
-
-    const { userRoot } = await getRoots()
-    const roots = uniq([
-      ...await resolveAddons(addons),
-      userRoot,
-    ])
-
+  injectPreparserExtensionLoader(async (roots: string[], headmatter: Record<string, unknown>, filepath: string, mode?: string) => {
     const returns = await loadSetups<PreparserSetup>(roots, 'preparser.ts', [{ filepath, headmatter, mode }])
     return returns.flat()
   })

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -134,7 +134,7 @@ export interface SlidevPreparserExtension {
   transformNote?: (note: string | undefined, frontmatter: any) => Promise<string | undefined>
 }
 
-export type PreparserExtensionLoader = (headmatter: Record<string, unknown>, filepath: string, mode?: string) => Promise<SlidevPreparserExtension[]>
+export type PreparserExtensionLoader = (roots: string[], headmatter: Record<string, unknown>, filepath: string, mode?: string) => Promise<SlidevPreparserExtension[]>
 
 export type RenderContext = 'none' | 'slide' | 'overview' | 'presenter' | 'previewNext'
 

--- a/packages/vscode/src/projects.ts
+++ b/packages/vscode/src/projects.ts
@@ -195,7 +195,7 @@ export function removeProject(entry: string) {
 
 async function loadProject(entry: string) {
   const userRoot = dirname(entry)
-  return markRaw(await load(userRoot, entry, async (path: string) => {
+  return markRaw(await load({ userRoot, roots: [userRoot] }, entry, async (path: string) => {
     const document = workspace.textDocuments.find(d => slash(d.uri.fsPath) === path)
     if (document) {
       return document.getText()

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -29,7 +29,7 @@ describe('md parser', () => {
 
   for (const file of files) {
     it(basename(file), async () => {
-      const data = await load(userRoot, file)
+      const data = await load({ userRoot, roots: [userRoot] }, file)
 
       expect(stringify(data.entry).trim()).toEqual(replaceCRLF(data.entry.raw.trim()))
 


### PR DESCRIPTION
Not loading preparsers from the theme is unexpected (cp. #2402, #2456) and not documented. This PR aligns the behavior such that preparsers are also loaded from the theme. It also avoids duplicating the logic to determine the roots that things are loaded from, which might also improve perforrmance by avoiding doing `resolveAddons` twice. I hope this is in line with the [requested refactor](https://github.com/slidevjs/slidev/pull/2456#issuecomment-4223724037).

[I explained my use cases for wanting to load a preparser from a theme in a prior comment.](https://github.com/slidevjs/slidev/pull/2456#issuecomment-4222739953)