### PR TITLE
fix(client): hide goto dialog suggestions when dialog is closed

### DIFF
--- a/packages/client/internals/Goto.vue
+++ b/packages/client/internals/Goto.vue
@@ -136,7 +136,7 @@ watch(activeElement, () => {
       >
     </div>
     <div
-      v-if="result.length > 0"
+      v-if="showGotoDialog && result.length > 0"
       ref="list"
       class="autocomplete-list"
       shadow="~"


### PR DESCRIPTION
## Summary

Hide the goto dialog's autocomplete suggestions list when the dialog itself is in its closed state, so the list cannot leak into the viewport while the dialog wrapper is offscreen.

Fixes #2593

## Background

The dialog wrapper toggles between `top-5` and `-top-20` based on `showGotoDialog`. The wrapper has no height constraint and no `overflow: hidden`, so its content can extend back into the viewport. The autocomplete list inside the wrapper renders whenever `result.length > 0`, which depends on `text` - independently of the dialog's own open/closed state.

If those two pieces of state ever drift (the dialog flips to closed while `text` still has content), the list keeps rendering and the wrapper grows tall enough that the list spills below the `-top-20` offset, exactly as observed in #2593 (`#slidev-goto-dialog.-top-20` with `height` ~666px and an `.autocomplete-list` still mounted).

## Fix

Add `showGotoDialog` to the list's `v-if` so the autocomplete list only renders while the dialog is in its open state. The list visibility now depends tautologically on the dialog's state — there's no path where the wrapper is in its closed position and the list is still mounted.

## Test plan

- `pnpm eslint packages/client/internals/Goto.vue --cache` — clean.
- `pnpm exec vue-tsc --noEmit --skipLibCheck` — no diagnostics in `packages/client` (preexisting unrelated diagnostics in `docs/node_modules/vitepress` only).
- `pnpm -C demo/starter run build` — clean.
- Manual verification in `pnpm demo:dev`:
  - press `g`, type a query → suggestions list appears as expected;
  - close the dialog → wrapper slides to `top: -80px` and the list is unmounted (previously remained rendered below the offset whenever `text` was non-empty at close-time);
  - reopen the dialog with `g` → text and selection are reset by the existing watcher, list hidden until a new query is typed.
- Reproduced the buggy state by temporarily skipping the `text` reset in `close()`: with the previous `v-if="result.length > 0"` the wrapper got `-top-20` while `.autocomplete-list` stayed mounted (matching the issue's DOM snapshot); with the new `v-if` it does not.