### PR TITLE
fix(export): pass timeout to frame.waitForLoadState()

### DIFF
--- a/packages/slidev/node/commands/export.ts
+++ b/packages/slidev/node/commands/export.ts
@@ -276,7 +276,7 @@ export async function exportSlides({
     // Wait for frames to load
     {
       const frames = page.frames()
-      await Promise.all(frames.map(frame => frame.waitForLoadState()))
+      await Promise.all(frames.map(frame => frame.waitForLoadState(undefined, { timeout })))
     }
     // Wait for Mermaid graphs to be rendered
     {


### PR DESCRIPTION
The timeout option was already forwarded to page.goto() and page.waitForLoadState(), but the subsequent frame loop used Playwright's hardcoded 30 s default. "Heavy" slides, iframes, or complex components could exceed 30 s, making --timeout and export.timeout ineffective.

Fixes #2577