### PR TITLE
docs: add Tahta to community themes gallery

### DIFF
--- a/docs/.vitepress/themes.ts
+++ b/docs/.vitepress/themes.ts
@@ -659,6 +659,29 @@ export const community: ThemeInfo[] = [
       'light',
     ],
   },
+  {
+    id: 'slidev-theme-tahta',
+    name: 'Tahta',
+    description: 'A design system for Slidev — design tokens, components and 7 themeable style variants. WCAG-AA contrast, charts, and frontmatter-driven layouts (no CSS).',
+    author: {
+      name: 'Cagdas Salur',
+      link: 'https://github.com/zcag',
+    },
+    repo: 'https://github.com/zcag/tahta',
+    link: 'https://tahta.cagdas.io',
+    previews: [
+      'https://cdn.jsdelivr.net/gh/zcag/tahta@main/docs/screenshots/01.png',
+      'https://cdn.jsdelivr.net/gh/zcag/tahta@main/docs/screenshots/02.png',
+      'https://cdn.jsdelivr.net/gh/zcag/tahta@main/docs/screenshots/03.png',
+      'https://cdn.jsdelivr.net/gh/zcag/tahta@main/docs/screenshots/04.png',
+      'https://cdn.jsdelivr.net/gh/zcag/tahta@main/docs/screenshots/05.png',
+      'https://cdn.jsdelivr.net/gh/zcag/tahta@main/docs/screenshots/06.png',
+    ],
+    tags: [
+      'dark',
+      'light',
+    ],
+  },
   // Add yours here!
   {
     id: '',

--- a/docs/.vitepress/themes.ts
+++ b/docs/.vitepress/themes.ts
@@ -662,7 +662,7 @@ export const community: ThemeInfo[] = [
   {
     id: 'slidev-theme-tahta',
     name: 'Tahta',
-    description: 'A design system for Slidev — design tokens, components and 7 themeable style variants. WCAG-AA contrast, charts, and frontmatter-driven layouts (no CSS).',
+    description: 'A design system for Slidev — design tokens, components, and 13 themeable style variants with themed chart palettes and role-color cards. WCAG-AA contrast, ECharts, and frontmatter-driven layouts (no CSS).',
     author: {
       name: 'Cagdas Salur',
       link: 'https://github.com/zcag',
@@ -670,12 +670,12 @@ export const community: ThemeInfo[] = [
     repo: 'https://github.com/zcag/tahta',
     link: 'https://tahta.cagdas.io',
     previews: [
-      'https://cdn.jsdelivr.net/gh/zcag/tahta@main/docs/screenshots/01.png',
-      'https://cdn.jsdelivr.net/gh/zcag/tahta@main/docs/screenshots/02.png',
-      'https://cdn.jsdelivr.net/gh/zcag/tahta@main/docs/screenshots/03.png',
-      'https://cdn.jsdelivr.net/gh/zcag/tahta@main/docs/screenshots/04.png',
-      'https://cdn.jsdelivr.net/gh/zcag/tahta@main/docs/screenshots/05.png',
-      'https://cdn.jsdelivr.net/gh/zcag/tahta@main/docs/screenshots/06.png',
+      'https://cdn.jsdelivr.net/gh/zcag/tahta@1dd8357/docs/screenshots/01.png',
+      'https://cdn.jsdelivr.net/gh/zcag/tahta@1dd8357/docs/screenshots/02.png',
+      'https://cdn.jsdelivr.net/gh/zcag/tahta@1dd8357/docs/screenshots/03.png',
+      'https://cdn.jsdelivr.net/gh/zcag/tahta@1dd8357/docs/screenshots/04.png',
+      'https://cdn.jsdelivr.net/gh/zcag/tahta@1dd8357/docs/screenshots/05.png',
+      'https://cdn.jsdelivr.net/gh/zcag/tahta@1dd8357/docs/screenshots/06.png',
     ],
     tags: [
       'dark',


### PR DESCRIPTION
Adds [**Tahta**](https://github.com/zcag/tahta) to the community theme gallery.

Tahta is a design system for Slidev rather than a single look: a 3-tier design-token layer drives **7 themeable style variants** (editorial, brutalist, soft, minimal, paper, atelier, notebook), with components (stats, charts, callouts, icons) and ~20 frontmatter-driven layouts so decks are authored without writing CSS. Contrast is WCAG-AA gated in CI per variant.

- npm: [`slidev-theme-tahta`](https://www.npmjs.com/package/slidev-theme-tahta)
- Repo: https://github.com/zcag/tahta
- Live explorer: https://tahta.cagdas.io
- License: MIT

Previews are served from the repo via jsDelivr. The six screenshots show different variants and layouts (cover, showcase, stats, chart, quote, feature cards).