### PR TITLE
fix: restore Windows virtual style globs

### DIFF
--- a/packages/slidev/node/utils.ts
+++ b/packages/slidev/node/utils.ts
@@ -1,7 +1,7 @@
 import type { ResolvedFontOptions, SourceSlideInfo } from '@slidev/types'
 import type MarkdownExit from 'markdown-exit'
 import type { Connect, GeneralImportGlobOptions } from 'vite'
-import { relative } from 'node:path'
+import { relative, win32 } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { slash } from '@antfu/utils'
 import { createJiti } from 'jiti'
@@ -10,6 +10,7 @@ import YAML from 'yaml'
 const RE_WHITESPACE_ONLY = /^\s*$/
 const RE_QUOTED_STRING = /^(['"])(.*)\1$/
 const RE_WHITESPACE = /\s+/g
+const RE_WINDOWS_DRIVE = /^[A-Z]:\//i
 
 type Token = ReturnType<MarkdownExit['parseInline']>[number]
 
@@ -104,16 +105,38 @@ export function getBodyJson(req: Connect.IncomingMessage) {
   })
 }
 
+function getImportGlobRelativePath(from: string, to: string) {
+  const normalizedFrom = slash(from)
+  const normalizedTo = slash(to)
+  return slash(
+    RE_WINDOWS_DRIVE.test(normalizedFrom) || RE_WINDOWS_DRIVE.test(normalizedTo)
+      ? win32.relative(normalizedFrom, normalizedTo)
+      : relative(normalizedFrom, normalizedTo),
+  )
+}
+
 export function makeAbsoluteImportGlob(
   self: string,
   globs: string[],
   options: Partial<GeneralImportGlobOptions> = {},
+  baseRoot?: string,
 ) {
-  // Vite's import.meta.glob only supports relative paths
-  const relativeGlobs = globs.map(glob => `${slash(relative(self, glob))}`)
+  // Vite's import.meta.glob only supports relative paths. On Windows, though,
+  // resolving drive-letter paths from a virtual /@slidev module can drop the
+  // drive prefix. Use Vite's root-relative form for those paths instead.
+  const root = baseRoot && globs.some(glob => RE_WINDOWS_DRIVE.test(slash(glob)))
+    ? baseRoot
+    : undefined
+  const relativeGlobs = globs.map((glob) => {
+    const relativeGlob = getImportGlobRelativePath(root ?? self, glob)
+    return root && !relativeGlob.startsWith('.') && !RE_WINDOWS_DRIVE.test(relativeGlob)
+      ? `./${relativeGlob}`
+      : relativeGlob
+  })
   const opts: GeneralImportGlobOptions = {
     eager: true,
     exhaustive: true,
+    ...(root ? { base: '/' } : {}),
     ...options,
   }
   return `import.meta.glob(${JSON.stringify(relativeGlobs)}, ${JSON.stringify(opts)})`

--- a/packages/slidev/node/virtual/conditional-styles.ts
+++ b/packages/slidev/node/virtual/conditional-styles.ts
@@ -7,7 +7,7 @@ const id = '/@slidev/conditional-styles'
 
 export const templateConditionalStyles: VirtualModuleTemplate = {
   id,
-  async getContent({ data, roots }) {
+  async getContent({ data, roots, userRoot }) {
     const imports: string[] = []
 
     for (const root of roots) {
@@ -15,7 +15,7 @@ export const templateConditionalStyles: VirtualModuleTemplate = {
         join(root, 'styles/index.{ts,js,css}'),
         join(root, 'styles.{ts,js,css}'),
         join(root, 'style.{ts,js,css}'),
-      ]))
+      ], {}, userRoot))
     }
 
     if (data.features.katex)

--- a/packages/slidev/node/virtual/global-layers.ts
+++ b/packages/slidev/node/virtual/global-layers.ts
@@ -6,13 +6,13 @@ const id = `/@slidev/global-layers`
 
 export const templateGlobalLayers: VirtualModuleTemplate = {
   id,
-  getContent({ roots }) {
+  getContent({ roots, userRoot }) {
     function* getComponent(name: string, names: string[]) {
       yield `const ${name}Components = [\n`
       for (const root of roots) {
         const globs = names.map(name => join(root, `${name}.{ts,js,vue}`))
         yield '  Object.values('
-        yield makeAbsoluteImportGlob(id, globs, { import: 'default' })
+        yield makeAbsoluteImportGlob(id, globs, { import: 'default' }, userRoot)
         yield ')[0],\n'
       }
       yield `].filter(Boolean)\n`

--- a/packages/slidev/node/virtual/setups.ts
+++ b/packages/slidev/node/virtual/setups.ts
@@ -6,10 +6,10 @@ function createSetupTemplate(name: string): VirtualModuleTemplate {
   const id = `/@slidev/setups/${name}`
   return {
     id,
-    getContent({ roots }) {
+    getContent({ roots, userRoot }) {
       const globs = roots.map((root) => {
         const glob = join(root, `setup/${name}.{ts,js,mts,mjs}`)
-        return `Object.values(${makeAbsoluteImportGlob(id, [glob], { import: 'default' })})[0]`
+        return `Object.values(${makeAbsoluteImportGlob(id, [glob], { import: 'default' }, userRoot)})[0]`
       })
       return `export default [${globs.join(', ')}].filter(Boolean)`
     },

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it } from 'vitest'
 import YAML from 'yaml'
 import { parseAspectRatio, parseRangeString } from '../packages/parser/src'
 import { getRoots } from '../packages/slidev/node/resolver'
-import { generateCoollabsFontsUrl, generateGoogleFontsUrl, stringifyMarkdownTokens, updateFrontmatterPatch } from '../packages/slidev/node/utils'
+import { generateCoollabsFontsUrl, generateGoogleFontsUrl, makeAbsoluteImportGlob, stringifyMarkdownTokens, updateFrontmatterPatch } from '../packages/slidev/node/utils'
 
 describe('utils', () => {
   it('page-range', () => {
@@ -87,6 +87,16 @@ describe('utils', () => {
     expectRelative(clientRoot).toMatchInlineSnapshot(`"../packages/client"`)
     expectRelative(userRoot).toMatchInlineSnapshot(`".."`)
     expectRelative(userWorkspaceRoot).toMatchInlineSnapshot(`".."`)
+  })
+
+  it('uses root-relative glob patterns for Windows drive paths', () => {
+    expect(makeAbsoluteImportGlob('/@slidev/conditional-styles', [
+      'C:\\Users\\Donald\\Documents\\slides\\styles\\index.{ts,js,css}',
+      'C:\\Users\\Donald\\Documents\\slides\\styles.{ts,js,css}',
+      'C:\\Users\\Donald\\Documents\\slides\\style.{ts,js,css}',
+    ], {}, 'C:\\Users\\Donald\\Documents\\slides')).toMatchInlineSnapshot(
+      `"import.meta.glob([\"./styles/index.{ts,js,css}\",\"./styles.{ts,js,css}\",\"./style.{ts,js,css}\"], {\"eager\":true,\"exhaustive\":true,\"base\":\"/\"})"`,
+    )
   })
 
   it('update frontmatter patch', async () => {


### PR DESCRIPTION
## Summary

- Preserve the self-relative `import.meta.glob` behavior for normal paths, but fall back to Vite root-relative globs for Windows drive-letter paths so virtual modules do not lose the drive prefix.
- Pass `userRoot` into the virtual glob helper for conditional styles, global layers, and setup modules.
- Add a regression test covering `C:\\...` conditional style glob generation.

Fixes #2567.

## Tests

- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm exec vitest run --project test test/utils.test.ts`
- `pnpm exec eslint packages/slidev/node/utils.ts packages/slidev/node/virtual/conditional-styles.ts packages/slidev/node/virtual/global-layers.ts packages/slidev/node/virtual/setups.ts test/utils.test.ts`
- `pnpm --filter @slidev/types --filter @slidev/parser --filter @slidev/client --filter @slidev/cli build`
- `pnpm exec slidev build demo/starter/slides.md --out /tmp/oss-pr-pipeline/round-10-ai-tools-20260429T231732Z/slidev-2567/validation-build-output`
- `git diff --check`
