### PR TITLE
fix(client): retry failed image preloads instead of giving up silently

### DIFF
--- a/packages/client/composables/usePreloadImages.ts
+++ b/packages/client/composables/usePreloadImages.ts
@@ -14,6 +14,9 @@ function resolveUrl(url: string): string {
   return `${base}${url.startsWith('/') ? url : `/${url}`}`
 }
 
+const RETRY_LIMIT = 2
+const retries = new Map<string, number>()
+
 function preloadImage(url: string): void {
   const resolved = resolveUrl(url)
   if (loaded.has(resolved) || loading.has(resolved))
@@ -23,9 +26,17 @@ function preloadImage(url: string): void {
   img.onload = () => {
     loading.delete(resolved)
     loaded.add(resolved)
+    retries.delete(resolved)
   }
   img.onerror = () => {
     loading.delete(resolved)
+    // Retry transient preload failures (e.g. flaky network) instead of silently
+    // giving up; bounded so genuinely-missing assets aren't hammered.
+    const attempts = retries.get(resolved) ?? 0
+    if (attempts < RETRY_LIMIT) {
+      retries.set(resolved, attempts + 1)
+      setTimeout(preloadImage, 1000 * (attempts + 1), url)
+    }
   }
   img.src = resolved
 }


### PR DESCRIPTION
## Summary

The image preloader's `onerror` handler removed the URL from the in-flight set and stopped. On a flaky connection a transiently-failed preload was abandoned with no recovery — the asset would then only load when its slide was actually shown (the exact stutter preloading is meant to prevent).

Retry failed preloads with a bounded backoff (2 attempts) so transient failures recover, while genuinely-missing assets aren't hammered.

## Change

`packages/client/composables/usePreloadImages.ts` — track per-URL retry counts; on `onerror`, reschedule the preload up to `RETRY_LIMIT` times.

## Verification

`pnpm build` + `pnpm test` + `pnpm typecheck` + `pnpm lint` all pass.
