### PR TITLE
docs(skill): add content fit guidance

### DIFF
--- a/skills/slidev/README.md
+++ b/skills/slidev/README.md
@@ -18,7 +18,7 @@ The Slidev skill provides Claude Code with knowledge about:
 - **Animations** - Click animations, transitions, motion effects
 - **Code Features** - Line highlighting, Monaco editor, code groups, magic-move
 - **Diagrams** - Mermaid, PlantUML, LaTeX math
-- **Layouts** - Built-in layouts, slots, global layers
+- **Layouts** - Built-in layouts, slots, global layers, content-fit guidance
 - **Presenter Mode** - Recording, timer, remote access
 - **Exporting** - PDF, PPTX, PNG, SPA hosting
 

--- a/skills/slidev/SKILL.md
+++ b/skills/slidev/SKILL.md
@@ -28,6 +28,17 @@ pnpm run export       # Export to PDF (requires playwright-chromium)
 
 **Verify**: After `pnpm run dev`, confirm slides load at `http://localhost:3030`. After `pnpm run export`, check the output PDF exists in the project root.
 
+## Reference Loading Guidance
+
+This file is an index. For non-trivial decks, load the relevant files from `references/` before writing or editing slides. In particular:
+
+- Dense generated slides, large diagrams, wide tables, or long code: [layout-content-fit](references/layout-content-fit.md), [layout-transform](references/layout-transform.md), [layout-zoom](references/layout-zoom.md), and [code-max-height](references/code-max-height.md)
+- Mermaid diagrams: [diagram-mermaid](references/diagram-mermaid.md) plus [layout-content-fit](references/layout-content-fit.md)
+- Export behavior: [core-exporting](references/core-exporting.md), [build-pdf](references/build-pdf.md), and [core-hosting](references/core-hosting.md)
+- Advanced Markdown syntax: [core-syntax](references/core-syntax.md), [syntax-comark](references/syntax-comark.md), and [syntax-block-frontmatter](references/syntax-block-frontmatter.md)
+
+When creating slides for export, treat a successful build as necessary but not sufficient. Check that visible content fits the slide canvas and remains readable in the browser or exported artifact.
+
 ## Basic Syntax
 
 ```md
@@ -101,6 +112,7 @@ Presenter notes go here
 | Feature | Usage | Reference |
 |---------|-------|-----------|
 | Canvas size | `canvasWidth`, `aspectRatio` | [layout-canvas-size](references/layout-canvas-size.md) |
+| Content fit | Split dense slides, constrain overflow, verify exports | [layout-content-fit](references/layout-content-fit.md) |
 | Zoom slide | `zoom: 0.8` | [layout-zoom](references/layout-zoom.md) |
 | Scale elements | `<Transform :scale="0.5">` | [layout-transform](references/layout-transform.md) |
 | Layout slots | `::right::`, `::default::` | [layout-slots](references/layout-slots.md) |

--- a/skills/slidev/references/code-max-height.md
+++ b/skills/slidev/references/code-max-height.md
@@ -35,3 +35,9 @@ Use `{*}` when you only need maxHeight:
 ## Use Case
 
 When code is too long to fit on one slide but you want to show it all with scrolling.
+
+## Fit Guidance
+
+Use `maxHeight` when the complete snippet should remain available. If only a few lines are important, prefer a smaller focused snippet or line-highlighting steps. For export-heavy decks, check that the scrollable block is still understandable in the exported format.
+
+See [layout-content-fit](layout-content-fit.md) for choosing between splitting, scrolling, local transforms, and slide-level zoom.

--- a/skills/slidev/references/diagram-mermaid.md
+++ b/skills/slidev/references/diagram-mermaid.md
@@ -38,6 +38,18 @@ C -->|Two| E[Result 2]
 - `gantt` - Gantt charts
 - `pie` - Pie charts
 
+## Fit Guidance
+
+For large Mermaid diagrams:
+
+- Shorten labels before reducing scale.
+- Split unrelated clusters into separate slides.
+- Change graph direction when width or height is the limiting dimension.
+- Use Mermaid `scale` or a local `<Transform>` for the diagram, not whole-slide `zoom`, when surrounding text already fits.
+- Verify the rendered diagram in the browser or exported artifact.
+
+See [layout-content-fit](layout-content-fit.md) for the broader dense-slide workflow.
+
 ## Resources
 
 - Mermaid docs: https://mermaid.js.org/

--- a/skills/slidev/references/layout-content-fit.md
+++ b/skills/slidev/references/layout-content-fit.md
@@ -1,0 +1,75 @@
+---
+name: content-fit
+description: Keep dense diagrams, tables, code, and text within the visible slide canvas
+---
+
+# Content Fit
+
+Keep generated or content-heavy slides readable inside the visible canvas.
+
+Use this reference when a slide contains large diagrams, wide tables, long code blocks, dense bullet lists, screenshots, or imported content.
+
+## Decision Order
+
+1. Split independent ideas into multiple slides before scaling.
+2. Pick a layout that matches the structure, such as `two-cols`, `two-cols-header`, `image-left`, or `image-right`.
+3. Put only the oversized element inside `<Transform>` when a single diagram, table, image, or component is too large.
+4. Use code `maxHeight` when the goal is to keep a long snippet available with scrolling.
+5. Rewrite wide tables before scaling: reduce columns, split rows into multiple slides, or convert records into lists.
+6. Use slide-level `zoom` only after structure and local constraints are chosen.
+7. Verify the rendered slide in the browser or exported artifact, not just Markdown syntax.
+
+## Dense Text
+
+- Prefer one claim per slide.
+- Keep headings short.
+- Split long bullet lists by topic or progression.
+- Use speaker notes for details that do not need to be visible.
+
+## Mermaid And Diagrams
+
+- Shorten labels before reducing scale.
+- Split a large graph into smaller subgraphs or sequential slides.
+- Change diagram direction when width is the limiting dimension.
+- Wrap the rendered diagram in `<Transform>` when only the diagram needs scaling.
+- Avoid shrinking the whole slide when surrounding text is already readable.
+
+## Tables
+
+Wide Markdown tables are a common source of overflow.
+
+- Keep only comparison-critical columns visible.
+- Move low-priority columns into notes or follow-up slides.
+- Split long row sets across slides.
+- Convert key-value rows into definition lists or bullet groups when a table would become unreadable.
+- If a table must stay intact, put the table in a local `<Transform>` and check the exported result.
+
+## Code
+
+- Use focused snippets instead of complete files.
+- Use code highlighting steps to reveal only the important lines.
+- Use `{maxHeight:'...'}` for scrollable code when the full snippet must remain available.
+- Split setup, core logic, and edge cases into separate slides.
+
+## When To Use `zoom`
+
+Use `zoom` for whole-slide density mismatch, not as the first fix for one oversized object.
+
+Good uses:
+
+- A slide has many balanced regions that all need slightly more room.
+- A generated deck needs a conservative per-slide scale after structural cleanup.
+
+Avoid:
+
+- Making normal text unreadable to fit a single diagram.
+- Hiding a bad table shape by shrinking the whole slide.
+- Applying one fixed zoom value to every dense slide without checking the rendered output.
+
+## Verification Checklist
+
+- No visible content is clipped by the slide edge.
+- Important text remains readable.
+- Code, Mermaid, and tables fit in the exported PDF/PNG or hosted build.
+- Local transforms do not overlap neighboring slots.
+- Speaker notes contain details removed from the visible slide.

--- a/skills/slidev/references/layout-transform.md
+++ b/skills/slidev/references/layout-transform.md
@@ -27,7 +27,14 @@ Scale elements without affecting slide layout.
 - Fit oversized content
 - Create emphasis effects
 
+## Fit Guidance
+
+Use `<Transform>` when one region is oversized but the rest of the slide is already readable. Keep the transform local to the diagram, table, image, or component that needs scaling.
+
+Prefer `origin="top left"` or `origin="top center"` for content that should stay aligned with surrounding text. After scaling, check neighboring slots to make sure the transformed content does not overlap or get clipped.
+
 ## Related Features
 
+- Content fit workflow: Use [layout-content-fit](layout-content-fit.md)
 - Scale all slides: Use `canvasWidth` / `aspectRatio` in headmatter
 - Scale individual slides: Use `zoom` frontmatter option

--- a/skills/slidev/references/layout-zoom.md
+++ b/skills/slidev/references/layout-zoom.md
@@ -33,7 +33,14 @@ zoom: 0.8
 - Make text more readable
 - Adjust for different content densities
 
+## Fit Guidance
+
+Use `zoom` after choosing the slide structure. If only one object is too large, prefer a local `<Transform>` around that object. If the slide contains independent ideas, split it into multiple slides instead of shrinking everything.
+
+Do not use one fixed `zoom` value as a substitute for checking the rendered output. Text, diagrams, and tables still need to remain readable after export.
+
 ## Related Features
 
+- Content fit workflow: Use [layout-content-fit](layout-content-fit.md)
 - Scale all slides: Use `canvasWidth` / `aspectRatio` in headmatter
 - Scale elements: Use `<Transform>` component


### PR DESCRIPTION
## Title: Docs: Add content-fit guidance to the Slidev skill

### 1. Context & Motivation (Context)
- **Issue:** N/A
- **Problem:** The Slidev skill lists layout, Mermaid, transform, zoom, and code-scroll primitives independently, but it does not give agents a clear decision order for dense slides. That can lead agents to overuse whole-slide `zoom` or accept build-success as proof even when diagrams, tables, code, or text may overflow the visible canvas.
- **Trade-offs:** This keeps the change as additive skill guidance instead of changing runtime layout behavior. The trade-off is that agents get better heuristics without deterministic engine-level enforcement; that avoids API/runtime risk and keeps the PR scoped to the skill content.

### 2. Implementation Details (Implementation)
- Adds `layout-content-fit.md` as a dedicated reference for dense diagrams, tables, code, text, local transforms, slide zoom, and export verification.
- Updates `SKILL.md` so agents treat it as an index and load task-specific references for dense slides, Mermaid diagrams, export behavior, and advanced Markdown syntax.
- Cross-links `layout-zoom`, `layout-transform`, `diagram-mermaid`, and `code-max-height` to the content-fit workflow so the primitives are presented as complementary choices instead of isolated fixes.
- Updates the skill README capability list to mention content-fit guidance.
- **Note:** This PR intentionally does not change Slidev runtime, bundler, CLI behavior, or export output. Engine-level overflow detection would be a separate feature PR with tests.

### 3. Testing Strategies (Validation)
- [x] Added documentation-only coverage for `skills/slidev/references/layout-content-fit.md` and linked it from the relevant skill references.
- [x] Ran changed skill markdown link check for the modified `skills/slidev` files.
- [x] Ran `pnpm lint`.
- [x] Ran `git diff --check`.
- [x] Verified backward compatibility with existing skill references: the change is additive and does not remove or rename existing reference files.
- **Benchmark:** N/A, docs-only skill guidance change.
