### PR TITLE
fix(create-slidev): avoid --open in starter dev script

### DIFF
--- a/packages/create-app/template/package.json
+++ b/packages/create-app/template/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "build": "slidev build",
-    "dev": "slidev --open",
+    "dev": "slidev",
     "export": "slidev export"
   },
   "dependencies": {


### PR DESCRIPTION
Closes #2582

## Summary

This updates the `create-slidev` starter template to use `slidev` instead of `slidev --open` for the generated `dev` script.

## What changed

- changed the starter template `dev` script from:
  ```json
  "dev": "slidev --open"
  ```
  to:
  ```json
  "dev": "slidev"
  ```

## Why

On some Windows or restricted shell environments, the browser auto-open step can fail with errors like:

```text
Error: spawn EPERM
```

even though the Slidev dev server itself starts successfully.

Removing `--open` from the default starter script makes the first-run experience more reliable and avoids making setup appear broken when only the browser launch failed.
```