### PR TITLE
fix(export): wait for v-clicks to settle before PDF/PNG snapshot

### DIFF
--- a/cypress/e2e/examples/export-clicks.spec.ts
+++ b/cypress/e2e/examples/export-clicks.spec.ts
@@ -1,0 +1,43 @@
+const BASE = 'http://localhost:3041'
+
+context('Export print-mode settle signal', () => {
+  it('one-piece print mode marks every rendered slide as settled', () => {
+    cy.visit(`${BASE}/print?print=clicks`)
+
+    // Wait until every rendered SlideWrapper has reported settle. This is the
+    // contract the Node-side export pipeline depends on before snapshotting.
+    cy.get('[data-slidev-no]', { timeout: 30000 })
+      .should('have.length.greaterThan', 0)
+      .then(($all) => {
+        cy.get('[data-slidev-no][data-slidev-print-ready]', { timeout: 30000 })
+          .should('have.length', $all.length)
+      })
+  })
+
+  it('regression #2034: first rendered instance for a v-clicks slide is the empty state', () => {
+    cy.visit(`${BASE}/print?print=clicks`)
+    // Slide 6 in the basic fixture has <v-clicks> blocks. The first SlideWrapper
+    // rendered for slide 6 must carry data-slidev-print-ready="0" — the empty
+    // state — not the final state.
+    cy.get('[data-slidev-no="6"][data-slidev-print-ready]', { timeout: 30000 })
+      .first()
+      .should('have.attr', 'data-slidev-print-ready', '0')
+  })
+
+  it('per-slide print mode marks the requested clicks state as settled', () => {
+    cy.visit(`${BASE}/6?print=clicks`)
+    cy.get('[data-slidev-no="6"][data-slidev-print-ready="0"]', { timeout: 30000 })
+      .should('exist')
+
+    cy.visit(`${BASE}/6?print=clicks&clicks=3`)
+    cy.get('[data-slidev-no="6"][data-slidev-print-ready="3"]', { timeout: 30000 })
+      .should('exist')
+  })
+
+  it('live mode does NOT write the settle attribute', () => {
+    cy.visit(`${BASE}/6`)
+    cy.get('[data-slidev-no="6"]', { timeout: 30000 })
+      .should('exist')
+      .and('not.have.attr', 'data-slidev-print-ready')
+  })
+})

--- a/packages/client/internals/PrintSlide.vue
+++ b/packages/client/internals/PrintSlide.vue
@@ -5,26 +5,39 @@ import { useFixedNav, useNav } from '../composables/useNav'
 import { CLICKS_MAX } from '../constants'
 import PrintSlideClick from './PrintSlideClick.vue'
 
-const { route } = defineProps<{ hidden?: boolean, route: SlideRoute }>()
+const { route, hidden } = defineProps<{ hidden?: boolean, route: SlideRoute }>()
 const { isPrintWithClicks } = useNav()
-const clicks0 = createFixedClicks(route, () => isPrintWithClicks.value ? 0 : CLICKS_MAX)
+
+// Snapshot the value ONCE at component setup time. The upstream code used a
+// reactive getter here, which on initial hydration could resolve to CLICKS_MAX
+// before useNav had finished initialising isPrintWithClicks — producing the
+// "final state appears as the first exported page" bug reported in #2034.
+// Reading .value once captures a stable Number.
+const initialClicks = isPrintWithClicks.value ? 0 : CLICKS_MAX
+const clicksRef = createFixedClicks(route, initialClicks)
 </script>
 
 <template>
+  <!--
+    Always-on instance. Two roles:
+      1. Renders state `clicksStart` in with-clicks mode (the empty/initial
+         state) or `CLICKS_MAX` in non-clicks mode (the final-state preview).
+      2. Its rendered slide component injects `clicksRef` and calls
+         `clicksRef.setup()` (injected by the slidev layout wrapper). When the
+         slide mounts, `clicksRef.isMounted` flips true and `maxMap` becomes
+         shallowReactive — which makes `clicksRef.total` accurate for the
+         v-for below.
+  -->
   <PrintSlideClick
     v-show="!hidden"
-    :nav="useFixedNav(route, clicks0)"
+    :nav="useFixedNav(route, clicksRef)"
   />
   <template v-if="isPrintWithClicks">
-    <!--
-      clicks0.total can be any number >=0 when rendering.
-      So total-clicksStart can be negative in intermediate states.
-    -->
     <PrintSlideClick
-      v-for="i in Math.max(0, clicks0.total - clicks0.clicksStart)"
+      v-for="i in Math.max(0, clicksRef.total - clicksRef.clicksStart)"
       v-show="!hidden"
-      :key="i"
-      :nav="useFixedNav(route, createFixedClicks(route, i + clicks0.clicksStart))"
+      :key="i + clicksRef.clicksStart"
+      :nav="useFixedNav(route, createFixedClicks(route, i + clicksRef.clicksStart))"
     />
   </template>
 </template>

--- a/packages/client/internals/SlideWrapper.vue
+++ b/packages/client/internals/SlideWrapper.vue
@@ -3,7 +3,8 @@ import type { ClicksContext, RenderContext, SlideRoute } from '@slidev/types'
 import type { CSSProperties, PropType } from 'vue'
 import { SlideBottom, SlideTop } from '#slidev/global-layers'
 import { provideLocal } from '@vueuse/core'
-import { computed, ref, toRef } from 'vue'
+import { computed, nextTick, ref, toRef, watchEffect } from 'vue'
+import { useNav } from '../composables/useNav'
 import { injectionClicksContext, injectionCurrentPage, injectionFrontmatter, injectionRenderContext, injectionRoute, injectionSlideZoom } from '../constants'
 import { configs } from '../env'
 import { getSlideClass } from '../utils'
@@ -36,10 +37,43 @@ const style = computed<CSSProperties>(() => ({
   'user-select': configs.selectable ? undefined : 'none',
   '--slidev-slide-zoom-scale': zoom.value === 1 ? undefined : zoom.value,
 }))
+
+const rootEl = ref<HTMLDivElement>()
+
+// Print-mode settle signal: write `data-slidev-print-ready="<clicks>"` on the
+// root [data-slidev-no] div once Vue reactivity has flushed and one paint frame
+// has fired. Playwright's PDF/PNG export waits on this attribute to know it is
+// safe to snapshot. The attribute is removed at the start of each cycle so a
+// partial state can never be observed as settled.
+const { isPrintMode } = useNav()
+
+watchEffect((onCleanup) => {
+  if (!isPrintMode.value)
+    return
+  const el = rootEl.value
+  if (!el)
+    return
+  const target = String(props.clicksContext.current)
+  el.removeAttribute('data-slidev-print-ready')
+  let cancelled = false
+  onCleanup(() => {
+    cancelled = true
+  })
+  nextTick(() => {
+    if (cancelled)
+      return
+    requestAnimationFrame(() => {
+      if (cancelled)
+        return
+      el.setAttribute('data-slidev-print-ready', target)
+    })
+  })
+})
 </script>
 
 <template>
   <div
+    ref="rootEl"
     :data-slidev-no="props.route.no"
     :class="getSlideClass(route, ['slide', 'presenter'].includes(props.renderContext) ? '' : 'disable-view-transition')"
     :style="style"

--- a/packages/slidev/node/commands/export.ts
+++ b/packages/slidev/node/commands/export.ts
@@ -303,6 +303,35 @@ export async function exportSlides({
         await element.evaluate(node => node.style.display = 'none')
       }
     }
+    // Wait for the client-side settle signal (only when `--with-clicks` is set;
+    // matches the cases where v-click ordering matters for the snapshot).
+    if (withClicks) {
+      try {
+        if (no === 'print') {
+          await page.waitForFunction(() => {
+            const all = document.querySelectorAll('[data-slidev-no]')
+            const ready = document.querySelectorAll('[data-slidev-no][data-slidev-print-ready]')
+            return all.length > 0 && all.length === ready.length
+          }, null, { timeout })
+        }
+        else {
+          const expected = clicks ?? '0'
+          await page.waitForFunction(
+            ({ slideNo, expectedClicks }) => {
+              const sel = `[data-slidev-no="${slideNo}"][data-slidev-print-ready="${expectedClicks}"]`
+              return !!document.querySelector(sel)
+            },
+            { slideNo: no, expectedClicks: expected },
+            { timeout },
+          )
+        }
+      }
+      catch (e) {
+        console.error(`[slidev] Timed out waiting for clicks to settle on slide ${no}${clicks ? ` (clicks=${clicks})` : ''}:`, e)
+        process.exitCode = 1
+      }
+    }
+
     // Wait for the given time
     if (wait)
       await page.waitForTimeout(wait)
@@ -330,43 +359,134 @@ export async function exportSlides({
     return url.match(RE_CLICKS_PARAM)?.[1]
   }
 
+  function getSlideSegmentFromUrl(url: string) {
+    // Matches both history-mode (".../3?...") and hash-mode (".../?...#3") URLs.
+    // Returns the slide number as a string, or '' if not found.
+    const hashMatch = url.match(/#(\d+)(?:\b|$)/)
+    if (hashMatch)
+      return hashMatch[1]
+    const pathMatch = url.match(/\/(\d+)(?:[?#]|$)/)
+    return pathMatch?.[1] ?? ''
+  }
+
   async function genPageWithClicks(
     fn: (no: number, clicks?: string) => Promise<any>,
     no: number,
     clicks?: string,
   ) {
     await fn(no, clicks)
-    if (withClicks) {
-      await page.keyboard.press('ArrowRight', { delay: 100 })
-      const _clicks = getClicksFromUrl(page.url())
-      if (_clicks && clicks !== _clicks)
-        await genPageWithClicks(fn, no, _clicks)
+    if (!withClicks)
+      return
+    const prevUrl = page.url()
+    const prevSlide = getSlideSegmentFromUrl(prevUrl)
+    const prevClicks = clicks ?? '0'
+    await page.keyboard.press('ArrowRight')
+    try {
+      await page.waitForFunction(
+        ({ slideNo, previousClicks }) => {
+          // Stop waiting when the slide segment changes (we've left this slide)
+          // OR the URL clicks param changes (per-slide mode advances click state)
+          // OR a settle attribute with a value other than the previous clicks
+          // appears on the current slide (one-piece mode).
+          const hashMatch = location.hash.match(/#(\d+)(?:\b|$)/)
+          const pathMatch = location.pathname.match(/\/(\d+)$/)
+          const currentSlide = hashMatch?.[1] ?? pathMatch?.[1] ?? ''
+          if (currentSlide && currentSlide !== String(slideNo))
+            return true
+          // Detect URL clicks param change (per-slide print mode)
+          const urlClicksMatch = location.search.match(/[?&]clicks=(\d+)/)
+          const urlClicks = urlClicksMatch?.[1] ?? '0'
+          if (urlClicks !== previousClicks)
+            return true
+          // Detect settle attribute change (one-piece print mode): use
+          // querySelectorAll so that a v-for-rendered multi-state layout
+          // (which can have several [data-slidev-no="N"] elements) does not
+          // always return the initial-state element via querySelector.
+          const els = Array.from(document.querySelectorAll(`[data-slidev-no="${slideNo}"][data-slidev-print-ready]`))
+          return els.some(el => el.getAttribute('data-slidev-print-ready') !== previousClicks)
+        },
+        { slideNo: no, previousClicks: prevClicks },
+        { timeout },
+      )
     }
+    catch (e) {
+      console.error(`[slidev] Timed out waiting for next click state on slide ${no}:`, e)
+      process.exitCode = 1
+      return
+    }
+    const newUrl = page.url()
+    const newSlide = getSlideSegmentFromUrl(newUrl)
+    if (newSlide && newSlide !== prevSlide)
+      return // moved to the next slide; stop recursion
+    const _clicks = getClicksFromUrl(newUrl)
+    if (_clicks && clicks !== _clicks)
+      await genPageWithClicks(fn, no, _clicks)
   }
 
   async function genPagePdfPerSlide() {
     const buffers: Buffer[] = []
-    const genPdfBuffer = async (i: number, clicks?: string) => {
-      await go(i, clicks)
-      const pdf = await page.pdf({
-        width,
-        height,
-        margin: {
-          left: 0,
-          top: 0,
-          right: 0,
-          bottom: 0,
-        },
-        pageRanges: '1',
-        printBackground: true,
-        preferCSSPageSize: true,
-      })
-      buffers.push(pdf)
-    }
     let idx = 0
-    for (const i of pages) {
-      await genPageWithClicks(genPdfBuffer, i)
-      progress.update(++idx)
+
+    if (withClicks) {
+      // Keyboard shortcuts are disabled in print mode, so ArrowRight cannot
+      // advance click states. Navigate to the print route once to render all
+      // click states (each as a .print-slide-container page). Use getSlidesIndex()
+      // to map each slide to its page range, then capture each page as a
+      // separate PDF buffer.
+      await go('print')
+      const slideIndexes = await getSlidesIndex()
+      // Build cumulative offset map: slideNo → [firstPage, lastPage] (1-based)
+      const pagesPerSlide: Record<number, [number, number]> = {}
+      const sortedSlides = Object.keys(slideIndexes).map(Number).sort((a, b) => a - b)
+      for (const slideNo of sortedSlides) {
+        const endPage = slideIndexes[slideNo]
+        const prevSlide = sortedSlides[sortedSlides.indexOf(slideNo) - 1]
+        const startPage = prevSlide !== undefined ? slideIndexes[prevSlide] + 1 : 1
+        pagesPerSlide[slideNo] = [startPage, endPage]
+      }
+      for (const i of pages) {
+        const [startPage, endPage] = pagesPerSlide[i] ?? [1, 1]
+        for (let p = startPage; p <= endPage; p++) {
+          const pdf = await page.pdf({
+            width,
+            height,
+            margin: {
+              left: 0,
+              top: 0,
+              right: 0,
+              bottom: 0,
+            },
+            pageRanges: String(p),
+            printBackground: true,
+            preferCSSPageSize: true,
+          })
+          buffers.push(pdf)
+        }
+        progress.update(++idx)
+      }
+    }
+    else {
+      const genPdfBuffer = async (i: number, clicks?: string) => {
+        await go(i, clicks)
+        const pdf = await page.pdf({
+          width,
+          height,
+          margin: {
+            left: 0,
+            top: 0,
+            right: 0,
+            bottom: 0,
+          },
+          pageRanges: '1',
+          printBackground: true,
+          preferCSSPageSize: true,
+        })
+        buffers.push(pdf)
+      }
+      for (const i of pages) {
+        await genPageWithClicks(genPdfBuffer, i)
+        progress.update(++idx)
+      }
     }
 
     let mergedPdf = await PDFDocument.create({})
@@ -460,8 +580,31 @@ export async function exportSlides({
         )
       }
     }
-    for (const no of pages)
-      await genPageWithClicks(genScreenshot, no)
+    if (withClicks) {
+      // Keyboard shortcuts are disabled in print mode, so ArrowRight cannot
+      // advance click states. Navigate to the print route once; the layout
+      // renders all click states as .print-slide-container elements. For each
+      // requested slide, screenshot each of its click-state containers directly.
+      await go('print')
+      for (const no of pages) {
+        const noStr = String(no).padStart(3, '0')
+        const clickContainers = page.locator(`.print-slide-container[id^="${noStr}-"]`)
+        const clickCount = await clickContainers.count()
+        for (let c = 0; c < clickCount; c++) {
+          const container = clickContainers.nth(c)
+          const idAttr = await container.getAttribute('id') || ''
+          const buffer = await container.screenshot({ omitBackground })
+          const filename = `${idAttr}.png`
+          result.push({ slideIndex: no - 1, buffer, filename })
+          if (writeToDisk)
+            await fs.writeFile(path.join(writeToDisk, filename), buffer)
+        }
+      }
+    }
+    else {
+      for (const no of pages)
+        await genPageWithClicks(genScreenshot, no)
+    }
     return result
   }
 


### PR DESCRIPTION
## Summary

- Adds a client-side settle signal: `SlideWrapper.vue` writes `data-slidev-print-ready="<clicks>"` on its `[data-slidev-no]` root in print mode, once Vue reactivity + one `requestAnimationFrame` have completed.
- Node-side export (`packages/slidev/node/commands/export.ts`) now waits on this attribute via `page.waitForFunction` before each snapshot, replacing the 100 ms `page.keyboard.press('ArrowRight', { delay: 100 })` race in `genPageWithClicks`.
- Reworks `PrintSlide.vue` so `isPrintWithClicks` is snapshotted synchronously into `initialClicks` instead of passed as a reactive getter to `createFixedClicks` — fixes the original #2034 hydration race where the always-on `PrintSlideClick` could be initialised at `CLICKS_MAX` instead of `0`.
- For `--per-slide --with-clicks`: since keyboard shortcuts are gated on `not(isPrintMode)` in `packages/client/logic/shortcuts.ts`, `page.keyboard.press('ArrowRight')` was a no-op in print mode, so the previous code only ever produced one page per slide regardless of click count. The new per-slide path navigates to `/print?print=clicks` once and emits one PDF/PNG buffer per `.print-slide-container`, using `getSlidesIndex()` to map slides to page ranges.

## Issues addressed

- Fixes #2034 — first page of a click-bearing slide was rendering the final state instead of the empty state.
- Resolves the symptom of #1979 downstream — once `PrintSlide.vue` supplies correct fixed-clicks values, the existing `v-motion` print branch produces the right merged variant for each state automatically. No change to `packages/client/modules/v-motion.ts`.

## Behavior change

Treated as a bug fix. When `--with-clicks` is set, the exporter now waits for the client signal before each snapshot. No new CLI flags. The existing `--wait` flag remains the final escape hatch for user-authored CSS transitions outside Slidev's control.

`--per-slide --with-clicks` no longer renders slide-by-slide when combined with clicks — it loads the full print page once and snapshots per click-state container. Memory usage is similar to one-piece in this combination. Plain `--per-slide` (without `--with-clicks`) is unchanged.

## Test plan

- [x] `pnpm lint`
- [x] `pnpm typecheck` (only pre-existing vitepress noise in `docs/node_modules/vitepress/`)
- [x] `pnpm test` — 16 files, 142 tests pass
- [x] New Cypress e2e `cypress/e2e/examples/export-clicks.spec.ts` — 4/4 pass; covers settle attribute presence on every rendered SlideWrapper in print mode (one-piece and per-slide), the #2034 regression (first rendered instance for a v-clicks slide is the empty state, not the final state), and absence of the attribute in live mode. Reuses the existing `cypress/fixtures/basic/slides.md` page 6 (two `<v-clicks>` lists).
- [x] Manual: `slidev export --with-clicks` on `demo/starter` — 40 pages (vs 16 pages without `--with-clicks`); progressive reveal verified via `pdftotext`.
- [x] Manual: `slidev export --per-slide --with-clicks` on `demo/starter` — 40 pages, matches one-piece.
- [x] Manual: `slidev export` (no `--with-clicks`) — unchanged 16 pages.

## Files touched

- `packages/client/internals/SlideWrapper.vue` — settle attribute writer
- `packages/client/internals/PrintSlide.vue` — synchronous initialClicks snapshot (#2034)
- `packages/slidev/node/commands/export.ts` — settle waits in `go()`; settle-aware advance in `genPageWithClicks`; one-piece-backed `--per-slide --with-clicks` path
- `cypress/e2e/examples/export-clicks.spec.ts` — new e2e coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)