### PR TITLE
docs: add slidev-addon-second-screen to addons gallery

### DIFF
--- a/docs/.vitepress/addons.ts
+++ b/docs/.vitepress/addons.ts
@@ -292,6 +292,17 @@ export const community: AddonInfo[] = [
     },
     repo: 'https://github.com/mickaelalvs/slidev-addon-livecode',
   },
+  {
+    id: 'slidev-addon-second-screen',
+    name: 'Second Screen',
+    description: 'Open presentation on a second screen from presenter view with automatic fullscreen and visual status indicator.',
+    tags: ['Navigation', 'Presenter'],
+    author: {
+      name: 'Denis Sowa',
+      link: 'https://github.com/L-C-P',
+    },
+    repo: 'https://github.com/L-C-P/slidev-addon-second-screen',
+  },
   // Add yours here!
   {
     id: '',


### PR DESCRIPTION
## Summary

Adds [slidev-addon-second-screen](https://github.com/L-C-P/slidev-addon-second-screen) to the community addons gallery.

## About

A Slidev addon that adds a button to the presenter view for opening the presentation on a second screen, similar to PowerPoint's presenter view.

### Features

- Opens the slide presentation on the external display where the presenter is NOT running
- Automatic fullscreen mode with fallback dialog (Enter/Escape/X-button)
- Visual status indicator (filled/outline icon)
- Auto-detects manual close of the second screen window
- Graceful degradation in unsupported browsers (Safari, Firefox)

Published on npm: https://www.npmjs.com/package/slidev-addon-second-screen