### PR TITLE
fix(client): make drawing stroke-width control click-triggered

### DIFF
--- a/packages/client/internals/DrawingControls.vue
+++ b/packages/client/internals/DrawingControls.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { Menu } from 'floating-vue'
+import { Dropdown } from 'floating-vue'
+import { ref } from 'vue'
 import { useDrawings } from '../composables/useDrawings'
 import Draggable from './Draggable.vue'
 import IconButton from './IconButton.vue'
@@ -17,6 +18,23 @@ const {
   drawingPinned,
   brushColors,
 } = useDrawings()
+
+const strokeWidthDropdownShown = ref(false)
+
+function showStrokeWidthDropdown(event: Event) {
+  event.preventDefault()
+  event.stopPropagation()
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      strokeWidthDropdownShown.value = true
+    })
+  })
+}
+
+function showStrokeWidthDropdownForPointer(event: PointerEvent) {
+  if (event.pointerType !== 'mouse')
+    showStrokeWidthDropdown(event)
+}
 
 function undo() {
   drauu.undo()
@@ -71,8 +89,8 @@ function setBrushColor(color: string) {
 
     <VerticalDivider />
 
-    <Menu>
-      <IconButton title="Adjust stroke width" :class="{ shallow: drawingMode === 'eraseLine' }">
+    <Dropdown v-model:shown="strokeWidthDropdownShown" :triggers="[]">
+      <IconButton title="Adjust stroke width" :class="{ shallow: drawingMode === 'eraseLine' }" @click="showStrokeWidthDropdown" @pointerdown="showStrokeWidthDropdownForPointer" @pointerup="showStrokeWidthDropdownForPointer" @touchend="showStrokeWidthDropdown">
         <svg viewBox="0 0 32 32" width="1.2em" height="1.2em">
           <line x1="2" y1="15" x2="22" y2="4" stroke="currentColor" stroke-width="1" stroke-linecap="round" />
           <line x1="2" y1="24" x2="28" y2="10" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
@@ -89,7 +107,7 @@ function setBrushColor(color: string) {
           </div>
         </div>
       </template>
-    </Menu>
+    </Dropdown>
     <IconButton
       v-for="color of brushColors"
       :key="color"
@@ -134,7 +152,7 @@ function setBrushColor(color: string) {
 </template>
 
 <style>
-.v-popper--theme-menu .v-popper__arrow-inner {
+.v-popper--theme-dropdown .v-popper__arrow-inner {
   --uno: border-main;
 }
 </style>


### PR DESCRIPTION
Closes #2550. Replaces #2551 per @antfu's review feedback.

## Problem

The drawing toolbar's "Adjust stroke width" control uses floating-vue's `<Menu>`, which defaults to hover/focus behavior (`triggers: ["hover", "focus"]`, `popperTriggers: ["hover"]`). On desktop the click does nothing; on touch devices the tap does nothing.

## Fix

Swap `<Menu>` for `<Dropdown>`. They share the same Popper internals; `<Dropdown>` is the click-oriented floating-vue component, which is the desired UX. No custom popover and no Teleport — the popper remains floating-vue-managed, as suggested in #2551.

For the stroke-width button, the Dropdown is controlled with `v-model:shown` and its built-in trigger listeners are disabled for this reference button. The button opens the Dropdown from `click`, `pointerup`, or `touchend`, delayed two animation frames so floating-vue's touch auto-hide guard has already completed. Outside-click/tap dismissal remains handled by floating-vue `autoHide` through the same `v-model:shown` update.

The `<style>` arrow-color selector is updated from the `menu` theme to the `dropdown` theme to keep visual parity.

## Verification

- `pnpm build` clean.
- `pnpm eslint packages/client/internals/DrawingControls.vue --cache` clean.
- Local browser verification before this revision confirmed desktop click opens and outside click closes. This revision preserves the same Dropdown/autoHide path while moving trigger ownership to the button events.
