### PR TITLE
feat(vscode): add overview preview mode

### DIFF
--- a/packages/client/composables/useEmbeddedCtrl.ts
+++ b/packages/client/composables/useEmbeddedCtrl.ts
@@ -31,8 +31,10 @@ export function useEmbeddedControl() {
 
   if (nav.isEmbedded.value) {
     throttledWatch(
-      [nav.currentSlideNo, nav.clicks, nav.hasNext, nav.hasPrev],
-      ([no, clicks, hasNext, hasPrev]) => {
+      [nav.currentSlideNo, nav.clicks, nav.hasNext, nav.hasPrev, nav.hasPrimarySlide],
+      ([no, clicks, hasNext, hasPrev, hasPrimarySlide]) => {
+        if (!hasPrimarySlide)
+          return
         window.parent.postMessage(
           {
             target: 'slidev',

--- a/packages/client/internals/ClicksSlider.vue
+++ b/packages/client/internals/ClicksSlider.vue
@@ -45,6 +45,7 @@ const current = computed({
 const isReset = computed(() => props.resettable && current.value < 0)
 const clicksRange = computed(() => range(start.value, total.value + 1))
 const sliderEl = ref<HTMLElement>()
+let pointerDown: { id: number, x: number, y: number, dragging: boolean } | undefined
 
 function getPointerRatio(event: PointerEvent) {
   const rect = sliderEl.value!.getBoundingClientRect()
@@ -59,7 +60,13 @@ function syncCurrentFromPointer(event: PointerEvent) {
     current.value = -1
     return
   }
-  const next = Math.round(start.value + clamp(0, ratio, 1) * (total.value - start.value))
+  const position = clamp(0, ratio, 1) * length.value
+  const currentOffset = clamp(0, current.value - start.value, length.value - 1)
+  let next = current.value
+  if (position >= currentOffset + 1.5)
+    next = start.value + Math.floor(position - 0.5)
+  else if (position < currentOffset - 0.5)
+    next = start.value + Math.ceil(position - 0.5)
   current.value = clamp(start.value, next, total.value)
 }
 
@@ -74,27 +81,46 @@ function onPointerDown(event: PointerEvent) {
   if (props.readonly)
     return
   sliderEl.value?.setPointerCapture(event.pointerId)
+  pointerDown = { id: event.pointerId, x: event.clientX, y: event.clientY, dragging: false }
   syncCurrentFromVisibleBlock(event)
+}
+
+function onPointerMove(event: PointerEvent) {
+  if (pointerDown?.id === event.pointerId) {
+    pointerDown.dragging ||= Math.abs(event.clientX - pointerDown.x) > 3 || Math.abs(event.clientY - pointerDown.y) > 3
+    if (!pointerDown.dragging)
+      return
+  }
+  syncCurrentFromPointer(event)
+}
+
+function onPointerUp(event: PointerEvent) {
+  if (pointerDown?.id === event.pointerId)
+    pointerDown = undefined
+}
+
+function onPointerCancel() {
+  pointerDown = undefined
 }
 </script>
 
 <template>
   <div
-    class="flex gap-1 items-center select-none"
+    class="flex gap-1 select-none"
     :title="`Clicks in this slide: ${length}`"
-    :class="length && props.clicksContext.isMounted ? '' : 'op50'"
+    :class="[attached ? 'items-end' : 'items-center', length && props.clicksContext.isMounted ? '' : 'op50']"
   >
     <div
       class="flex items-center font-mono"
-      :class="compact ? 'gap-1 min-w-0 mr0' : 'gap-0.2 min-w-16 mr1'"
+      :class="[compact ? 'gap-1 min-w-0 mr0' : 'gap-0.2 min-w-16 mr1', attached ? 'h-[22px]' : '']"
     >
-      <div class="i-carbon:cursor-1 text-sm op50" />
+      <div class="i-carbon:cursor-1 text-sm op50" :class="compact ? 'ml-1' : ''" />
       <template v-if="current >= 0 && current !== CLICKS_MAX && active">
         <div v-if="!compact" flex-auto />
         <span>
           <span text-primary>{{ current }}</span>
-          <span op25 :class="compact ? '' : 'text-sm'">/</span>
-          <span op50 :class="compact ? '' : 'text-sm'">{{ total }}</span>
+          <span op25 text-sm>/</span>
+          <span op50 text-sm>{{ total }}</span>
         </span>
       </template>
       <div
@@ -102,25 +128,30 @@ function onPointerDown(event: PointerEvent) {
         op50
         :class="compact ? '' : 'flex-auto pl1'"
       >
-        <span>{{ total }}</span>
-        <span v-if="compact" invisible>/{{ total }}</span>
+        <span
+          :class="compact ? 'inline-block text-center' : ''"
+          :style="compact ? { width: `${String(total).length * 2 + 1}ch`, marginLeft: '-0.25ch' } : undefined"
+        >{{ total }}</span>
       </div>
     </div>
     <div
       ref="sliderEl"
-      relative flex-auto h5 font-mono flex="~"
+      relative flex-auto font-mono flex="~"
       touch-none
-      :class="isReset ? 'op80' : ''"
+      :class="[attached ? 'h-[22px]' : 'h5', isReset ? 'op80' : '']"
       @pointerdown.capture="onPointerDown"
-      @pointermove="syncCurrentFromPointer"
+      @pointermove="onPointerMove"
+      @pointerup="onPointerUp"
+      @pointercancel="onPointerCancel"
     >
       <div
         v-for="i of clicksRange" :key="i"
         border="y main" of-hidden relative
         :class="[
-          i === 0 ? 'rounded-l border-l' : '',
+          i === 0 ? 'border-l' : '',
+          i === 0 ? attached ? 'rounded-tl' : 'rounded-l' : '',
           i === total ? 'border-r' : '',
-          i === total && +i !== +current ? 'rounded-r' : '',
+          i === total && +i !== +current ? attached ? 'rounded-tr' : 'rounded-r' : '',
           attached ? 'border-b-0' : '',
         ]"
         :style="{ width: length > 0 ? `${1 / length * 100}%` : '100%' }"
@@ -136,8 +167,8 @@ function onPointerDown(event: PointerEvent) {
         <div
           :class="[
             (+i === +current && active) ? 'text-primary font-bold op100' : 'op30',
-            i === 0 ? 'rounded-l' : '',
-            i === total && +i !== +current && !attached ? 'rounded-r' : '',
+            i === 0 ? attached ? 'rounded-tl' : 'rounded-l' : '',
+            i === total && +i !== +current ? attached ? 'rounded-tr' : 'rounded-r' : '',
             i !== total ? 'border-r-2 border-main' : '',
           ]"
           w-full h-full text-xs flex items-center justify-center z-1

--- a/packages/client/internals/ClicksSlider.vue
+++ b/packages/client/internals/ClicksSlider.vue
@@ -21,7 +21,6 @@ const emit = defineEmits<{
 
 const total = computed(() => props.clicksContext.total)
 const start = computed(() => clamp(0, props.clicksContext.clicksStart, total.value))
-const dragStart = computed(() => props.resettable ? -1 : start.value)
 const length = computed(() => total.value - start.value + 1)
 const current = computed({
   get() {
@@ -46,27 +45,33 @@ const isReset = computed(() => props.resettable && current.value < 0)
 const clicksRange = computed(() => range(start.value, total.value + 1))
 const sliderEl = ref<HTMLElement>()
 
+function getPointerRatio(event: PointerEvent) {
+  const rect = sliderEl.value!.getBoundingClientRect()
+  return (event.clientX - rect.left) / Math.max(1, rect.width)
+}
+
 function syncCurrentFromPointer(event: PointerEvent) {
   if (props.readonly || !(event.buttons & 1) || !sliderEl.value)
     return
-  const rect = sliderEl.value.getBoundingClientRect()
-  const ratio = clamp(0, (event.clientX - rect.left) / Math.max(1, rect.width), 1)
-  const next = Math.round(dragStart.value + ratio * (total.value - dragStart.value))
-  current.value = clamp(dragStart.value, next, total.value)
+  const ratio = getPointerRatio(event)
+  if (props.resettable && ratio < 0) {
+    current.value = -1
+    return
+  }
+  const next = Math.round(start.value + clamp(0, ratio, 1) * (total.value - start.value))
+  current.value = clamp(start.value, next, total.value)
 }
 
 function syncCurrentFromVisibleBlock(event: PointerEvent) {
   if (props.readonly || !sliderEl.value)
     return
-  const rect = sliderEl.value.getBoundingClientRect()
-  const ratio = clamp(0, (event.clientX - rect.left) / Math.max(1, rect.width), 0.999999)
+  const ratio = clamp(0, getPointerRatio(event), 0.999999)
   current.value = clamp(start.value, start.value + Math.floor(ratio * length.value), total.value)
 }
 
 function onPointerDown(event: PointerEvent) {
   if (props.readonly)
     return
-  event.preventDefault()
   sliderEl.value?.setPointerCapture(event.pointerId)
   syncCurrentFromVisibleBlock(event)
 }
@@ -103,6 +108,7 @@ function onPointerDown(event: PointerEvent) {
     <div
       ref="sliderEl"
       relative flex-auto h5 font-mono flex="~"
+      touch-none
       :class="isReset ? 'op80' : ''"
       @pointerdown.capture="onPointerDown"
       @pointermove="syncCurrentFromPointer"

--- a/packages/client/internals/ClicksSlider.vue
+++ b/packages/client/internals/ClicksSlider.vue
@@ -45,62 +45,50 @@ const current = computed({
 const isReset = computed(() => props.resettable && current.value < 0)
 const clicksRange = computed(() => range(start.value, total.value + 1))
 const sliderEl = ref<HTMLElement>()
-let pointerDown: { id: number, x: number, y: number, dragging: boolean } | undefined
+let pointerDown: { id: number, x: number, y: number } | undefined
 
 function getPointerRatio(event: PointerEvent) {
   const rect = sliderEl.value!.getBoundingClientRect()
   return (event.clientX - rect.left) / Math.max(1, rect.width)
 }
 
-function syncCurrentFromPointer(event: PointerEvent) {
-  if (props.readonly || !(event.buttons & 1) || !sliderEl.value)
+// Presses snap to a cell; drags switch only after crossing half a cell.
+function setCurrentFromPointer(event: PointerEvent, snap: boolean) {
+  if (props.readonly || !sliderEl.value || (!snap && !(event.buttons & 1)))
     return
   const ratio = getPointerRatio(event)
+  // In resettable mode, dragging left of the rail restores the inactive state.
   if (props.resettable && ratio < 0) {
     current.value = -1
     return
   }
-  const position = clamp(0, ratio, 1) * length.value
+  // Keep press-at-right-edge inside the last cell.
+  const position = clamp(0, ratio, snap ? 0.999999 : 1) * length.value
   const currentOffset = clamp(0, current.value - start.value, length.value - 1)
-  let next = current.value
-  if (position >= currentOffset + 1.5)
+  let next = snap ? start.value + Math.floor(position) : current.value
+  if (!snap && position >= currentOffset + 1.5)
     next = start.value + Math.floor(position - 0.5)
-  else if (position < currentOffset - 0.5)
+  else if (!snap && position < currentOffset - 0.5)
     next = start.value + Math.ceil(position - 0.5)
   current.value = clamp(start.value, next, total.value)
-}
-
-function syncCurrentFromVisibleBlock(event: PointerEvent) {
-  if (props.readonly || !sliderEl.value)
-    return
-  const ratio = clamp(0, getPointerRatio(event), 0.999999)
-  current.value = clamp(start.value, start.value + Math.floor(ratio * length.value), total.value)
 }
 
 function onPointerDown(event: PointerEvent) {
   if (props.readonly)
     return
   sliderEl.value?.setPointerCapture(event.pointerId)
-  pointerDown = { id: event.pointerId, x: event.clientX, y: event.clientY, dragging: false }
-  syncCurrentFromVisibleBlock(event)
+  pointerDown = { id: event.pointerId, x: event.clientX, y: event.clientY }
+  setCurrentFromPointer(event, true)
 }
 
 function onPointerMove(event: PointerEvent) {
   if (pointerDown?.id === event.pointerId) {
-    pointerDown.dragging ||= Math.abs(event.clientX - pointerDown.x) > 3 || Math.abs(event.clientY - pointerDown.y) > 3
-    if (!pointerDown.dragging)
+    // Treat tiny movement after pointerdown as part of the click.
+    if (Math.abs(event.clientX - pointerDown.x) <= 3 && Math.abs(event.clientY - pointerDown.y) <= 3)
       return
-  }
-  syncCurrentFromPointer(event)
-}
-
-function onPointerUp(event: PointerEvent) {
-  if (pointerDown?.id === event.pointerId)
     pointerDown = undefined
-}
-
-function onPointerCancel() {
-  pointerDown = undefined
+  }
+  setCurrentFromPointer(event, false)
 }
 </script>
 
@@ -141,8 +129,8 @@ function onPointerCancel() {
       :class="[attached ? 'h-[22px]' : 'h5', isReset ? 'op80' : '']"
       @pointerdown.capture="onPointerDown"
       @pointermove="onPointerMove"
-      @pointerup="onPointerUp"
-      @pointercancel="onPointerCancel"
+      @pointerup="pointerDown = undefined"
+      @pointercancel="pointerDown = undefined"
     >
       <div
         v-for="i of clicksRange" :key="i"
@@ -167,8 +155,6 @@ function onPointerCancel() {
         <div
           :class="[
             (+i === +current && active) ? 'text-primary font-bold op100' : 'op30',
-            i === 0 ? attached ? 'rounded-tl' : 'rounded-l' : '',
-            i === total && +i !== +current ? attached ? 'rounded-tr' : 'rounded-r' : '',
             i !== total ? 'border-r-2 border-main' : '',
           ]"
           w-full h-full text-xs flex items-center justify-center z-1

--- a/packages/client/internals/ClicksSlider.vue
+++ b/packages/client/internals/ClicksSlider.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { ClicksContext } from '@slidev/types'
 import { clamp, range } from '@antfu/utils'
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import { CLICKS_MAX } from '../constants'
 
 const props = withDefaults(defineProps<{
@@ -44,6 +44,7 @@ const current = computed({
 
 const isReset = computed(() => props.resettable && current.value < 0)
 const clicksRange = computed(() => range(start.value, total.value + 1))
+const sliderEl = ref<HTMLElement>()
 
 function onMousedown() {
   if (props.readonly)
@@ -52,6 +53,31 @@ function onMousedown() {
     return
   if (current.value < 0 || current.value > total.value)
     current.value = 0
+}
+
+function syncCurrentFromPointer(event: PointerEvent) {
+  if (props.readonly || !(event.buttons & 1) || !sliderEl.value)
+    return
+  const rect = sliderEl.value.getBoundingClientRect()
+  const ratio = clamp(0, (event.clientX - rect.left) / Math.max(1, rect.width), 1)
+  const next = Math.round(inputStart.value + ratio * (total.value - inputStart.value))
+  current.value = clamp(inputStart.value, next, total.value)
+}
+
+function syncCurrentFromVisibleBlock(event: PointerEvent) {
+  if (props.readonly || !sliderEl.value)
+    return
+  const rect = sliderEl.value.getBoundingClientRect()
+  const ratio = clamp(0, (event.clientX - rect.left) / Math.max(1, rect.width), 0.999999)
+  current.value = clamp(start.value, start.value + Math.floor(ratio * length.value), total.value)
+}
+
+function onPointerDown(event: PointerEvent) {
+  if (props.readonly)
+    return
+  event.preventDefault()
+  sliderEl.value?.setPointerCapture(event.pointerId)
+  syncCurrentFromVisibleBlock(event)
 }
 </script>
 
@@ -84,15 +110,18 @@ function onMousedown() {
       </div>
     </div>
     <div
+      ref="sliderEl"
       relative flex-auto h5 font-mono flex="~"
       :class="isReset ? 'op80' : ''"
+      @pointerdown.capture="onPointerDown"
+      @pointermove="syncCurrentFromPointer"
     >
       <div
         v-for="i of clicksRange" :key="i"
         border="y main" of-hidden relative
         :class="[
           i === 0 ? 'rounded-l border-l' : '',
-          i === total ? 'rounded-r border-r' : '',
+          i === total && +i !== +current ? 'rounded-r border-r' : '',
         ]"
         :style="{ width: length > 0 ? `${1 / length * 100}%` : '100%' }"
       >
@@ -101,10 +130,15 @@ function onMousedown() {
           :class="(i <= current && active) ? 'bg-primary op15' : ''"
         />
         <div
+          v-if="+i === +current && active"
+          absolute inset-y-0 right-0 w-0.5 bg-primary z-1
+        />
+        <div
           :class="[
-            (+i === +current && active) ? 'text-primary font-bold op100 border-primary' : 'op30 border-main',
+            (+i === +current && active) ? 'text-primary font-bold op100' : 'op30',
             i === 0 ? 'rounded-l' : '',
-            i === total ? 'rounded-r' : 'border-r-2',
+            i === total && +i !== +current ? 'rounded-r' : '',
+            i !== total ? 'border-r-2 border-main' : '',
           ]"
           w-full h-full text-xs flex items-center justify-center z-1
         >

--- a/packages/client/internals/ClicksSlider.vue
+++ b/packages/client/internals/ClicksSlider.vue
@@ -8,27 +8,46 @@ const props = withDefaults(defineProps<{
   clicksContext: ClicksContext
   readonly?: boolean
   active?: boolean
+  resettable?: boolean
 }>(), {
   active: true,
 })
 
+const emit = defineEmits<{
+  (type: 'activate'): void
+  (type: 'reset'): void
+}>()
+
 const total = computed(() => props.clicksContext.total)
 const start = computed(() => clamp(0, props.clicksContext.clicksStart, total.value))
+const inputStart = computed(() => props.resettable ? -1 : start.value)
 const length = computed(() => total.value - start.value + 1)
 const current = computed({
   get() {
+    if (props.resettable && !props.active)
+      return -1
     return props.clicksContext.current > total.value ? -1 : props.clicksContext.current
   },
   set(value: number) {
+    if (props.resettable && value < 0) {
+      emit('reset')
+      // eslint-disable-next-line vue/no-mutating-props
+      props.clicksContext.current = CLICKS_MAX
+      return
+    }
+    emit('activate')
     // eslint-disable-next-line vue/no-mutating-props
     props.clicksContext.current = value
   },
 })
 
+const isReset = computed(() => props.resettable && current.value < 0)
 const clicksRange = computed(() => range(start.value, total.value + 1))
 
 function onMousedown() {
   if (props.readonly)
+    return
+  if (props.resettable)
     return
   if (current.value < 0 || current.value > total.value)
     current.value = 0
@@ -58,6 +77,7 @@ function onMousedown() {
     </div>
     <div
       relative flex-auto h5 font-mono flex="~"
+      :class="isReset ? 'op80' : ''"
     >
       <div
         v-for="i of clicksRange" :key="i"
@@ -86,7 +106,7 @@ function onMousedown() {
       <input
         v-model="current"
         class="range"
-        type="range" :min="start" :max="total" :step="1"
+        type="range" :min="inputStart" :max="total" :step="1"
         absolute inset-0 z-label op0
         :class="readonly ? 'pointer-events-none' : ''"
         :style="{ '--thumb-width': `${1 / (length + 1) * 100}%` }"

--- a/packages/client/internals/ClicksSlider.vue
+++ b/packages/client/internals/ClicksSlider.vue
@@ -21,7 +21,7 @@ const emit = defineEmits<{
 
 const total = computed(() => props.clicksContext.total)
 const start = computed(() => clamp(0, props.clicksContext.clicksStart, total.value))
-const inputStart = computed(() => props.resettable ? -1 : start.value)
+const dragStart = computed(() => props.resettable ? -1 : start.value)
 const length = computed(() => total.value - start.value + 1)
 const current = computed({
   get() {
@@ -46,22 +46,13 @@ const isReset = computed(() => props.resettable && current.value < 0)
 const clicksRange = computed(() => range(start.value, total.value + 1))
 const sliderEl = ref<HTMLElement>()
 
-function onMousedown() {
-  if (props.readonly)
-    return
-  if (props.resettable)
-    return
-  if (current.value < 0 || current.value > total.value)
-    current.value = 0
-}
-
 function syncCurrentFromPointer(event: PointerEvent) {
   if (props.readonly || !(event.buttons & 1) || !sliderEl.value)
     return
   const rect = sliderEl.value.getBoundingClientRect()
   const ratio = clamp(0, (event.clientX - rect.left) / Math.max(1, rect.width), 1)
-  const next = Math.round(inputStart.value + ratio * (total.value - inputStart.value))
-  current.value = clamp(inputStart.value, next, total.value)
+  const next = Math.round(dragStart.value + ratio * (total.value - dragStart.value))
+  current.value = clamp(dragStart.value, next, total.value)
 }
 
 function syncCurrentFromVisibleBlock(event: PointerEvent) {
@@ -121,7 +112,8 @@ function onPointerDown(event: PointerEvent) {
         border="y main" of-hidden relative
         :class="[
           i === 0 ? 'rounded-l border-l' : '',
-          i === total && +i !== +current ? 'rounded-r border-r' : '',
+          i === total ? 'border-r' : '',
+          i === total && +i !== +current ? 'rounded-r' : '',
         ]"
         :style="{ width: length > 0 ? `${1 / length * 100}%` : '100%' }"
       >
@@ -145,34 +137,6 @@ function onPointerDown(event: PointerEvent) {
           {{ i }}
         </div>
       </div>
-      <input
-        v-model="current"
-        class="range"
-        type="range" :min="inputStart" :max="total" :step="1"
-        absolute inset-0 z-label op0
-        :class="readonly ? 'pointer-events-none' : ''"
-        :style="{ '--thumb-width': `${1 / (length + 1) * 100}%` }"
-        @mousedown="onMousedown"
-        @focus="event => (event.currentTarget as HTMLElement)?.blur()"
-      >
     </div>
   </div>
 </template>
-
-<style scoped>
-.range {
-  -webkit-appearance: none;
-  appearance: none;
-  background: transparent;
-}
-.range::-webkit-slider-thumb {
-  -webkit-appearance: none;
-  height: 100%;
-  width: var(--thumb-width, 0.5rem);
-}
-
-.range::-moz-range-thumb {
-  height: 100%;
-  width: var(--thumb-width, 0.5rem);
-}
-</style>

--- a/packages/client/internals/ClicksSlider.vue
+++ b/packages/client/internals/ClicksSlider.vue
@@ -9,6 +9,7 @@ const props = withDefaults(defineProps<{
   readonly?: boolean
   active?: boolean
   resettable?: boolean
+  compact?: boolean
 }>(), {
   active: true,
 })
@@ -60,19 +61,26 @@ function onMousedown() {
     :title="`Clicks in this slide: ${length}`"
     :class="length && props.clicksContext.isMounted ? '' : 'op50'"
   >
-    <div class="flex gap-0.2 items-center min-w-16 font-mono mr1">
+    <div
+      class="flex items-center font-mono"
+      :class="compact ? 'gap-1 min-w-0 mr0' : 'gap-0.2 min-w-16 mr1'"
+    >
       <div class="i-carbon:cursor-1 text-sm op50" />
       <template v-if="current >= 0 && current !== CLICKS_MAX && active">
-        <div flex-auto />
-        <span text-primary>{{ current }}</span>
-        <span op25 text-sm>/</span>
-        <span op50 text-sm>{{ total }}</span>
+        <div v-if="!compact" flex-auto />
+        <span>
+          <span text-primary>{{ current }}</span>
+          <span op25 :class="compact ? '' : 'text-sm'">/</span>
+          <span op50 :class="compact ? '' : 'text-sm'">{{ total }}</span>
+        </span>
       </template>
       <div
         v-else
-        op50 flex-auto pl1
+        op50
+        :class="compact ? '' : 'flex-auto pl1'"
       >
-        {{ total }}
+        <span>{{ total }}</span>
+        <span v-if="compact" invisible>/{{ total }}</span>
       </div>
     </div>
     <div

--- a/packages/client/internals/ClicksSlider.vue
+++ b/packages/client/internals/ClicksSlider.vue
@@ -10,6 +10,7 @@ const props = withDefaults(defineProps<{
   active?: boolean
   resettable?: boolean
   compact?: boolean
+  attached?: boolean
 }>(), {
   active: true,
 })
@@ -120,6 +121,7 @@ function onPointerDown(event: PointerEvent) {
           i === 0 ? 'rounded-l border-l' : '',
           i === total ? 'border-r' : '',
           i === total && +i !== +current ? 'rounded-r' : '',
+          attached ? 'border-b-0' : '',
         ]"
         :style="{ width: length > 0 ? `${1 / length * 100}%` : '100%' }"
       >
@@ -135,7 +137,7 @@ function onPointerDown(event: PointerEvent) {
           :class="[
             (+i === +current && active) ? 'text-primary font-bold op100' : 'op30',
             i === 0 ? 'rounded-l' : '',
-            i === total && +i !== +current ? 'rounded-r' : '',
+            i === total && +i !== +current && !attached ? 'rounded-r' : '',
             i !== total ? 'border-r-2 border-main' : '',
           ]"
           w-full h-full text-xs flex items-center justify-center z-1

--- a/packages/client/internals/CodeRunner.vue
+++ b/packages/client/internals/CodeRunner.vue
@@ -22,12 +22,12 @@ const props = defineProps<{
 
 const emit = defineEmits(['update:modelValue'])
 
-const { isPrintMode } = useNav()
+const { isEmbedded, isPrintMode } = useNav()
 
 const code = useVModel(props, 'modelValue', emit)
 
 const { $renderContext, $clicksContext } = useSlideContext()
-const disabled = computed(() => !['slide', 'presenter'].includes($renderContext.value))
+const disabled = computed(() => !['slide', 'presenter'].includes($renderContext.value) && !($renderContext.value === 'overview' && isEmbedded.value))
 
 const autorun = isPrintMode.value ? 'once' : props.autorun
 const isRunning = ref(autorun)

--- a/packages/client/internals/NoteDisplay.vue
+++ b/packages/client/internals/NoteDisplay.vue
@@ -172,4 +172,9 @@ watchEffect(() => {
 .slidev-note :first-child {
   margin-top: 0;
 }
+
+.slidev-note {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
 </style>

--- a/packages/client/internals/NoteEditable.vue
+++ b/packages/client/internals/NoteEditable.vue
@@ -131,10 +131,9 @@ watch(
     v-else
     ref="inputEl"
     v-model="note"
-    class="prose dark:prose-invert resize-none overflow-auto outline-none bg-transparent block border-primary border-2"
-    style="line-height: 1.75;"
+    class="prose dark:prose-invert resize-none overflow-auto outline-none bg-transparent block border-primary border-2 slidev-note placeholder:op25"
     :style="[props.style, inputHeight != null ? { height: `${inputHeight}px` } : {}]"
-    :class="props.class"
+    :class="[props.class, note ? '' : 'italic']"
     :placeholder="placeholder"
     @keydown.esc="editing = false"
     @keydown="onKeyDown"

--- a/packages/client/pages/overview.vue
+++ b/packages/client/pages/overview.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { ClicksContext, SlideRoute } from '@slidev/types'
 import { useHead } from '@unhead/vue'
-import { computed, nextTick, onMounted, reactive, ref, shallowRef } from 'vue'
+import { computed, nextTick, onMounted, onUnmounted, reactive, ref, shallowRef } from 'vue'
 import { useRoute } from 'vue-router'
 import { createFixedClicks } from '../composables/useClicks'
 import { useNav } from '../composables/useNav'
@@ -29,14 +29,19 @@ const overviewCardWidth = computed(() => {
   if (!isPreviewMode.value)
     return cardWidth
   if (isEmbeddedPreviewMode.value)
-    return Math.max(320, windowSize.width.value - 16)
+    return windowSize.width.value - 16
   return Math.min(900, Math.max(320, windowSize.width.value - 160))
 })
 const overviewSlideHeight = computed(() => overviewCardWidth.value / slideAspect.value)
 
 const blocks: Map<number, HTMLElement> = reactive(new Map())
+const slidePreviews: Map<number, HTMLElement> = reactive(new Map())
 const activeBlocks = ref<number[]>([])
+const scroller = ref<HTMLElement>()
 const edittingNote = ref<number | null>(null)
+let ignoreOverviewScrollUntil = 0
+let pendingOverviewScrollNo: number | undefined
+let overviewScrollTimer: ReturnType<typeof setTimeout> | undefined
 const wordCounts = computed(() => slides.value.map(route => wordCount(route.meta?.slide?.note || '')))
 const totalWords = computed(() => wordCounts.value.reduce((a, b) => a + b, 0))
 const totalClicks = computed(() => slides.value.map(route => getSlideClicks(route)).reduce((a, b) => a + b, 0))
@@ -111,6 +116,98 @@ function scrollToSlide(idx: number) {
     el.scrollIntoView({ behavior: 'smooth', block: 'start' })
 }
 
+function getSlidePreviewTop(idx: number) {
+  const el = slidePreviews.get(idx) || blocks.get(idx)
+  if (!el || !scroller.value)
+    return null
+  const scrollerRect = scroller.value.getBoundingClientRect()
+  const elRect = el.getBoundingClientRect()
+  return elRect.top - scrollerRect.top + scroller.value.scrollTop
+}
+
+function scrollSlideNoIntoCenter(no: number) {
+  if (!scroller.value || slides.value.length === 0)
+    return
+  const clamped = Math.min(Math.max(no, 1), slides.value.length)
+  const idx = Math.floor(clamped) - 1
+  const progress = clamped - (idx + 1)
+  const start = getSlidePreviewTop(idx)
+  const end = getSlidePreviewTop(idx + 1)
+  if (start == null)
+    return
+  const top = start
+    + (end == null ? 0 : (end - start) * progress)
+    - scroller.value.clientHeight * 0.5
+  if (Math.abs(scroller.value.scrollTop - top) < 1)
+    return
+  scroller.value.scrollTo({ top })
+}
+
+function getCenteredSlideNo() {
+  if (!scroller.value || slides.value.length === 0)
+    return null
+  const center = scroller.value.scrollTop + scroller.value.clientHeight * 0.5
+  const tops = slides.value
+    .map((_, idx) => getSlidePreviewTop(idx))
+    .filter((top): top is number => top != null)
+  if (tops.length === 0)
+    return null
+  if (tops.length === 1 || center <= tops[0])
+    return 1
+  for (let i = 1; i < tops.length; i++) {
+    if (center <= tops[i]) {
+      const span = Math.max(1, tops[i] - tops[i - 1])
+      return i + (center - tops[i - 1]) / span
+    }
+  }
+  return slides.value.length
+}
+
+function postOverviewScroll(no: number) {
+  pendingOverviewScrollNo = no
+  if (overviewScrollTimer)
+    return
+  overviewScrollTimer = setTimeout(() => {
+    overviewScrollTimer = undefined
+    const no = pendingOverviewScrollNo
+    pendingOverviewScrollNo = undefined
+    if (no == null || Date.now() < ignoreOverviewScrollUntil)
+      return
+    window.parent.postMessage({
+      target: 'slidev',
+      sender: 'slidev',
+      type: 'overview-scroll',
+      no,
+    }, '*')
+  }, 50)
+}
+
+function onOverviewScroll() {
+  checkActiveBlocks()
+  if (!isEmbeddedPreviewMode.value || Date.now() < ignoreOverviewScrollUntil)
+    return
+  const no = getCenteredSlideNo()
+  if (no != null)
+    postOverviewScroll(no)
+}
+
+function onOverviewMessage({ data }: MessageEvent) {
+  if (
+    !isEmbeddedPreviewMode.value
+    || data?.target !== 'slidev'
+    || data.sender !== 'vscode'
+    || data.type !== 'overview-scroll'
+  ) {
+    return
+  }
+  const no = Number(data.no)
+  if (no > 0) {
+    ignoreOverviewScrollUntil = Date.now() + 300
+    pendingOverviewScrollNo = undefined
+    scrollSlideNoIntoCenter(no)
+  }
+}
+
 function onMarkerClick(e: MouseEvent, clicks: number, route: SlideRoute) {
   const ctx = getClicksContext(route)
   if (ctx.current === clicks)
@@ -133,9 +230,16 @@ function openOverviewSlideSource(route: SlideRoute) {
 }
 
 onMounted(() => {
+  window.addEventListener('message', onOverviewMessage)
   nextTick(() => {
     checkActiveBlocks()
   })
+})
+
+onUnmounted(() => {
+  window.removeEventListener('message', onOverviewMessage)
+  if (overviewScrollTimer)
+    clearTimeout(overviewScrollTimer)
 })
 </script>
 
@@ -190,9 +294,10 @@ onMounted(() => {
       </div>
     </nav>
     <main
+      ref="scroller"
       class="flex-1 h-full of-auto"
       :style="`grid-template-columns: repeat(auto-fit,minmax(${cardWidth}px,1fr))`"
-      @scroll="checkActiveBlocks"
+      @scroll="onOverviewScroll"
     >
       <div
         v-for="(route, idx) of slides"
@@ -251,13 +356,15 @@ onMounted(() => {
               :active="activeSlide === route"
               :clicks-context="getClicksContext(route)"
               resettable
-              class="min-w-0 flex-1"
+              compact
+              class="ml-auto w-88 max-w-[calc(100%-3rem)]"
               @dblclick="toggleRoute(route)"
               @activate="activeSlide = route"
               @reset="activeSlide = undefined"
             />
           </div>
           <div
+            :ref="el => slidePreviews.set(idx, el as any)"
             class="border rounded border-main overflow-hidden bg-main select-none h-max"
             @dblclick="openSlideInNewTab(getSlidePath(route, false))"
           >

--- a/packages/client/pages/overview.vue
+++ b/packages/client/pages/overview.vue
@@ -337,7 +337,7 @@ onUnmounted(() => {
         </div>
         <div
           class="flex flex-col"
-          :class="isEmbeddedPreviewMode ? 'my1 gap-1' : 'my5 gap-2'"
+          :class="isEmbeddedPreviewMode ? 'my1 gap-0' : 'my5 gap-2'"
           :style="{ width: `${overviewCardWidth}px` }"
         >
           <div

--- a/packages/client/pages/overview.vue
+++ b/packages/client/pages/overview.vue
@@ -357,6 +357,7 @@ onUnmounted(() => {
               :clicks-context="getClicksContext(route)"
               resettable
               compact
+              attached
               class="ml-auto w-88 max-w-[calc(100%-3rem)]"
               @dblclick="toggleRoute(route)"
               @activate="activeSlide = route"
@@ -366,6 +367,7 @@ onUnmounted(() => {
           <div
             :ref="el => slidePreviews.set(idx, el as any)"
             class="border rounded border-main overflow-hidden bg-main select-none h-max"
+            :class="isEmbeddedPreviewMode && getSlideClicks(route) ? 'rounded-tr-0' : ''"
             @dblclick="openSlideInNewTab(getSlidePath(route, false))"
           >
             <SlideContainer

--- a/packages/client/pages/overview.vue
+++ b/packages/client/pages/overview.vue
@@ -2,7 +2,7 @@
 import type { ClicksContext, SlideRoute } from '@slidev/types'
 import { useHead } from '@unhead/vue'
 import { computed, nextTick, onMounted, onUnmounted, reactive, ref, shallowRef } from 'vue'
-import { useRoute } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import { createFixedClicks } from '../composables/useClicks'
 import { useNav } from '../composables/useNav'
 import { CLICKS_MAX } from '../constants'
@@ -22,6 +22,7 @@ const cardWidth = 450
 useHead({ title: `Overview - ${slidesTitle}` })
 
 const currentRoute = useRoute()
+const router = useRouter()
 const { openInEditor, slides, isEmbedded } = useNav()
 const isPreviewMode = computed(() => currentRoute.query.mode === 'preview')
 const isEmbeddedPreviewMode = computed(() => isPreviewMode.value && isEmbedded.value)
@@ -106,8 +107,22 @@ function checkActiveBlocks() {
 function openSlideInNewTab(path: string) {
   const a = document.createElement('a')
   a.target = '_blank'
-  a.href = pathPrefix + path.slice(1)
+  a.href = new URL(pathPrefix + path.slice(1), location.origin).href
   a.click()
+}
+
+function openSlideInBrowser(path: string) {
+  const url = new URL(pathPrefix + path.slice(1), location.origin).href
+  if (isEmbedded.value) {
+    window.parent.postMessage({
+      target: 'slidev',
+      sender: 'slidev',
+      type: 'open-external',
+      url,
+    }, '*')
+    return
+  }
+  openSlideInNewTab(path)
 }
 
 function scrollToSlide(idx: number) {
@@ -143,6 +158,26 @@ function scrollSlideNoIntoCenter(no: number) {
   scroller.value.scrollTo({ top })
 }
 
+function getInitialSlideNo() {
+  const value = currentRoute.query.slideNo
+  const no = Number(Array.isArray(value) ? value[0] : value)
+  return Number.isFinite(no) && no > 0 ? no : undefined
+}
+
+function updateSlideNoQuery(no: number) {
+  if (!isEmbeddedPreviewMode.value)
+    return
+  const slideNo = Number(no.toFixed(3)).toString()
+  if (currentRoute.query.slideNo === slideNo)
+    return
+  router.replace({
+    query: {
+      ...currentRoute.query,
+      slideNo,
+    },
+  })
+}
+
 function getCenteredSlideNo() {
   if (!scroller.value || slides.value.length === 0)
     return null
@@ -171,7 +206,10 @@ function postOverviewScroll(no: number) {
     overviewScrollTimer = undefined
     const no = pendingOverviewScrollNo
     pendingOverviewScrollNo = undefined
-    if (no == null || Date.now() < ignoreOverviewScrollUntil)
+    if (no == null)
+      return
+    updateSlideNoQuery(no)
+    if (Date.now() < ignoreOverviewScrollUntil)
       return
     window.parent.postMessage({
       target: 'slidev',
@@ -204,6 +242,7 @@ function onOverviewMessage({ data }: MessageEvent) {
   if (no > 0) {
     ignoreOverviewScrollUntil = Date.now() + 300
     pendingOverviewScrollNo = undefined
+    updateSlideNoQuery(no)
     scrollSlideNoIntoCenter(no)
   }
 }
@@ -217,7 +256,12 @@ function onMarkerClick(e: MouseEvent, clicks: number, route: SlideRoute) {
   e.preventDefault()
 }
 
-function openOverviewSlideSource(route: SlideRoute) {
+function openOverviewSlideSource(e: MouseEvent, route: SlideRoute) {
+  if (e.ctrlKey || e.metaKey) {
+    e.preventDefault()
+    openSlideInBrowser(getSlidePath(route, false))
+    return
+  }
   const slide = route.meta?.slide
   if (!slide)
     return
@@ -231,7 +275,14 @@ function openOverviewSlideSource(route: SlideRoute) {
 
 onMounted(() => {
   window.addEventListener('message', onOverviewMessage)
+  const initialSlideNo = isEmbeddedPreviewMode.value ? getInitialSlideNo() : undefined
+  if (initialSlideNo != null) {
+    ignoreOverviewScrollUntil = Date.now() + 300
+    scrollSlideNoIntoCenter(initialSlideNo)
+  }
   nextTick(() => {
+    if (initialSlideNo != null)
+      scrollSlideNoIntoCenter(initialSlideNo)
     checkActiveBlocks()
   })
 })
@@ -342,12 +393,12 @@ onUnmounted(() => {
         >
           <div
             v-if="isEmbeddedPreviewMode"
-            class="flex items-center gap-2"
+            class="flex items-end gap-2"
           >
             <button
               type="button"
-              class="select-none pl-1 text-base op60 tabular-nums hover:op90 hover:underline underline-offset-2"
-              @click="openOverviewSlideSource(route)"
+              class="select-none pl-1 text-lg leading-tight op60 tabular-nums hover:op90 hover:underline underline-offset-2"
+              @click="openOverviewSlideSource($event, route)"
             >
               {{ idx + 1 }}
             </button>
@@ -358,7 +409,7 @@ onUnmounted(() => {
               resettable
               compact
               attached
-              class="ml-auto w-88 max-w-[calc(100%-3rem)]"
+              class="ml-auto w-88 min-w-[70%] max-w-[calc(100%-3rem)]"
               @dblclick="toggleRoute(route)"
               @activate="activeSlide = route"
               @reset="activeSlide = undefined"
@@ -366,14 +417,14 @@ onUnmounted(() => {
           </div>
           <div
             :ref="el => slidePreviews.set(idx, el as any)"
-            class="border rounded border-main overflow-hidden bg-main select-none h-max"
-            :class="isEmbeddedPreviewMode && getSlideClicks(route) ? 'rounded-tr-0' : ''"
-            @dblclick="openSlideInNewTab(getSlidePath(route, false))"
+            class="border rounded border-main overflow-hidden bg-main h-max"
+            :class="[isEmbeddedPreviewMode && getSlideClicks(route) ? 'rounded-tr-0' : '', isEmbeddedPreviewMode ? '' : 'select-none']"
+            @dblclick="!isEmbeddedPreviewMode && openSlideInNewTab(getSlidePath(route, false))"
           >
             <SlideContainer
               :key="route.no"
               :width="overviewCardWidth"
-              class="pointer-events-none important:[&_*]:select-none"
+              :class="isEmbeddedPreviewMode ? '' : 'pointer-events-none important:[&_*]:select-none'"
             >
               <SlideWrapper
                 :clicks-context="getClicksContext(route)"

--- a/packages/client/pages/overview.vue
+++ b/packages/client/pages/overview.vue
@@ -2,10 +2,11 @@
 import type { ClicksContext, SlideRoute } from '@slidev/types'
 import { useHead } from '@unhead/vue'
 import { computed, nextTick, onMounted, reactive, ref, shallowRef } from 'vue'
+import { useRoute } from 'vue-router'
 import { createFixedClicks } from '../composables/useClicks'
 import { useNav } from '../composables/useNav'
 import { CLICKS_MAX } from '../constants'
-import { pathPrefix, slidesTitle } from '../env'
+import { pathPrefix, slideAspect, slidesTitle } from '../env'
 import ClicksSlider from '../internals/ClicksSlider.vue'
 import DrawingPreview from '../internals/DrawingPreview.vue'
 import IconButton from '../internals/IconButton.vue'
@@ -14,12 +15,24 @@ import SlideContainer from '../internals/SlideContainer.vue'
 import SlideWrapper from '../internals/SlideWrapper.vue'
 import { isColorSchemaConfigured, isDark, toggleDark } from '../logic/dark'
 import { getSlidePath } from '../logic/slides'
+import { windowSize } from '../state'
 
 const cardWidth = 450
 
 useHead({ title: `Overview - ${slidesTitle}` })
 
-const { openInEditor, slides } = useNav()
+const currentRoute = useRoute()
+const { openInEditor, slides, isEmbedded } = useNav()
+const isPreviewMode = computed(() => currentRoute.query.mode === 'preview')
+const isEmbeddedPreviewMode = computed(() => isPreviewMode.value && isEmbedded.value)
+const overviewCardWidth = computed(() => {
+  if (!isPreviewMode.value)
+    return cardWidth
+  if (isEmbeddedPreviewMode.value)
+    return Math.max(320, windowSize.width.value - 16)
+  return Math.min(900, Math.max(320, windowSize.width.value - 160))
+})
+const overviewSlideHeight = computed(() => overviewCardWidth.value / slideAspect.value)
 
 const blocks: Map<number, HTMLElement> = reactive(new Map())
 const activeBlocks = ref<number[]>([])
@@ -27,6 +40,7 @@ const edittingNote = ref<number | null>(null)
 const wordCounts = computed(() => slides.value.map(route => wordCount(route.meta?.slide?.note || '')))
 const totalWords = computed(() => wordCounts.value.reduce((a, b) => a + b, 0))
 const totalClicks = computed(() => slides.value.map(route => getSlideClicks(route)).reduce((a, b) => a + b, 0))
+const slideNoDigits = computed(() => String(Math.max(1, slides.value.length)).length)
 
 const activeSlide = shallowRef<SlideRoute>()
 const clicksContextMap = new WeakMap<SlideRoute, ClicksContext>()
@@ -65,25 +79,23 @@ function wordCount(str: string) {
   return count
 }
 
-function isElementInViewport(el: HTMLElement) {
-  const rect = el.getBoundingClientRect()
-  const delta = 20
-  return (
-    rect.top >= 0 - delta
-    && rect.left >= 0 - delta
-    && rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) + delta
-    && rect.right <= (window.innerWidth || document.documentElement.clientWidth) + delta
-  )
-}
-
 function checkActiveBlocks() {
-  const active: number[] = []
-  Array.from(blocks.entries())
-    .forEach(([idx, el]) => {
-      if (isElementInViewport(el))
-        active.push(idx)
-    })
-  activeBlocks.value = active
+  const viewportHeight = window.innerHeight || document.documentElement.clientHeight
+  let active: { idx: number, visibleHeight: number } | undefined
+  const fullyVisible: number[] = []
+
+  for (const [idx, el] of blocks.entries()) {
+    const rect = el.getBoundingClientRect()
+    const visibleHeight = Math.max(0, Math.min(rect.bottom, viewportHeight) - Math.max(rect.top, 0))
+    if (visibleHeight === 0)
+      continue
+    if (visibleHeight >= rect.height)
+      fullyVisible.push(idx)
+    if (!active || visibleHeight > active.visibleHeight)
+      active = { idx, visibleHeight }
+  }
+
+  activeBlocks.value = fullyVisible.length ? fullyVisible : active ? [active.idx] : []
 }
 
 function openSlideInNewTab(path: string) {
@@ -108,6 +120,18 @@ function onMarkerClick(e: MouseEvent, clicks: number, route: SlideRoute) {
   e.preventDefault()
 }
 
+function openOverviewSlideSource(route: SlideRoute) {
+  const slide = route.meta?.slide
+  if (!slide)
+    return
+  window.parent.postMessage({
+    target: 'slidev',
+    type: 'command',
+    command: 'goto',
+    args: [slide.filepath, slide.sourceIndex],
+  }, '*')
+}
+
 onMounted(() => {
   nextTick(() => {
     checkActiveBlocks()
@@ -117,9 +141,12 @@ onMounted(() => {
 
 <template>
   <div class="h-screen w-screen of-hidden flex">
-    <nav class="grid grid-rows-[auto_max-content] border-r border-main select-none max-h-full h-full">
+    <nav
+      v-if="!isEmbedded"
+      class="grid grid-rows-[auto_max-content] border-r border-main select-none max-h-full h-full"
+    >
       <div class="relative">
-        <div class="absolute left-0 top-0 bottom-0 w-200 flex flex-col flex-auto items-end group p2 gap-1 max-h-full of-x-visible of-y-auto" style="direction:rtl">
+        <div class="absolute left-0 top-0 bottom-0 w-200 flex flex-col flex-auto items-end group p-6px md:p-10px gap-1 max-h-full of-x-visible of-y-auto" style="direction:rtl">
           <div
             v-for="(route, idx) of slides"
             :key="route.no"
@@ -171,37 +198,72 @@ onMounted(() => {
         v-for="(route, idx) of slides"
         :key="route.no"
         :ref="el => blocks.set(idx, el as any)"
-        class="relative border-t border-main of-hidden flex gap-4 min-h-50 group"
-        :class="idx === 0 ? 'pt5' : ''"
+        class="overview-slide-block relative of-hidden flex gap-4 min-h-50"
+        :class="[idx === 0 && !isEmbeddedPreviewMode ? 'pt2' : '', isEmbeddedPreviewMode ? 'justify-center' : 'border-t border-main']"
       >
-        <div class="select-none w-13 text-right my4 flex flex-col gap-1 items-end">
-          <div class="text-3xl op20 mb2">
+        <div
+          v-if="!isEmbeddedPreviewMode"
+          class="select-none text-right my5 flex flex-col justify-between items-end"
+          :class="isPreviewMode ? 'w-9' : 'w-13'"
+          :style="{ height: `${overviewSlideHeight}px` }"
+        >
+          <div class="self-center text-3xl op20 mb2 text-center mr--14px tabular-nums" :style="{ width: `${slideNoDigits}ch` }">
             {{ idx + 1 }}
           </div>
-          <IconButton
-            class="mr--3 op0 group-hover:op80"
-            title="Play in new tab"
-            @click="openSlideInNewTab(getSlidePath(route, false))"
-          >
-            <div class="i-carbon:presentation-file" />
-          </IconButton>
-          <IconButton
-            v-if="__DEV__ && route.meta?.slide"
-            class="mr--3 op0 group-hover:op80"
-            title="Open in editor"
-            @click="openInEditor(`${route.meta.slide.filepath}:${route.meta.slide.start}`)"
-          >
-            <div class="i-carbon:cics-program" />
-          </IconButton>
+          <div class="flex flex-col gap-1 mx-1 items-end">
+            <IconButton
+              class="overview-slide-action mr--4 op0"
+              :class="isPreviewMode ? 'text-lg' : ''"
+              title="Play in new tab"
+              @click="openSlideInNewTab(getSlidePath(route, false))"
+            >
+              <div class="i-carbon:presentation-file" />
+            </IconButton>
+            <IconButton
+              v-if="__DEV__ && route.meta?.slide"
+              class="overview-slide-action mr--4 op0"
+              :class="isPreviewMode ? 'text-lg' : ''"
+              title="Open in editor"
+              @click="openInEditor(`${route.meta.slide.filepath}:${route.meta.slide.start}`)"
+            >
+              <div class="i-carbon:edit" />
+            </IconButton>
+          </div>
         </div>
-        <div class="flex flex-col gap-2 my5" :style="{ width: `${cardWidth}px` }">
+        <div
+          class="flex flex-col"
+          :class="isEmbeddedPreviewMode ? 'my1 gap-1' : 'my5 gap-2'"
+          :style="{ width: `${overviewCardWidth}px` }"
+        >
+          <div
+            v-if="isEmbeddedPreviewMode"
+            class="flex items-center gap-2"
+          >
+            <button
+              type="button"
+              class="select-none pl-1 text-base op60 tabular-nums hover:op90 hover:underline underline-offset-2"
+              @click="openOverviewSlideSource(route)"
+            >
+              {{ idx + 1 }}
+            </button>
+            <ClicksSlider
+              v-if="getSlideClicks(route)"
+              :active="activeSlide === route"
+              :clicks-context="getClicksContext(route)"
+              resettable
+              class="min-w-0 flex-1"
+              @dblclick="toggleRoute(route)"
+              @activate="activeSlide = route"
+              @reset="activeSlide = undefined"
+            />
+          </div>
           <div
             class="border rounded border-main overflow-hidden bg-main select-none h-max"
             @dblclick="openSlideInNewTab(getSlidePath(route, false))"
           >
             <SlideContainer
               :key="route.no"
-              :width="cardWidth"
+              :width="overviewCardWidth"
               class="pointer-events-none important:[&_*]:select-none"
             >
               <SlideWrapper
@@ -213,27 +275,21 @@ onMounted(() => {
             </SlideContainer>
           </div>
           <ClicksSlider
-            v-if="getSlideClicks(route)"
+            v-if="getSlideClicks(route) && !isEmbeddedPreviewMode"
             :active="activeSlide === route"
             :clicks-context="getClicksContext(route)"
-            class="w-full mt-2"
+            resettable
+            class="ml-1 w-[calc(100%-0.25rem)]"
+            :class="isPreviewMode ? '' : 'mt-2'"
             @dblclick="toggleRoute(route)"
-            @click="activeSlide = route"
+            @activate="activeSlide = route"
+            @reset="activeSlide = undefined"
           />
         </div>
-        <div class="py3 mt-0.5 mr--8 ml--4 op0 transition group-hover:op100">
-          <IconButton
-            title="Edit Note"
-            class="rounded-full w-9 h-9 text-sm"
-            :class="edittingNote === route.no ? 'important:op0' : ''"
-            @click="edittingNote = route.no"
-          >
-            <div class="i-carbon:pen" />
-          </IconButton>
-        </div>
         <NoteEditable
+          v-if="!isPreviewMode"
           :no="route.no"
-          class="max-w-250 w-250 text-lg rounded p3"
+          class="relative z-1 max-w-250 w-250 text-lg rounded p3"
           :auto-height="true"
           :highlight="activeSlide === route"
           :editing="edittingNote === route.no"
@@ -243,14 +299,17 @@ onMounted(() => {
           @marker-click="(e, clicks) => onMarkerClick(e, clicks, route)"
         />
         <div
-          v-if="wordCounts[idx] > 0"
+          v-if="!isPreviewMode && wordCounts[idx] > 0"
           class="select-none absolute bottom-0 right-0 bg-main rounded-tl p2 op35 text-xs"
         >
           {{ wordCounts[idx] }} words
         </div>
       </div>
     </main>
-    <div class="absolute top-0 right-0 px3 py1.5 border-b border-l rounded-lb bg-main border-main select-none">
+    <div
+      v-if="!isEmbedded"
+      class="absolute z-2 top-0 right-0 px3 py1.5 border-b border-l rounded-lb bg-main/80 backdrop-blur border-main select-none"
+    >
       <div class="text-xs op50">
         {{ slides.length }} slides ·
         {{ totalClicks + slides.length - 1 }} clicks ·
@@ -259,3 +318,13 @@ onMounted(() => {
     </div>
   </div>
 </template>
+
+<style scoped>
+.overview-slide-block:hover .overview-slide-action {
+  opacity: 0.6;
+}
+
+.overview-slide-action:hover {
+  opacity: 0.8;
+}
+</style>

--- a/packages/client/pages/overview.vue
+++ b/packages/client/pages/overview.vue
@@ -29,7 +29,7 @@ const overviewCardWidth = computed(() => {
   if (!isPreviewMode.value)
     return cardWidth
   if (isEmbeddedPreviewMode.value)
-    return windowSize.width.value - 16
+    return Math.max(0, windowSize.width.value - 16)
   return Math.min(900, Math.max(320, windowSize.width.value - 160))
 })
 const overviewSlideHeight = computed(() => overviewCardWidth.value / slideAspect.value)

--- a/packages/client/pages/overview.vue
+++ b/packages/client/pages/overview.vue
@@ -107,12 +107,12 @@ function checkActiveBlocks() {
 function openSlideInNewTab(path: string) {
   const a = document.createElement('a')
   a.target = '_blank'
-  a.href = new URL(pathPrefix + path.slice(1), location.origin).href
+  a.href = pathPrefix + path.slice(1)
   a.click()
 }
 
 function openSlideInBrowser(path: string) {
-  const url = new URL(pathPrefix + path.slice(1), location.origin).href
+  const url = new URL(pathPrefix + path.slice(1), location.href).href
   if (isEmbedded.value) {
     window.parent.postMessage({
       target: 'slidev',

--- a/packages/client/pages/presenter.vue
+++ b/packages/client/pages/presenter.vue
@@ -436,6 +436,7 @@ onMounted(() => {
   --slidev-presenter-notes-width: 360px;
   --slidev-presenter-notes-row-size: 280px;
   --uno: bg-gray/20 flex-1 of-hidden;
+  position: relative;
   display: grid;
   gap: 1px 1px;
 }
@@ -572,8 +573,6 @@ onMounted(() => {
   top: 0;
   width: 1px;
   height: 100%;
-  background-color: currentColor;
-  opacity: 0.2;
   transform: translateX(-50%);
 }
 
@@ -596,8 +595,6 @@ onMounted(() => {
   top: 0;
   width: 1px;
   height: 100%;
-  background-color: currentColor;
-  opacity: 0.2;
   transform: translateX(-50%);
 }
 </style>

--- a/packages/client/shim-vue.d.ts
+++ b/packages/client/shim-vue.d.ts
@@ -23,6 +23,7 @@ declare module 'vue-router' {
       noteHTML: string
       filepath: string
       start: number
+      sourceIndex: number
       id: number
       no: number
     }

--- a/packages/slidev/node/vite/loaders.ts
+++ b/packages/slidev/node/vite/loaders.ts
@@ -358,6 +358,7 @@ export function createSlidesLoader(
               `    frontmatter,`,
               `    filepath: ${JSON.stringify(mode === 'dev' ? slide.source.filepath : '')},`,
               `    start: ${JSON.stringify(slide.source.start)},`,
+              `    sourceIndex: ${JSON.stringify(slide.source.index)},`,
               `    id: ${idx},`,
               `    no: ${no},`,
               '  },',

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -197,6 +197,20 @@
         "icon": "$(globe)"
       },
       {
+        "command": "slidev.show-slide-preview",
+        "category": "Slidev",
+        "title": "Show slide preview",
+        "icon": "$(preview)",
+        "enablement": "slidev:preview:overview"
+      },
+      {
+        "command": "slidev.show-overview-preview",
+        "category": "Slidev",
+        "title": "Show overview preview",
+        "icon": "$(list-tree)",
+        "enablement": "!slidev:preview:overview"
+      },
+      {
         "command": "slidev.preview-prev-click",
         "category": "Slidev",
         "title": "Navigate to prev click in preview window",
@@ -275,22 +289,22 @@
         },
         {
           "command": "slidev.preview-prev-slide",
-          "when": "view =~ /slidev-preview/ && slidev:preview:ready && !slidev:preview:compat",
+          "when": "view =~ /slidev-preview/ && slidev:preview:ready && !slidev:preview:compat && !slidev:preview:overview",
           "group": "navigation@1"
         },
         {
           "command": "slidev.preview-next-slide",
-          "when": "view =~ /slidev-preview/ && slidev:preview:ready && !slidev:preview:compat",
+          "when": "view =~ /slidev-preview/ && slidev:preview:ready && !slidev:preview:compat && !slidev:preview:overview",
           "group": "navigation@2"
         },
         {
           "command": "slidev.preview-prev-click",
-          "when": "view =~ /slidev-preview/ && slidev:preview:ready && !slidev:preview:compat",
+          "when": "view =~ /slidev-preview/ && slidev:preview:ready && !slidev:preview:compat && !slidev:preview:overview",
           "group": "navigation@3"
         },
         {
           "command": "slidev.preview-next-click",
-          "when": "view =~ /slidev-preview/ && slidev:preview:ready && !slidev:preview:compat",
+          "when": "view =~ /slidev-preview/ && slidev:preview:ready && !slidev:preview:compat && !slidev:preview:overview",
           "group": "navigation@4"
         },
         {
@@ -304,19 +318,29 @@
           "group": "navigation@5"
         },
         {
+          "command": "slidev.show-slide-preview",
+          "when": "view =~ /slidev-preview/ && slidev:preview:ready && !slidev:preview:compat && slidev:preview:overview",
+          "group": "navigation@6"
+        },
+        {
+          "command": "slidev.show-overview-preview",
+          "when": "view =~ /slidev-preview/ && slidev:preview:ready && !slidev:preview:compat && !slidev:preview:overview",
+          "group": "navigation@6"
+        },
+        {
           "command": "slidev.refresh-preview",
           "when": "view =~ /slidev-preview/",
-          "group": "navigation@6"
+          "group": "navigation@7"
         },
         {
           "command": "slidev.enable-preview-sync",
           "when": "view =~ /slidev-preview/ && !slidev:preview:sync",
-          "group": "navigation@7"
+          "group": "navigation@8"
         },
         {
           "command": "slidev.disable-preview-sync",
           "when": "view =~ /slidev-preview/ && slidev:preview:sync",
-          "group": "navigation@7"
+          "group": "navigation@8"
         }
       ],
       "view/item/context": [
@@ -409,14 +433,14 @@
           "name": "Projects",
           "visibility": "collapsed",
           "initialSize": 1,
-          "when": "slidev:enabled"
+          "when": "slidev:enabled && (!slidev:preview:overview || !slidev:preview:ready)"
         },
         {
           "id": "slidev-slides-tree",
           "name": "Slides",
           "visibility": "visible",
           "initialSize": 3,
-          "when": "slidev:enabled"
+          "when": "slidev:enabled && (!slidev:preview:overview || !slidev:preview:ready)"
         },
         {
           "type": "webview",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -199,14 +199,14 @@
       {
         "command": "slidev.show-slide-preview",
         "category": "Slidev",
-        "title": "Show slide preview",
+        "title": "Switch to slide preview",
         "icon": "$(preview)",
         "enablement": "slidev:preview:overview"
       },
       {
         "command": "slidev.show-overview-preview",
         "category": "Slidev",
-        "title": "Show overview preview",
+        "title": "Switch to overview preview",
         "icon": "$(multiple-windows)",
         "enablement": "!slidev:preview:overview"
       },

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -315,32 +315,32 @@
         {
           "command": "slidev.open-in-browser",
           "when": "view =~ /slidev-preview/ && slidev:preview:ready",
-          "group": "navigation@5"
+          "group": "navigation@7"
         },
         {
           "command": "slidev.show-slide-preview",
           "when": "view =~ /slidev-preview/ && slidev:preview:ready && !slidev:preview:compat && slidev:preview:overview",
-          "group": "navigation@6"
+          "group": "navigation@8"
         },
         {
           "command": "slidev.show-overview-preview",
           "when": "view =~ /slidev-preview/ && slidev:preview:ready && !slidev:preview:compat && !slidev:preview:overview",
-          "group": "navigation@6"
+          "group": "navigation@8"
         },
         {
           "command": "slidev.refresh-preview",
           "when": "view =~ /slidev-preview/",
-          "group": "navigation@7"
+          "group": "navigation@6"
         },
         {
           "command": "slidev.enable-preview-sync",
           "when": "view =~ /slidev-preview/ && !slidev:preview:sync",
-          "group": "navigation@8"
+          "group": "navigation@5"
         },
         {
           "command": "slidev.disable-preview-sync",
           "when": "view =~ /slidev-preview/ && slidev:preview:sync",
-          "group": "navigation@8"
+          "group": "navigation@5"
         }
       ],
       "view/item/context": [

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -207,7 +207,7 @@
         "command": "slidev.show-overview-preview",
         "category": "Slidev",
         "title": "Show overview preview",
-        "icon": "$(list-tree)",
+        "icon": "$(multiple-windows)",
         "enablement": "!slidev:preview:overview"
       },
       {

--- a/packages/vscode/src/commands.ts
+++ b/packages/vscode/src/commands.ts
@@ -136,6 +136,8 @@ export function useCommands() {
   useCommand('slidev.preview-next-click', () => usePreviewWebview().nextClick())
   useCommand('slidev.preview-prev-slide', () => usePreviewWebview().prevSlide())
   useCommand('slidev.preview-next-slide', () => usePreviewWebview().nextSlide())
+  useCommand('slidev.show-slide-preview', () => usePreviewWebview().setPreviewMode('slide'))
+  useCommand('slidev.show-overview-preview', () => usePreviewWebview().setPreviewMode('overview'))
 
   useCommand('slidev.enable-preview-sync', () => (config.update('preview-sync', true, ConfigurationTarget.Global)))
   useCommand('slidev.disable-preview-sync', () => (config.update('preview-sync', false, ConfigurationTarget.Global)))

--- a/packages/vscode/src/composables/useFocusedSlide.ts
+++ b/packages/vscode/src/composables/useFocusedSlide.ts
@@ -47,9 +47,9 @@ export const useFocusedSlide = defineService(() => {
   })
   const overviewAnchors = computed(() => {
     const info = projectInfo.value
-    const slides = info?.project.data.slides
-    if (!info || !slides)
+    if (!info)
       return []
+    const slides = info.project.data.slides
     return info.md.slides
       .map((source): OverviewAnchor | null => {
         const displayedSource = getFirstDisplayedChild(source)
@@ -65,9 +65,8 @@ export const useFocusedSlide = defineService(() => {
       .sort((a, b) => a.no - b.no)
   })
   const viewportSlideNo = computed(() => {
-    const info = projectInfo.value
     const range = visibleRanges.value[0]
-    if (!info || !range)
+    if (!range)
       return null
     const start = getFractionalVisibleLine(range.start)
     const end = getFractionalVisibleLine(range.end)
@@ -139,12 +138,14 @@ export const useFocusedSlide = defineService(() => {
   }
 
   function revealViewportSlide(no: number) {
+    const textEditor = editor.value
+    if (!textEditor)
+      return
     const line = interpolate(overviewAnchors.value.map(anchor => ({
       x: anchor.no,
       y: anchor.line,
     })), no)
-    const textEditor = editor.value
-    if (line == null || !textEditor)
+    if (line == null)
       return
     const position = new Position(Math.round(line), 0)
     textEditor.revealRange(new Range(position, position), TextEditorRevealType.InCenter)

--- a/packages/vscode/src/composables/useFocusedSlide.ts
+++ b/packages/vscode/src/composables/useFocusedSlide.ts
@@ -1,13 +1,20 @@
 import type { SlidevProject } from '../projects'
-import { computed, defineService, useActiveTextEditor, useTextEditorSelection, useVscodeContext } from 'reactive-vscode'
-import { Position, Range, Uri, window, workspace } from 'vscode'
+import { computed, defineService, useActiveTextEditor, useTextEditorSelection, useTextEditorVisibleRanges, useVscodeContext } from 'reactive-vscode'
+import { Position, Range, TextEditorRevealType, Uri, window, workspace } from 'vscode'
 import { activeData } from '../projects'
+import { getFirstDisplayedChild } from '../utils/getFirstDisplayedChild'
 import { useDebouncedComputed } from './useDebouncedComputed'
 import { useProjectFromDoc } from './useProjectFromDoc'
+
+interface OverviewAnchor {
+  line: number
+  no: number
+}
 
 export const useFocusedSlide = defineService(() => {
   const editor = useActiveTextEditor()
   const selection = useTextEditorSelection(editor)
+  const visibleRanges = useTextEditorVisibleRanges(editor)
   const debouncedEditor = useDebouncedComputed(() => editor.value, val => val ? null : 150)
   const projectInfo = useProjectFromDoc(() => debouncedEditor.value?.document)
   const focusedMarkdown = computed(() => projectInfo.value?.md)
@@ -29,21 +36,87 @@ export const useFocusedSlide = defineService(() => {
   const displayedSourceSlide = computed(() => {
     if (!focusedSourceSlide.value)
       return null
-    let source = focusedSourceSlide.value
-    while (true) {
-      const firstChild = source.imports?.[0]
-      if (firstChild)
-        source = firstChild
-      else
-        return source
-    }
+    return getFirstDisplayedChild(focusedSourceSlide.value)
   })
   const focusedSlideNo = computed(() => {
     const slides = projectInfo.value?.project.data.slides
     if (!slides || !displayedSourceSlide.value)
       return null
-    return slides.findIndex(s => s.source === displayedSourceSlide.value) + 1
+    const index = slides.findIndex(s => s.source === displayedSourceSlide.value)
+    return index < 0 ? null : index + 1
   })
+  const overviewAnchors = computed(() => {
+    const info = projectInfo.value
+    const slides = info?.project.data.slides
+    if (!info || !slides)
+      return []
+    return info.md.slides
+      .map((source): OverviewAnchor | null => {
+        const displayedSource = getFirstDisplayedChild(source)
+        const index = slides.findIndex(s => s.source === displayedSource)
+        if (index < 0)
+          return null
+        return {
+          line: source.contentStart,
+          no: index + 1,
+        }
+      })
+      .filter((anchor): anchor is OverviewAnchor => anchor != null)
+      .sort((a, b) => a.no - b.no)
+  })
+  const viewportSlideNo = computed(() => {
+    const info = projectInfo.value
+    const range = visibleRanges.value[0]
+    if (!info || !range)
+      return null
+    const start = getFractionalVisibleLine(range.start)
+    const end = getFractionalVisibleLine(range.end)
+    const visibleLines = Math.max(1, end - start)
+    return interpolate(overviewAnchors.value.map(anchor => ({
+      x: (anchor.line - start) / visibleLines,
+      y: anchor.no,
+    })), 0.5)
+  })
+
+  function getFractionalVisibleLine(position: Position) {
+    const document = editor.value?.document
+    const line = position.line
+    if (!document || line < 0 || line >= document.lineCount)
+      return line
+    return line + position.character / (document.lineAt(line).text.length + 2)
+  }
+
+  function interpolate(points: { x: number, y: number }[], x: number) {
+    if (points.length === 0)
+      return null
+    if (points.length === 1)
+      return points[0].y
+    const sorted = [...points].sort((a, b) => a.x - b.x)
+    const minY = Math.min(...sorted.map(point => point.y))
+    const maxY = Math.max(...sorted.map(point => point.y))
+
+    let previous = sorted[0]
+    let next = sorted[1]
+    if (x > sorted.at(-1)!.x) {
+      previous = sorted.at(-2)!
+      next = sorted.at(-1)!
+    }
+    else {
+      for (let i = 1; i < sorted.length; i++) {
+        if (sorted[i].x >= x) {
+          previous = sorted[i - 1]
+          next = sorted[i]
+          break
+        }
+      }
+    }
+
+    const span = next.x - previous.x
+    const y = span === 0
+      ? previous.y
+      : previous.y + (x - previous.x) / span * (next.y - previous.y)
+    return Math.min(Math.max(y, minY), maxY)
+  }
 
   async function gotoSlide(filepath: string, index: number) {
     if (focusedMarkdown.value?.filepath === filepath && focusedSourceSlide.value?.index === index)
@@ -65,11 +138,25 @@ export const useFocusedSlide = defineService(() => {
     await gotoSlide(source.filepath, source.index)
   }
 
+  function revealViewportSlide(no: number) {
+    const line = interpolate(overviewAnchors.value.map(anchor => ({
+      x: anchor.no,
+      y: anchor.line,
+    })), no)
+    const textEditor = editor.value
+    if (line == null || !textEditor)
+      return
+    const position = new Position(Math.round(line), 0)
+    textEditor.revealRange(new Range(position, position), TextEditorRevealType.InCenter)
+  }
+
   return {
     focusedMarkdown,
     focusedSourceSlide,
     focusedSlideNo,
+    viewportSlideNo,
     gotoSlide,
     focusSlide,
+    revealViewportSlide,
   }
 })

--- a/packages/vscode/src/html/ready.ts
+++ b/packages/vscode/src/html/ready.ts
@@ -1,4 +1,11 @@
-export function generateReadyHtml(port: number) {
+export type PreviewMode = 'slide' | 'overview'
+
+export function generateReadyHtml(port: number, mode: PreviewMode, hashRoute: boolean) {
+  const iframeSrc = mode === 'overview'
+    ? hashRoute
+      ? `http://localhost:${port}?embedded=true#/overview?mode=preview`
+      : `http://localhost:${port}/overview?mode=preview&embedded=true`
+    : `http://localhost:${port}?embedded=true`
   return `
   <head>
     <meta
@@ -8,7 +15,7 @@ export function generateReadyHtml(port: number) {
     <style>
     :root {
       overflow: hidden;
-      --scale: 0.6;
+      --scale: 0.75;
     }
     body {
       padding: 0;
@@ -26,7 +33,7 @@ export function generateReadyHtml(port: number) {
     </style>
   <head>
   <body>
-    <iframe id="iframe" sandbox="allow-same-origin allow-scripts" src="http://localhost:${port}?embedded=true"></iframe>
+    <iframe id="iframe" sandbox="allow-same-origin allow-scripts" src="${iframeSrc}"></iframe>
     <script>
       const vscode = acquireVsCodeApi()
       const iframe = document.getElementById('iframe')
@@ -34,6 +41,8 @@ export function generateReadyHtml(port: number) {
         if (data && data.target === 'slidev') {
           if (data.sender === 'vscode')
             iframe.contentWindow.postMessage(data, '*')
+          else if (data.type === 'command')
+            vscode.postMessage(data)
           else
             vscode.postMessage({
               ...data,

--- a/packages/vscode/src/html/ready.ts
+++ b/packages/vscode/src/html/ready.ts
@@ -41,9 +41,7 @@ export function generateReadyHtml(port: number, mode: PreviewMode, hashRoute: bo
         if (data && data.target === 'slidev') {
           if (data.sender === 'vscode')
             iframe.contentWindow.postMessage(data, '*')
-          else if (data.type === 'command')
-            vscode.postMessage(data)
-          else if (data.type === 'overview-scroll')
+          else if (data.type === 'command' || data.type === 'overview-scroll')
             vscode.postMessage(data)
           else
             vscode.postMessage({

--- a/packages/vscode/src/html/ready.ts
+++ b/packages/vscode/src/html/ready.ts
@@ -43,6 +43,8 @@ export function generateReadyHtml(port: number, mode: PreviewMode, hashRoute: bo
             iframe.contentWindow.postMessage(data, '*')
           else if (data.type === 'command')
             vscode.postMessage(data)
+          else if (data.type === 'overview-scroll')
+            vscode.postMessage(data)
           else
             vscode.postMessage({
               ...data,

--- a/packages/vscode/src/html/ready.ts
+++ b/packages/vscode/src/html/ready.ts
@@ -1,10 +1,11 @@
 export type PreviewMode = 'slide' | 'overview'
 
-export function generateReadyHtml(port: number, mode: PreviewMode, hashRoute: boolean) {
+export function generateReadyHtml(port: number, mode: PreviewMode, hashRoute: boolean, initialSlideNo?: number) {
+  const slideNoQuery = initialSlideNo == null ? '' : `&slideNo=${encodeURIComponent(String(initialSlideNo))}`
   const iframeSrc = mode === 'overview'
     ? hashRoute
-      ? `http://localhost:${port}?embedded=true#/overview?mode=preview`
-      : `http://localhost:${port}/overview?mode=preview&embedded=true`
+      ? `http://localhost:${port}?embedded=true#/overview?mode=preview${slideNoQuery}`
+      : `http://localhost:${port}/overview?mode=preview&embedded=true${slideNoQuery}`
     : `http://localhost:${port}?embedded=true`
   return `
   <head>
@@ -41,7 +42,7 @@ export function generateReadyHtml(port: number, mode: PreviewMode, hashRoute: bo
         if (data && data.target === 'slidev') {
           if (data.sender === 'vscode')
             iframe.contentWindow.postMessage(data, '*')
-          else if (data.type === 'command' || data.type === 'overview-scroll')
+          else if (data.type === 'command' || data.type === 'overview-scroll' || data.type === 'open-external')
             vscode.postMessage(data)
           else
             vscode.postMessage({

--- a/packages/vscode/src/views/previewWebview.ts
+++ b/packages/vscode/src/views/previewWebview.ts
@@ -1,3 +1,4 @@
+import type { PreviewMode } from '../html/ready'
 import { computed, defineService, extensionContext, reactive, ref, useIsDarkTheme, useVscodeContext, useWebviewView, watch, watchEffect } from 'reactive-vscode'
 import { commands, env, Uri, window } from 'vscode'
 import { useFocusedSlide } from '../composables/useFocusedSlide'
@@ -18,11 +19,15 @@ export const usePreviewWebview = defineService(() => {
   const message = computed(() => detected.value?.message ?? '')
   const compatMode = useVscodeContext('slidev:preview:compat', () => !!detected.value?.compatMode)
   const ready = useVscodeContext('slidev:preview:ready', () => activeProject.value && !!detected.value?.ready)
+  const savedPreviewMode = extensionContext.value?.globalState.get<PreviewMode>('slidev:preview:mode')
+  const previewMode = ref<PreviewMode>(savedPreviewMode === 'overview' ? 'overview' : 'slide')
+  const hashRoute = computed(() => activeData.value?.slides[0]?.frontmatter.routerMode === 'hash')
   const html = computed(() => ready.value
-    ? generateReadyHtml(port.value)
+    ? generateReadyHtml(port.value, previewMode.value, hashRoute.value)
     : generateErrorHtml(message.value),
   )
   useVscodeContext('slidev:preview:sync', () => config['preview-sync'])
+  useVscodeContext('slidev:preview:overview', () => previewMode.value === 'overview')
 
   const previewNavState = reactive({
     no: 0,
@@ -31,10 +36,10 @@ export const usePreviewWebview = defineService(() => {
     hasPrev: false,
   })
 
-  useVscodeContext('slidev:preview:has-prev-slide', () => previewNavState.no > 1)
-  useVscodeContext('slidev:preview:has-next-slide', () => activeData.value && previewNavState.no < activeData.value.slides.length)
-  useVscodeContext('slidev:preview:has-next-click', () => previewNavState.hasNext)
-  useVscodeContext('slidev:preview:has-prev-click', () => previewNavState.hasPrev)
+  useVscodeContext('slidev:preview:has-prev-slide', () => previewMode.value === 'slide' && previewNavState.no > 1)
+  useVscodeContext('slidev:preview:has-next-slide', () => previewMode.value === 'slide' && activeData.value && previewNavState.no < activeData.value.slides.length)
+  useVscodeContext('slidev:preview:has-next-click', () => previewMode.value === 'slide' && previewNavState.hasNext)
+  useVscodeContext('slidev:preview:has-prev-click', () => previewMode.value === 'slide' && previewNavState.hasPrev)
 
   const initializedClientId = ref('')
 
@@ -49,7 +54,7 @@ export const usePreviewWebview = defineService(() => {
       },
       async onDidReceiveMessage(data) {
         if (data.type === 'command') {
-          commands.executeCommand(`slidev.${data.command}`)
+          commands.executeCommand(`slidev.${data.command}`, ...(data.args ?? []))
         }
         else if (data.type === 'update-state') {
           if (initializedClientId.value === data.clientId) {
@@ -57,7 +62,7 @@ export const usePreviewWebview = defineService(() => {
           }
           else {
             initializedClientId.value = data.clientId
-            if (config['preview-sync'] && initializedClientId.value === data.clientId)
+            if (previewMode.value === 'slide' && config['preview-sync'] && initializedClientId.value === data.clientId)
               postSlidevMessage('navigate', { no: focusedSlideNo.value })
           }
         }
@@ -75,7 +80,7 @@ export const usePreviewWebview = defineService(() => {
     logger.info(`Webview refreshed. Current URL: http://localhost:${port.value}`)
     setTimeout(() => pageId.value++, 300)
   }
-  watch([ready, view, port], refresh)
+  watch([ready, view, port, previewMode], refresh)
 
   function postSlidevMessage(type: string, data: Record<string, unknown>) {
     return postMessage({
@@ -91,14 +96,17 @@ export const usePreviewWebview = defineService(() => {
 
   watchEffect(() => {
     if (view.value) {
-      const slideNo = ready.value && previewNavState.no > 0 ? ` (${previewNavState.no}/${activeData.value?.slides.length})` : ''
+      const slideNo = ready.value && previewMode.value === 'slide' && previewNavState.no > 0 ? ` (${previewNavState.no}/${activeData.value?.slides.length})` : ''
+      const modeInfo = previewMode.value === 'overview' ? ' (overview)' : ''
       const compatInfo = compatMode.value ? ' (compat mode)' : ''
-      view.value.title = `Preview${slideNo}${compatInfo}`
+      view.value.title = `Preview${slideNo}${modeInfo}${compatInfo}`
     }
   })
 
   function useNavOperation(operation: string, ...args: unknown[]) {
     return () => {
+      if (previewMode.value !== 'slide')
+        return
       if (compatMode.value)
         window.showErrorMessage('Unsupported operation: Slidev server too old.')
       postSlidevMessage('navigate', { operation, args })
@@ -108,15 +116,15 @@ export const usePreviewWebview = defineService(() => {
   watch(
     () => previewNavState.no,
     (no) => {
-      if (ready.value && config['preview-sync'] && activeProject.value) {
+      if (previewMode.value === 'slide' && ready.value && config['preview-sync'] && activeProject.value) {
         focusSlide(activeProject.value, no)
       }
     },
   )
   watch(
-    [() => config['preview-sync'], focusedSlideNo],
-    ([enabled, no]) => {
-      if (enabled && no != null && previewNavState.no !== no) {
+    [() => config['preview-sync'], focusedSlideNo, previewMode],
+    ([enabled, no, mode]) => {
+      if (enabled && mode === 'slide' && no != null && previewNavState.no !== no) {
         postSlidevMessage('navigate', { no, clicks: 999999 })
       }
     },
@@ -125,6 +133,11 @@ export const usePreviewWebview = defineService(() => {
   return {
     view,
     refresh,
+    setPreviewMode: (mode: PreviewMode) => {
+      initializedClientId.value = ''
+      previewMode.value = mode
+      void extensionContext.value?.globalState.update('slidev:preview:mode', mode)
+    },
     nextClick: useNavOperation('next'),
     prevClick: useNavOperation('prev'),
     nextSlide: useNavOperation('nextSlide', true),

--- a/packages/vscode/src/views/previewWebview.ts
+++ b/packages/vscode/src/views/previewWebview.ts
@@ -73,7 +73,7 @@ export const usePreviewWebview = defineService(() => {
           }
           else {
             initializedClientId.value = data.clientId
-            if (previewMode.value === 'slide' && config['preview-sync'] && initializedClientId.value === data.clientId && focusedSlideNo.value != null)
+            if (previewMode.value === 'slide' && config['preview-sync'] && focusedSlideNo.value != null)
               postSlidevMessage('navigate', { no: focusedSlideNo.value })
           }
         }

--- a/packages/vscode/src/views/previewWebview.ts
+++ b/packages/vscode/src/views/previewWebview.ts
@@ -35,18 +35,14 @@ export const usePreviewWebview = defineService(() => {
   })
   let overviewSlideNoForUrl: number | undefined
 
-  function normalizeSlideNo(no: unknown) {
-    const slideNo = Number(no)
-    return Number.isFinite(slideNo) && slideNo > 0 ? slideNo : undefined
-  }
-
   function getOverviewSlideNoForUrl() {
-    return normalizeSlideNo(
+    const slideNo = Number(
       overviewSlideNoForUrl
       ?? viewportSlideNo.value
       ?? focusedSlideNo.value
       ?? previewNavState.no,
     )
+    return Number.isFinite(slideNo) && slideNo > 0 ? slideNo : undefined
   }
 
   function updateOverviewInitialSlideNo() {

--- a/packages/vscode/src/views/previewWebview.ts
+++ b/packages/vscode/src/views/previewWebview.ts
@@ -10,7 +10,7 @@ import { activeData, activeProject } from '../projects'
 import { logger } from './logger'
 
 export const usePreviewWebview = defineService(() => {
-  const { focusedSlideNo, focusSlide } = useFocusedSlide()
+  const { focusedSlideNo, viewportSlideNo, focusSlide, revealViewportSlide } = useFocusedSlide()
   const isDarkTheme = useIsDarkTheme()
 
   const { redetect } = useServerDetector()
@@ -42,6 +42,17 @@ export const usePreviewWebview = defineService(() => {
   useVscodeContext('slidev:preview:has-prev-click', () => previewMode.value === 'slide' && previewNavState.hasPrev)
 
   const initializedClientId = ref('')
+  let pendingOverviewScroll: { no: number } | undefined
+  let overviewScrollTimer: ReturnType<typeof setTimeout> | undefined
+  let syncEditorToOverviewUntil = 0
+
+  function cancelPendingOverviewScroll() {
+    pendingOverviewScroll = undefined
+    if (overviewScrollTimer) {
+      clearTimeout(overviewScrollTimer)
+      overviewScrollTimer = undefined
+    }
+  }
 
   const { view, postMessage, forceReload } = useWebviewView(
     'slidev-preview',
@@ -62,9 +73,16 @@ export const usePreviewWebview = defineService(() => {
           }
           else {
             initializedClientId.value = data.clientId
-            if (previewMode.value === 'slide' && config['preview-sync'] && initializedClientId.value === data.clientId)
+            if (previewMode.value === 'slide' && config['preview-sync'] && initializedClientId.value === data.clientId && focusedSlideNo.value != null)
               postSlidevMessage('navigate', { no: focusedSlideNo.value })
           }
+        }
+        else if (data.type === 'overview-scroll') {
+          syncEditorToOverviewUntil = Date.now() + 300
+          cancelPendingOverviewScroll()
+          const no = Number(data.no)
+          if (previewMode.value === 'overview' && config['preview-sync'] && Number.isFinite(no))
+            revealViewportSlide(no)
         }
       },
     },
@@ -91,7 +109,26 @@ export const usePreviewWebview = defineService(() => {
     })
   }
 
-  watch([pageId], () => postSlidevMessage('css-vars', { '--slidev-slide-container-background': 'transparent' }))
+  function scrollOverviewToSlide(no: number) {
+    if (Date.now() < syncEditorToOverviewUntil)
+      return
+    pendingOverviewScroll = { no }
+    if (overviewScrollTimer)
+      return
+    overviewScrollTimer = setTimeout(() => {
+      overviewScrollTimer = undefined
+      const scroll = pendingOverviewScroll
+      pendingOverviewScroll = undefined
+      if (scroll && Date.now() >= syncEditorToOverviewUntil && previewMode.value === 'overview' && config['preview-sync'])
+        postSlidevMessage('overview-scroll', scroll)
+    }, 50)
+  }
+
+  watch([pageId], () => {
+    postSlidevMessage('css-vars', { '--slidev-slide-container-background': 'transparent' })
+    if (previewMode.value === 'overview' && config['preview-sync'] && viewportSlideNo.value != null)
+      scrollOverviewToSlide(viewportSlideNo.value)
+  })
   watch([pageId, isDarkTheme], ([_, dark]) => postSlidevMessage('color-schema', { color: dark ? 'dark' : 'light' }))
 
   watchEffect(() => {
@@ -116,16 +153,19 @@ export const usePreviewWebview = defineService(() => {
   watch(
     () => previewNavState.no,
     (no) => {
-      if (previewMode.value === 'slide' && ready.value && config['preview-sync'] && activeProject.value) {
+      if (previewMode.value === 'slide' && no > 0 && ready.value && config['preview-sync'] && activeProject.value) {
         focusSlide(activeProject.value, no)
       }
     },
   )
   watch(
-    [() => config['preview-sync'], focusedSlideNo, previewMode],
-    ([enabled, no, mode]) => {
-      if (enabled && mode === 'slide' && no != null && previewNavState.no !== no) {
-        postSlidevMessage('navigate', { no, clicks: 999999 })
+    [() => config['preview-sync'], focusedSlideNo, viewportSlideNo, previewMode],
+    ([enabled, focusedNo, viewportNo, mode]) => {
+      if (enabled && mode === 'slide' && focusedNo != null && previewNavState.no !== focusedNo) {
+        postSlidevMessage('navigate', { no: focusedNo, clicks: 999999 })
+      }
+      else if (enabled && mode === 'overview' && viewportNo != null) {
+        scrollOverviewToSlide(viewportNo)
       }
     },
   )

--- a/packages/vscode/src/views/previewWebview.ts
+++ b/packages/vscode/src/views/previewWebview.ts
@@ -184,6 +184,10 @@ export const usePreviewWebview = defineService(() => {
     prevSlide: useNavOperation('prevSlide', true),
     openExternal: () => {
       const hashRoute = activeData.value?.slides[0]?.frontmatter.routerMode === 'hash'
+      if (previewMode.value === 'overview') {
+        const url = `http://localhost:${port.value}${hashRoute ? '#/' : '/'}overview?mode=preview`
+        return env.openExternal(Uri.parse(url))
+      }
       const query = previewNavState.clicks > 0 ? `?clicks=${previewNavState.clicks}` : ''
       const url = `http://localhost:${port.value}/${hashRoute ? '#' : ''}${previewNavState.no}${query}`
       return env.openExternal(Uri.parse(url))

--- a/packages/vscode/src/views/previewWebview.ts
+++ b/packages/vscode/src/views/previewWebview.ts
@@ -7,6 +7,7 @@ import { config } from '../configs'
 import { generateErrorHtml } from '../html/error'
 import { generateReadyHtml } from '../html/ready'
 import { activeData, activeProject } from '../projects'
+import { getSlidesTitle } from '../utils/getSlidesTitle'
 import { logger } from './logger'
 
 export const usePreviewWebview = defineService(() => {
@@ -22,10 +23,7 @@ export const usePreviewWebview = defineService(() => {
   const savedPreviewMode = extensionContext.value?.globalState.get<PreviewMode>('slidev:preview:mode')
   const previewMode = ref<PreviewMode>(savedPreviewMode === 'overview' ? 'overview' : 'slide')
   const hashRoute = computed(() => activeData.value?.slides[0]?.frontmatter.routerMode === 'hash')
-  const html = computed(() => ready.value
-    ? generateReadyHtml(port.value, previewMode.value, hashRoute.value)
-    : generateErrorHtml(message.value),
-  )
+  const overviewInitialSlideNo = ref<number>()
   useVscodeContext('slidev:preview:sync', () => config['preview-sync'])
   useVscodeContext('slidev:preview:overview', () => previewMode.value === 'overview')
 
@@ -35,6 +33,34 @@ export const usePreviewWebview = defineService(() => {
     hasNext: true,
     hasPrev: false,
   })
+  let overviewSlideNoForUrl: number | undefined
+
+  function normalizeSlideNo(no: unknown) {
+    const slideNo = Number(no)
+    return Number.isFinite(slideNo) && slideNo > 0 ? slideNo : undefined
+  }
+
+  function getOverviewSlideNoForUrl() {
+    return normalizeSlideNo(
+      overviewSlideNoForUrl
+      ?? viewportSlideNo.value
+      ?? focusedSlideNo.value
+      ?? previewNavState.no,
+    )
+  }
+
+  function updateOverviewInitialSlideNo() {
+    overviewInitialSlideNo.value = previewMode.value === 'overview'
+      ? getOverviewSlideNoForUrl()
+      : undefined
+  }
+
+  updateOverviewInitialSlideNo()
+
+  const html = computed(() => ready.value
+    ? generateReadyHtml(port.value, previewMode.value, hashRoute.value, overviewInitialSlideNo.value)
+    : generateErrorHtml(message.value),
+  )
 
   useVscodeContext('slidev:preview:has-prev-slide', () => previewMode.value === 'slide' && previewNavState.no > 1)
   useVscodeContext('slidev:preview:has-next-slide', () => previewMode.value === 'slide' && activeData.value && previewNavState.no < activeData.value.slides.length)
@@ -81,8 +107,13 @@ export const usePreviewWebview = defineService(() => {
           syncEditorToOverviewUntil = Date.now() + 300
           cancelPendingOverviewScroll()
           const no = Number(data.no)
+          if (Number.isFinite(no))
+            overviewSlideNoForUrl = no
           if (previewMode.value === 'overview' && config['preview-sync'] && Number.isFinite(no))
             revealViewportSlide(no)
+        }
+        else if (data.type === 'open-external' && typeof data.url === 'string') {
+          env.openExternal(Uri.parse(data.url))
         }
       },
     },
@@ -94,6 +125,7 @@ export const usePreviewWebview = defineService(() => {
       await redetect(port.value)
     if (!view.value)
       return
+    updateOverviewInitialSlideNo()
     forceReload()
     logger.info(`Webview refreshed. Current URL: http://localhost:${port.value}`)
     setTimeout(() => pageId.value++, 300)
@@ -112,6 +144,7 @@ export const usePreviewWebview = defineService(() => {
   function scrollOverviewToSlide(no: number) {
     if (Date.now() < syncEditorToOverviewUntil)
       return
+    overviewSlideNoForUrl = no
     pendingOverviewScroll = { no }
     if (overviewScrollTimer)
       return
@@ -133,10 +166,13 @@ export const usePreviewWebview = defineService(() => {
 
   watchEffect(() => {
     if (view.value) {
+      if (previewMode.value === 'overview' && activeData.value) {
+        view.value.title = getSlidesTitle(activeData.value)
+        return
+      }
       const slideNo = ready.value && previewMode.value === 'slide' && previewNavState.no > 0 ? ` (${previewNavState.no}/${activeData.value?.slides.length})` : ''
-      const modeInfo = previewMode.value === 'overview' ? ' (overview)' : ''
       const compatInfo = compatMode.value ? ' (compat mode)' : ''
-      view.value.title = `Preview${slideNo}${modeInfo}${compatInfo}`
+      view.value.title = `Preview${slideNo}${compatInfo}`
     }
   })
 
@@ -175,6 +211,11 @@ export const usePreviewWebview = defineService(() => {
     refresh,
     setPreviewMode: (mode: PreviewMode) => {
       initializedClientId.value = ''
+      if (mode !== previewMode.value)
+        overviewSlideNoForUrl = undefined
+      overviewInitialSlideNo.value = mode === 'overview'
+        ? getOverviewSlideNoForUrl()
+        : undefined
       previewMode.value = mode
       void extensionContext.value?.globalState.update('slidev:preview:mode', mode)
     },
@@ -184,12 +225,14 @@ export const usePreviewWebview = defineService(() => {
     prevSlide: useNavOperation('prevSlide', true),
     openExternal: () => {
       const hashRoute = activeData.value?.slides[0]?.frontmatter.routerMode === 'hash'
-      if (previewMode.value === 'overview') {
-        const url = `http://localhost:${port.value}${hashRoute ? '#/' : '/'}overview?mode=preview`
-        return env.openExternal(Uri.parse(url))
-      }
+      const no = previewMode.value === 'overview'
+        ? getOverviewSlideNoForUrl()
+        : previewNavState.no
+      if (!no)
+        return
+      const slideNo = activeData.value ? Math.min(Math.max(Math.round(no), 1), activeData.value.slides.length) : no
       const query = previewNavState.clicks > 0 ? `?clicks=${previewNavState.clicks}` : ''
-      const url = `http://localhost:${port.value}/${hashRoute ? '#' : ''}${previewNavState.no}${query}`
+      const url = `http://localhost:${port.value}/${hashRoute ? '#' : ''}${slideNo}${previewMode.value === 'slide' ? query : ''}`
       return env.openExternal(Uri.parse(url))
     },
   }


### PR DESCRIPTION
resolved #1351

## Summary
- add a toggleable overview preview mode for the VS Code webview
- support embedded overview scrolling, slide opening, and source jumping
- polish overview controls and sync behavior

<img width="1786" height="1162" alt="20260517191830_rec_" src="https://github.com/user-attachments/assets/fb81dc99-8efd-4ab8-bc54-ed7ba6cad19a" />
