### PR TITLE
fix(create-slidev): replace pnpm-specific npmrc with pnpm-workspace.yaml

### DIFF
--- a/packages/create-app/index.mjs
+++ b/packages/create-app/index.mjs
@@ -25,7 +25,6 @@ const RE_NON_ALPHANUMERIC = /[^a-z0-9-~]+/g
 
 const renameFiles = {
   _gitignore: '.gitignore',
-  _npmrc: '.npmrc',
 }
 
 async function init() {

--- a/packages/create-app/template/_npmrc
+++ b/packages/create-app/template/_npmrc
@@ -1,3 +1,0 @@
-# for pnpm
-shamefully-hoist=true
-auto-install-peers=true

--- a/packages/create-app/template/pnpm-workspace.yaml
+++ b/packages/create-app/template/pnpm-workspace.yaml
@@ -1,0 +1,1 @@
+shamefullyHoist: true


### PR DESCRIPTION
Closes #2563

## Summary

This updates `create-slidev` to stop scaffolding a pnpm-specific `.npmrc` file and instead add a `pnpm-workspace.yaml` file for pnpm configuration.

## What changed

- removed `packages/create-app/template/_npmrc`
- added `packages/create-app/template/pnpm-workspace.yaml`
- reverted the generator logic so template files are copied normally again

## Why

Previously, newly scaffolded projects included pnpm-specific `.npmrc` settings, which caused warnings for npm users.

Based on maintainer feedback, pnpm should no longer use `.npmrc` here either, so this change removes the `.npmrc` template entirely and moves the pnpm-specific config into `pnpm-workspace.yaml`.
