### PR TITLE
fix(parser): ignore slide separators inside HTML comments

### DIFF
--- a/packages/parser/src/core.ts
+++ b/packages/parser/src/core.ts
@@ -19,6 +19,31 @@ export interface SlidevParserOptions {
   preserveCR?: boolean
 }
 
+function advanceHtmlCommentState(line: string, inHtmlComment: boolean) {
+  let cursor = 0
+
+  while (cursor < line.length) {
+    if (inHtmlComment) {
+      const end = line.indexOf('-->', cursor)
+      if (end < 0)
+        return true
+      inHtmlComment = false
+      cursor = end + 3
+    }
+    else {
+      const start = line.indexOf('<!--', cursor)
+      if (start < 0)
+        return false
+      const end = line.indexOf('-->', start + 4)
+      if (end < 0)
+        return true
+      cursor = end + 3
+    }
+  }
+
+  return inHtmlComment
+}
+
 export function stringify(data: SlidevMarkdown) {
   return `${data.slides.map(stringifySlide).join('\n').trim()}\n`
 }
@@ -200,6 +225,7 @@ export async function parse(
 
   let start = 0
   let contentStart = 0
+  let inHtmlComment = false
 
   async function slice(end: number) {
     if (start === end)
@@ -247,7 +273,17 @@ export async function parse(
   }
 
   for (let i = 0; i < lines.length; i++) {
-    const line = lines[i].trimEnd()
+    const rawLine = lines[i]
+    const line = rawLine.trimEnd()
+    if (inHtmlComment) {
+      inHtmlComment = advanceHtmlCommentState(rawLine, true)
+      continue
+    }
+
+    inHtmlComment = advanceHtmlCommentState(rawLine, false)
+    if (inHtmlComment)
+      continue
+
     if (line.startsWith('---')) {
       await slice(i)
 
@@ -296,6 +332,7 @@ export function parseSync(
 
   let start = 0
   let contentStart = 0
+  let inHtmlComment = false
 
   function slice(end: number) {
     if (start === end)
@@ -315,7 +352,17 @@ export function parseSync(
   }
 
   for (let i = 0; i < lines.length; i++) {
-    const line = lines[i].trimEnd()
+    const rawLine = lines[i]
+    const line = rawLine.trimEnd()
+    if (inHtmlComment) {
+      inHtmlComment = advanceHtmlCommentState(rawLine, true)
+      continue
+    }
+
+    inHtmlComment = advanceHtmlCommentState(rawLine, false)
+    if (inHtmlComment)
+      continue
+
     if (line.startsWith('---')) {
       slice(i)
 

--- a/packages/parser/src/core.ts
+++ b/packages/parser/src/core.ts
@@ -280,10 +280,6 @@ export async function parse(
       continue
     }
 
-    inHtmlComment = advanceHtmlCommentState(rawLine, false)
-    if (inHtmlComment)
-      continue
-
     if (line.startsWith('---')) {
       await slice(i)
 
@@ -309,6 +305,9 @@ export async function parse(
       // Update i only when code block ends
       if (j !== lines.length)
         i = j
+    }
+    else {
+      inHtmlComment = advanceHtmlCommentState(rawLine, false)
     }
   }
 
@@ -359,10 +358,6 @@ export function parseSync(
       continue
     }
 
-    inHtmlComment = advanceHtmlCommentState(rawLine, false)
-    if (inHtmlComment)
-      continue
-
     if (line.startsWith('---')) {
       slice(i)
 
@@ -388,6 +383,9 @@ export function parseSync(
       // Update i only when code block ends
       if (j !== lines.length)
         i = j
+    }
+    else {
+      inHtmlComment = advanceHtmlCommentState(rawLine, false)
     }
   }
 

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -134,6 +134,20 @@ src: ./pages/three.md
       .toEqual(['./pages/one.md', './pages/three.md'])
   })
 
+  it('detects slide separator even when comment opens on the same line', async () => {
+    const data = await parse(`a
+
+----<!--
+hidden
+-->
+
+b
+`, 'file.md')
+
+    expect(data.slides).toHaveLength(2)
+    expect(data.slides.map(s => s.content.trim())).toEqual(['a', 'hidden\n-->\n\nb'])
+  })
+
   async function parseWithExtension(
     src: string,
     transformRawLines: (lines: string[]) => void | Promise<void> = () => {},

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -113,6 +113,27 @@ f
       .toEqual({ })
   })
 
+  it('ignores slide separators inside HTML comments', async () => {
+    const data = await parse(`---
+src: ./pages/one.md
+---
+
+<!--
+---
+src: ./pages/two.md
+---
+-->
+
+---
+src: ./pages/three.md
+---
+`, 'slides.md')
+
+    expect(data.slides).toHaveLength(2)
+    expect(data.slides.map(slide => slide.frontmatter.src))
+      .toEqual(['./pages/one.md', './pages/three.md'])
+  })
+
   async function parseWithExtension(
     src: string,
     transformRawLines: (lines: string[]) => void | Promise<void> = () => {},


### PR DESCRIPTION
## Summary
- ignore slide separators and frontmatter boundaries inside multi-line HTML comments during parser slicing
- add a parser regression test covering commented `src:` slide imports
- fix the VS Code Slidev slide tree counting issue reported in #2560

## Test Plan
- [x] `pnpm vitest test/parser.test.ts`
