### PR TITLE
docs: add CI environment setup guide for OG image with CJK fonts

### DIFF
--- a/docs/features/og-image.md
+++ b/docs/features/og-image.md
@@ -46,11 +46,14 @@ When generating the OG image on CI (e.g. GitHub Actions), the runner may not hav
 
 ### Install system fonts
 
-On Ubuntu-based runners, install the Noto CJK fonts before building:
+On Ubuntu-based runners, install the Noto CJK fonts before building. Make sure to install fonts **before** running `playwright install`:
 
 ```yaml
 - name: Install CJK fonts
   run: sudo apt-get install -y fonts-noto-cjk
+
+- name: Install Playwright browsers
+  run: pnpm exec playwright install chromium --with-deps
 ```
 
 ### Use web fonts

--- a/docs/features/og-image.md
+++ b/docs/features/og-image.md
@@ -39,3 +39,30 @@ seoMeta:
 ```
 
 It will use [playwright](https://playwright.dev/) to capture the first slide and save it as `./og-image.png` (same as `slidev export`). You may also commit the generated image to your repository to avoid the auto-generation. Or if you generate it on CI, you might also want to setup the playwright environment.
+
+## CI Environment
+
+When generating the OG image on CI (e.g. GitHub Actions), the runner may not have the fonts required to render your slides correctly. Non-Latin characters such as Japanese, Chinese, or Korean will appear as boxes (tofu) if the system fonts are missing.
+
+### Install system fonts
+
+On Ubuntu-based runners, install the Noto CJK fonts before building:
+
+```yaml
+- name: Install CJK fonts
+  run: sudo apt-get install -y fonts-noto-cjk
+```
+
+### Use web fonts
+
+Alternatively, configure your slides to use a web font that supports your language. Slidev will wait for all web fonts to finish loading before capturing the screenshot.
+
+```md
+---
+fonts:
+  sans: Noto Sans JP
+---
+```
+
+> [!TIP]
+> You can commit the generated `og-image.png` to your repository. Slidev will reuse the committed image instead of re-generating it on every build, which avoids the font issue entirely and speeds up your CI.


### PR DESCRIPTION
## Summary

Add a "CI Environment" section to the OG image docs to address CJK font
rendering issues on Ubuntu-based CI runners.

- Explain why Japanese/Chinese/Korean characters appear as boxes (tofu)
  when auto-generating OG images on CI
- Document the recommended fix: install `fonts-noto-cjk` before running
  `playwright install chromium --with-deps`
- Mention the web fonts alternative
- Add a tip about committing `og-image.png` to skip regeneration entirely

## Example

### Before (without CJK fonts)

<img width="980" height="551" alt="og-image" src="https://github.com/user-attachments/assets/2a8dd97a-a126-46a6-8a2a-6dd646dbb6af" />

### After (with `fonts-noto-cjk`)

<img width="980" height="551" alt="og-image" src="https://github.com/user-attachments/assets/773350c7-a43e-40c3-8922-80d42b3cc764" />

`.github/workflows/deploy.yml`
```yaml
- name: Install CJK fonts
  run: sudo apt-get install -y fonts-noto-cjk

- name: Install Playwright browsers
  run: pnpm exec playwright install chromium --with-deps

- name: Build slides
  run: pnpm slidev build
Related: #1932, #2111
