### PR TITLE
fix: editing presenter notes on frontmatter-only slides

### DIFF
--- a/packages/client/internals/SideEditor.vue
+++ b/packages/client/internals/SideEditor.vue
@@ -3,6 +3,7 @@ import { throttledWatch, useEventListener } from '@vueuse/core'
 import { computed, ref, watch } from 'vue'
 import { useNav } from '../composables/useNav'
 import { useDynamicSlideInfo } from '../composables/useSlideInfo'
+import { parseSideEditorContent } from '../logic/sideEditor'
 import { activeElement, editorHeight, editorWidth, isInputting, showEditor, isEditorVertical as vertical } from '../state'
 import IconButton from './IconButton.vue'
 import ShikiEditor from './ShikiEditor.vue'
@@ -10,8 +11,6 @@ import ShikiEditor from './ShikiEditor.vue'
 const props = defineProps<{
   resize?: boolean
 }>()
-
-const RE_FRONTMATTER_BLOCK = /^---\n([\s\S]*?)\n---\n/
 
 const { currentSlideNo, openInEditor } = useNav()
 
@@ -38,11 +37,7 @@ watch(
 async function save() {
   dirty.value = false
 
-  let frontmatterRaw: string | undefined
-  const contentOnly = content.value.trim().replace(RE_FRONTMATTER_BLOCK, (_, f) => {
-    frontmatterRaw = f
-    return ''
-  })
+  const { content: contentOnly, frontmatterRaw } = parseSideEditorContent(content.value)
 
   await update({
     note: note.value || undefined,

--- a/packages/client/logic/sideEditor.ts
+++ b/packages/client/logic/sideEditor.ts
@@ -1,0 +1,14 @@
+const RE_FRONTMATTER_BLOCK = /^---\n([\s\S]*?)\n---(?:\n|$)/
+
+export function parseSideEditorContent(content: string) {
+  let frontmatterRaw: string | undefined
+  const contentOnly = content.trim().replace(RE_FRONTMATTER_BLOCK, (_, f) => {
+    frontmatterRaw = f
+    return ''
+  })
+
+  return {
+    content: contentOnly,
+    frontmatterRaw,
+  }
+}

--- a/packages/slidev/node/vite/loaders.ts
+++ b/packages/slidev/node/vite/loaders.ts
@@ -107,7 +107,7 @@ export function createSlidesLoader(
                 slide.source.frontmatterDoc = parsed
             }
           }
-          if (body.note)
+          if (body.note != null)
             slide.note = slide.source.note = body.note
           if (body.frontmatter) {
             updateFrontmatterPatch(slide.source, body.frontmatter)

--- a/test/side-editor.test.ts
+++ b/test/side-editor.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { parseSideEditorContent } from '../packages/client/logic/sideEditor'
+
+describe('side editor', () => {
+  it('extracts frontmatter-only slide content', () => {
+    expect(parseSideEditorContent(`---
+layout: image
+image: /example.png
+---`)).toEqual({
+      content: '',
+      frontmatterRaw: 'layout: image\nimage: /example.png',
+    })
+  })
+
+  it('extracts frontmatter from slides with body content', () => {
+    expect(parseSideEditorContent(`---
+layout: center
+---
+
+# Hello`)).toEqual({
+      content: '\n# Hello',
+      frontmatterRaw: 'layout: center',
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Fix presenter/browser note editing for slides whose editor content is only a frontmatter block, such as image-layout slides with no Markdown body.

## Root Cause

The side editor trims the editor content before splitting out slide frontmatter. For a frontmatter-only slide, trimming removes the newline after the closing `---`, so the previous regex did not recognize the frontmatter block. The save path then sent that frontmatter back as slide body content, which could be parsed as a new slide on reload/HMR. With autosave enabled, this could create repeated image slides containing partial note edits.

This also updates the dev server note patch guard so an empty string note can be saved, allowing notes to be cleared from the editor.

## Changes

- Extract side-editor content parsing into a small helper.
- Accept either a newline or EOF after the closing frontmatter marker.
- Add regression coverage for frontmatter-only slide content.
- Treat `note: ''` as an intentional note update on the dev server.

## Validation

- `pnpm exec eslint packages/client/internals/SideEditor.vue packages/client/logic/sideEditor.ts packages/slidev/node/vite/loaders.ts test/side-editor.test.ts`
- `pnpm exec vitest run test/side-editor.test.ts`
- `pnpm run build`
- `pnpm test`

I also manually reproduced this with a personally-themed deck containing consecutive `layout: image` slides, then verified the patched editor no longer creates additional slides while editing presenter notes.
