### PR TITLE
fix: proxy virtual import globs through fs modules

### DIFF
--- a/packages/slidev/node/utils.ts
+++ b/packages/slidev/node/utils.ts
@@ -134,7 +134,7 @@ export function createMakeAbsoluteImportGlob(baseRoot: string) {
   ) {
     // Vite does not treat /@slidev/* as a real filesystem importer. Emit
     // import.meta.glob from a proxy file so Vite resolves imports from disk.
-    const content = `export default ${makeAbsoluteImportGlobExpression(dirname(proxyBase), globs, options, baseRoot)}\n`
+    const content = `export default ${makeAbsoluteImportGlobExpression(dirname(proxyBase), globs, options)}\n`
     const proxyModule = resolveImportGlobProxyModule(proxyBase, content)
     if (proxyModules.get(proxyModule) !== content) {
       mkdirSync(dirname(proxyModule), { recursive: true })
@@ -151,21 +151,16 @@ function makeAbsoluteImportGlobExpression(
   self: string,
   globs: string[],
   options: Partial<GeneralImportGlobOptions> = {},
-  baseRoot?: string,
 ) {
-  const root = baseRoot && globs.some(glob => RE_WINDOWS_DRIVE.test(slash(glob)))
-    ? baseRoot
-    : undefined
   const relativeGlobs = globs.map((glob) => {
-    const relativeGlob = getImportGlobRelativePath(root ?? self, glob)
-    return root && !relativeGlob.startsWith('.') && !RE_WINDOWS_DRIVE.test(relativeGlob)
+    const relativeGlob = getImportGlobRelativePath(self, glob)
+    return !relativeGlob.startsWith('.') && !RE_WINDOWS_DRIVE.test(relativeGlob)
       ? `./${relativeGlob}`
       : relativeGlob
   })
   const opts: GeneralImportGlobOptions = {
     eager: true,
     exhaustive: true,
-    ...(root ? { base: '/' } : {}),
     ...options,
   }
   return `import.meta.glob(${JSON.stringify(relativeGlobs)}, ${JSON.stringify(opts)})`

--- a/packages/slidev/node/utils.ts
+++ b/packages/slidev/node/utils.ts
@@ -1,11 +1,14 @@
 import type { ResolvedFontOptions, SourceSlideInfo } from '@slidev/types'
 import type MarkdownExit from 'markdown-exit'
 import type { Connect, GeneralImportGlobOptions } from 'vite'
-import { relative, win32 } from 'node:path'
+import { createHash } from 'node:crypto'
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { dirname, join, relative, win32 } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { slash } from '@antfu/utils'
 import { createJiti } from 'jiti'
 import YAML from 'yaml'
+import { toAtFS } from './resolver'
 
 const RE_WHITESPACE_ONLY = /^\s*$/
 const RE_QUOTED_STRING = /^(['"])(.*)\1$/
@@ -115,15 +118,41 @@ function getImportGlobRelativePath(from: string, to: string) {
   )
 }
 
-export function makeAbsoluteImportGlob(
+function resolveImportGlobProxyModule(proxyBase: string, content: string) {
+  const hash = createHash('sha256').update(content).digest('hex').slice(0, 10)
+  return `${proxyBase}.${hash}.ts`
+}
+
+export function createMakeAbsoluteImportGlob(baseRoot: string) {
+  const proxyModules = new Map<string, string>()
+  const proxyBasename = 'node_modules/.slidev/virtual/import-glob'
+  const proxyBase = slash(join(baseRoot, proxyBasename))
+
+  return function makeAbsoluteImportGlob(
+    globs: string[],
+    options: Partial<GeneralImportGlobOptions> = {},
+  ) {
+    // Vite does not treat /@slidev/* as a real filesystem importer. Emit
+    // import.meta.glob from a proxy file so Vite resolves imports from disk.
+    const content = `export default ${makeAbsoluteImportGlobExpression(dirname(proxyBase), globs, options, baseRoot)}\n`
+    const proxyModule = resolveImportGlobProxyModule(proxyBase, content)
+    if (proxyModules.get(proxyModule) !== content) {
+      mkdirSync(dirname(proxyModule), { recursive: true })
+      writeFileSync(proxyModule, content, 'utf-8')
+      proxyModules.set(proxyModule, content)
+    }
+    return toAtFS(proxyModule)
+  }
+}
+
+export type MakeAbsoluteImportGlob = ReturnType<typeof createMakeAbsoluteImportGlob>
+
+function makeAbsoluteImportGlobExpression(
   self: string,
   globs: string[],
   options: Partial<GeneralImportGlobOptions> = {},
   baseRoot?: string,
 ) {
-  // Vite's import.meta.glob only supports relative paths. On Windows, though,
-  // resolving drive-letter paths from a virtual /@slidev module can drop the
-  // drive prefix. Use Vite's root-relative form for those paths instead.
   const root = baseRoot && globs.some(glob => RE_WINDOWS_DRIVE.test(slash(glob)))
     ? baseRoot
     : undefined

--- a/packages/slidev/node/virtual/conditional-styles.ts
+++ b/packages/slidev/node/virtual/conditional-styles.ts
@@ -1,21 +1,21 @@
 import type { VirtualModuleTemplate } from './types'
 import { join } from 'node:path'
 import { resolveImportUrl } from '../resolver'
-import { makeAbsoluteImportGlob } from '../utils'
 
 const id = '/@slidev/conditional-styles'
 
 export const templateConditionalStyles: VirtualModuleTemplate = {
   id,
-  async getContent({ data, roots, userRoot }) {
+  async getContent({ data, roots }) {
     const imports: string[] = []
 
     for (const root of roots) {
-      imports.push(makeAbsoluteImportGlob(id, [
+      const importPath = this.makeAbsoluteImportGlob([
         join(root, 'styles/index.{ts,js,css}'),
         join(root, 'styles.{ts,js,css}'),
         join(root, 'style.{ts,js,css}'),
-      ], {}, userRoot))
+      ])
+      imports.push(`import ${JSON.stringify(importPath)}`)
     }
 
     if (data.features.katex)

--- a/packages/slidev/node/virtual/global-layers.ts
+++ b/packages/slidev/node/virtual/global-layers.ts
@@ -1,30 +1,34 @@
 import type { VirtualModuleTemplate } from './types'
 import { join } from 'node:path'
-import { makeAbsoluteImportGlob } from '../utils'
 
 const id = `/@slidev/global-layers`
 
 export const templateGlobalLayers: VirtualModuleTemplate = {
   id,
-  getContent({ roots, userRoot }) {
+  getContent({ roots }) {
+    const { makeAbsoluteImportGlob } = this
+    const imports = [`import { h } from 'vue'`]
+    let importIndex = 0
+
     function* getComponent(name: string, names: string[]) {
       yield `const ${name}Components = [\n`
       for (const root of roots) {
         const globs = names.map(name => join(root, `${name}.{ts,js,vue}`))
-        yield '  Object.values('
-        yield makeAbsoluteImportGlob(id, globs, { import: 'default' }, userRoot)
-        yield ')[0],\n'
+        const importName = `__slidev_global_layer_${importIndex++}`
+        imports.push(`import ${importName} from ${JSON.stringify(makeAbsoluteImportGlob(globs, { import: 'default' }))}`)
+        yield `  Object.values(${importName})[0],\n`
       }
       yield `].filter(Boolean)\n`
       yield `export const ${name} = { render: () => ${name}Components.map(comp => h(comp)) }\n\n`
     }
 
-    return [
-      `import { h } from 'vue'\n\n`,
+    const body = [
       ...getComponent('GlobalTop', ['global', 'global-top', 'GlobalTop']),
       ...getComponent('GlobalBottom', ['global-bottom', 'GlobalBottom']),
       ...getComponent('SlideTop', ['slide-top', 'SlideTop']),
       ...getComponent('SlideBottom', ['slide-bottom', 'SlideBottom']),
     ].join('')
+
+    return `${imports.join('\n')}\n\n${body}`
   },
 }

--- a/packages/slidev/node/virtual/setups.ts
+++ b/packages/slidev/node/virtual/setups.ts
@@ -1,17 +1,19 @@
 import type { VirtualModuleTemplate } from './types'
 import { join } from 'node:path'
-import { makeAbsoluteImportGlob } from '../utils'
 
 function createSetupTemplate(name: string): VirtualModuleTemplate {
   const id = `/@slidev/setups/${name}`
   return {
     id,
-    getContent({ roots, userRoot }) {
+    getContent({ roots }) {
+      const imports: string[] = []
       const globs = roots.map((root) => {
         const glob = join(root, `setup/${name}.{ts,js,mts,mjs}`)
-        return `Object.values(${makeAbsoluteImportGlob(id, [glob], { import: 'default' }, userRoot)})[0]`
+        const importName = `__slidev_setup_${imports.length}`
+        imports.push(`import ${importName} from ${JSON.stringify(this.makeAbsoluteImportGlob([glob], { import: 'default' }))}`)
+        return `Object.values(${importName})[0]`
       })
-      return `export default [${globs.join(', ')}].filter(Boolean)`
+      return `${imports.join('\n')}\n\nexport default [${globs.join(', ')}].filter(Boolean)`
     },
   }
 }

--- a/packages/slidev/node/virtual/types.ts
+++ b/packages/slidev/node/virtual/types.ts
@@ -1,7 +1,13 @@
 import type { Awaitable } from '@antfu/utils'
 import type { ResolvedSlidevOptions } from '@slidev/types'
+import type { Rolldown } from 'vite'
+import type { MakeAbsoluteImportGlob } from '../utils'
+
+export interface VirtualModuleContext extends Pick<Rolldown.PluginContext, 'resolve'> {
+  makeAbsoluteImportGlob: MakeAbsoluteImportGlob
+}
 
 export interface VirtualModuleTemplate {
   id: string
-  getContent: (this: any, options: ResolvedSlidevOptions) => Awaitable<string>
+  getContent: (this: VirtualModuleContext, options: ResolvedSlidevOptions) => Awaitable<string>
 }

--- a/packages/slidev/node/vite/loaders.ts
+++ b/packages/slidev/node/vite/loaders.ts
@@ -1,6 +1,6 @@
 import type { ResolvedSlidevOptions, SlideInfo, SlidePatch, SlidevData, SlidevServerOptions } from '@slidev/types'
-import type { LoadResult } from 'rollup'
-import type { ModuleNode, Plugin, ViteDevServer } from 'vite'
+import type { ModuleNode, Plugin, Rolldown, ViteDevServer } from 'vite'
+import type { VirtualModuleContext } from '../virtual/types'
 import { notNullish, range } from '@antfu/utils'
 import * as parser from '@slidev/parser/fs'
 import equal from 'fast-deep-equal'
@@ -9,7 +9,7 @@ import YAML from 'yaml'
 import { createDataUtils } from '../options'
 import MarkdownItKatex from '../syntax/katex'
 import markdownItLink from '../syntax/link'
-import { getBodyJson, updateFrontmatterPatch } from '../utils'
+import { createMakeAbsoluteImportGlob, getBodyJson, updateFrontmatterPatch } from '../utils'
 import { templates } from '../virtual'
 import { templateConfigs } from '../virtual/configs'
 import { templateMonacoRunDeps } from '../virtual/monaco-deps'
@@ -34,6 +34,7 @@ export function createSlidesLoader(
   const hmrSlidesIndexes = new Set<number>()
   let server: ViteDevServer | undefined
   let skipHmr: { filePath: string, fileContent: string } | null = null
+  const makeAbsoluteImportGlob = createMakeAbsoluteImportGlob(options.userRoot)
 
   interface ResolvedSourceIds {
     md: string[]
@@ -282,11 +283,15 @@ export function createSlidesLoader(
       },
     },
 
-    async load(id): Promise<LoadResult> {
+    async load(id): Promise<Rolldown.LoadResult> {
       const template = templates.find(i => i.id === id)
       if (template) {
+        const templateContext: VirtualModuleContext = {
+          resolve: this.resolve.bind(this),
+          makeAbsoluteImportGlob,
+        }
         return {
-          code: await template.getContent.call(this, options),
+          code: await template.getContent.call(templateContext, options),
           map: { mappings: '' },
         }
       }

--- a/test/mermaid-renderer.test.ts
+++ b/test/mermaid-renderer.test.ts
@@ -1,5 +1,5 @@
 import type { ResolvedSlidevOptions } from '@slidev/types'
-import type { PluginContext } from 'rollup'
+import type { VirtualModuleContext } from '../packages/slidev/node/virtual/types'
 import { describe, expect, it } from 'vitest'
 import { templateSetups } from '../packages/slidev/node/virtual/setups'
 
@@ -11,12 +11,17 @@ describe('mermaid-renderer virtual module', () => {
 
   it('generates content with mermaid-renderer glob', () => {
     const template = templateSetups.find(t => t.id === '/@slidev/setups/mermaid-renderer')!
-    const content = template.getContent.call({} as PluginContext, {
+    const context: VirtualModuleContext = {
+      makeAbsoluteImportGlob: () => '/node_modules/.slidev/virtual/setups/mermaid-renderer.test.ts',
+      resolve: async () => null,
+    }
+    const content = template.getContent.call(context, {
       userRoot: '/user/project',
       roots: ['/user/project'],
     } as ResolvedSlidevOptions)
 
     expect(content).toContain('mermaid-renderer')
+    expect(content).toContain('import __slidev_setup_0 from "/node_modules/.slidev/virtual/setups/mermaid-renderer.test.ts"')
     expect(content).toContain('export default')
     expect(content).toContain('filter(Boolean)')
   })

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,12 +1,15 @@
 import type { ResolvedFontOptions, SlideInfo } from '@slidev/types'
-import { relative, resolve } from 'node:path'
+import { createHash } from 'node:crypto'
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, relative, resolve } from 'node:path'
 import { slash } from '@antfu/utils'
 import MarkdownExit from 'markdown-exit'
 import { describe, expect, it } from 'vitest'
 import YAML from 'yaml'
 import { parseAspectRatio, parseRangeString } from '../packages/parser/src'
 import { getRoots } from '../packages/slidev/node/resolver'
-import { generateCoollabsFontsUrl, generateGoogleFontsUrl, makeAbsoluteImportGlob, stringifyMarkdownTokens, updateFrontmatterPatch } from '../packages/slidev/node/utils'
+import { createMakeAbsoluteImportGlob, generateCoollabsFontsUrl, generateGoogleFontsUrl, stringifyMarkdownTokens, updateFrontmatterPatch } from '../packages/slidev/node/utils'
 
 describe('utils', () => {
   it('page-range', () => {
@@ -89,14 +92,33 @@ describe('utils', () => {
     expectRelative(userWorkspaceRoot).toMatchInlineSnapshot(`".."`)
   })
 
-  it('uses root-relative glob patterns for Windows drive paths', () => {
-    expect(makeAbsoluteImportGlob('/@slidev/conditional-styles', [
-      'C:\\Users\\Donald\\Documents\\slides\\styles\\index.{ts,js,css}',
-      'C:\\Users\\Donald\\Documents\\slides\\styles.{ts,js,css}',
-      'C:\\Users\\Donald\\Documents\\slides\\style.{ts,js,css}',
-    ], {}, 'C:\\Users\\Donald\\Documents\\slides')).toMatchInlineSnapshot(
-      `"import.meta.glob([\"./styles/index.{ts,js,css}\",\"./styles.{ts,js,css}\",\"./style.{ts,js,css}\"], {\"eager\":true,\"exhaustive\":true,\"base\":\"/\"})"`,
-    )
+  it('proxies slidev import globs through a real filesystem module', () => {
+    const root = mkdtempSync(join(tmpdir(), 'slidev-import-glob-'))
+    const makeAbsoluteImportGlob = createMakeAbsoluteImportGlob(root)
+
+    try {
+      const proxyUrl = makeAbsoluteImportGlob([
+        join(root, 'setup/main.ts'),
+      ], { import: 'default' })
+      const secondProxyUrl = makeAbsoluteImportGlob([
+        join(root, 'theme/setup/main.ts'),
+      ], { import: 'default' })
+
+      expect(proxyUrl).toMatch(/^\/@fs\/.*\/node_modules\/\.slidev\/virtual\/import-glob\.[a-f0-9]{10}\.ts$/)
+      expect(secondProxyUrl).toMatch(/^\/@fs\/.*\/node_modules\/\.slidev\/virtual\/import-glob\.[a-f0-9]{10}\.ts$/)
+      expect(secondProxyUrl).not.toBe(proxyUrl)
+      const content = readFileSync(proxyUrl.slice('/@fs'.length), 'utf-8')
+      const secondContent = readFileSync(secondProxyUrl.slice('/@fs'.length), 'utf-8')
+      expect(proxyUrl).toBe(`/@fs${slash(join(root, `node_modules/.slidev/virtual/import-glob.${createHash('sha256').update(content).digest('hex').slice(0, 10)}.ts`))}`)
+      expect(secondProxyUrl).toBe(`/@fs${slash(join(root, `node_modules/.slidev/virtual/import-glob.${createHash('sha256').update(secondContent).digest('hex').slice(0, 10)}.ts`))}`)
+      expect(content)
+        .toBe('export default import.meta.glob(["../../../setup/main.ts"], {"eager":true,"exhaustive":true,"import":"default"})\n')
+      expect(secondContent)
+        .toBe('export default import.meta.glob(["../../../theme/setup/main.ts"], {"eager":true,"exhaustive":true,"import":"default"})\n')
+    }
+    finally {
+      rmSync(root, { recursive: true, force: true })
+    }
   })
 
   it('update frontmatter patch', async () => {

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -3,12 +3,13 @@ import { createHash } from 'node:crypto'
 import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, relative, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { slash } from '@antfu/utils'
 import MarkdownExit from 'markdown-exit'
 import { describe, expect, it } from 'vitest'
 import YAML from 'yaml'
 import { parseAspectRatio, parseRangeString } from '../packages/parser/src'
-import { getRoots } from '../packages/slidev/node/resolver'
+import { getRoots, toAtFS } from '../packages/slidev/node/resolver'
 import { createMakeAbsoluteImportGlob, generateCoollabsFontsUrl, generateGoogleFontsUrl, stringifyMarkdownTokens, updateFrontmatterPatch } from '../packages/slidev/node/utils'
 
 describe('utils', () => {
@@ -107,10 +108,10 @@ describe('utils', () => {
       expect(proxyUrl).toMatch(/^\/@fs\/.*\/node_modules\/\.slidev\/virtual\/import-glob\.[a-f0-9]{10}\.ts$/)
       expect(secondProxyUrl).toMatch(/^\/@fs\/.*\/node_modules\/\.slidev\/virtual\/import-glob\.[a-f0-9]{10}\.ts$/)
       expect(secondProxyUrl).not.toBe(proxyUrl)
-      const content = readFileSync(proxyUrl.slice('/@fs'.length), 'utf-8')
-      const secondContent = readFileSync(secondProxyUrl.slice('/@fs'.length), 'utf-8')
-      expect(proxyUrl).toBe(`/@fs${slash(join(root, `node_modules/.slidev/virtual/import-glob.${createHash('sha256').update(content).digest('hex').slice(0, 10)}.ts`))}`)
-      expect(secondProxyUrl).toBe(`/@fs${slash(join(root, `node_modules/.slidev/virtual/import-glob.${createHash('sha256').update(secondContent).digest('hex').slice(0, 10)}.ts`))}`)
+      const content = readFileSync(fileURLToPath(`file://${proxyUrl.slice('/@fs'.length)}`), 'utf-8')
+      const secondContent = readFileSync(fileURLToPath(`file://${secondProxyUrl.slice('/@fs'.length)}`), 'utf-8')
+      expect(proxyUrl).toBe(toAtFS(join(root, `node_modules/.slidev/virtual/import-glob.${createHash('sha256').update(content).digest('hex').slice(0, 10)}.ts`)))
+      expect(secondProxyUrl).toBe(toAtFS(join(root, `node_modules/.slidev/virtual/import-glob.${createHash('sha256').update(secondContent).digest('hex').slice(0, 10)}.ts`)))
       expect(content)
         .toBe('export default import.meta.glob(["../../../setup/main.ts"], {"eager":true,"exhaustive":true,"import":"default"})\n')
       expect(secondContent)


### PR DESCRIPTION
fixes #2605 

### Summary

- Proxy virtual module import.meta.glob calls through generated filesystem modules so Vite resolves globs from a real importer.
- Bind the proxy helper to userRoot once and expose a narrower makeAbsoluteImportGlob(globs, options?) context API.
- Type virtual module context against Vite/Rolldown plugin context to avoid Rollup/Rolldown resolve type mismatches.

### Tests

- pnpm exec eslint packages/slidev/node/utils.ts packages/slidev/node/virtual/conditional-styles.ts packages/slidev/node/virtual/global-layers.ts packages/slidev/node/virtual/setups.ts packages/slidev/node/vite/loaders.ts test/utils.test.ts test/mermaid-renderer.test.ts
- pnpm exec vitest run test/utils.test.ts test/mermaid-renderer.test.ts

Note: pnpm typecheck still fails on existing docs/node_modules/vitepress/... TS7016 declaration errors unrelated to this change.