### PR TITLE
docs: add addon for live embedded VS Code IDE sessions

### DIFF
--- a/docs/.vitepress/addons.ts
+++ b/docs/.vitepress/addons.ts
@@ -281,6 +281,17 @@ export const community: AddonInfo[] = [
     },
     repo: 'https://github.com/andreas-taranetz/slidev-addon-animated-text',
   },
+  {
+    id: 'slidev-addon-livecode',
+    name: 'Live embedded VS Code IDE',
+    description: 'Live VS Code IDE sessions in your Slidev presentations, powered by coderaft',
+    tags: ['Component', 'Integration', 'Tool', 'IDE'],
+    author: {
+      name: 'Mickaël Alves',
+      link: 'https://mickaelalves.dev/',
+    },
+    repo: 'https://github.com/mickaelalvs/slidev-addon-livecode',
+  },
   // Add yours here!
   {
     id: '',


### PR DESCRIPTION
Hi 👋🏼

Adds [slidev-addon-livecode](https://github.com/mickaelalvs/slidev-addon-livecode) to the community addons list on the docs page 📝

This addon brings live VS Code IDE sessions directly inside Slidev presentations, powered by [coderaft](https://coderaft.dev/). It allows presenters to run a fully functional embedded IDE in their slides without leaving the presentation.

See it in action via the screen capture on the README, or try it directly with the [showcase](https://github.com/mickaelalvs/slidev-addon-livecode/tree/main/showcase) provided in the addon.

Feel free to reach out if you have any questions! 😊