### PR TITLE
feat(client): expose preloadProgress / preloadComplete from the image preloader

### DIFF
--- a/packages/client/composables/usePreloadImages.ts
+++ b/packages/client/composables/usePreloadImages.ts
@@ -1,6 +1,6 @@
 import type { SlideRoute } from '@slidev/types'
 import type { ComputedRef, Ref } from 'vue'
-import { watchEffect } from 'vue'
+import { computed, ref, watchEffect } from 'vue'
 import configs from '#slidev/configs'
 
 const loaded = new Set<string>()
@@ -17,6 +17,20 @@ function resolveUrl(url: string): string {
 const RETRY_LIMIT = 2
 const retries = new Map<string, number>()
 
+const preloadedCount = ref(0)
+const totalImagesCount = ref(0)
+
+/**
+ * Progress of slide-image preloading, from 0 to 1 (1 when every preloadable
+ * image in the deck has loaded, or when the deck has no images).
+ */
+export const preloadProgress = computed(() =>
+  totalImagesCount.value === 0 ? 1 : preloadedCount.value / totalImagesCount.value,
+)
+
+/** Whether all preloadable slide images have finished loading. */
+export const preloadComplete = computed(() => preloadProgress.value >= 1)
+
 function preloadImage(url: string): void {
   const resolved = resolveUrl(url)
   if (loaded.has(resolved) || loading.has(resolved))
@@ -27,6 +41,7 @@ function preloadImage(url: string): void {
     loading.delete(resolved)
     loaded.add(resolved)
     retries.delete(resolved)
+    preloadedCount.value = loaded.size
   }
   img.onerror = () => {
     loading.delete(resolved)
@@ -60,6 +75,19 @@ export function usePreloadImages(
     return
 
   const ahead = (typeof config === 'object' && config?.ahead) || 3
+
+  // Track total preloadable images across the deck for progress reporting
+  watchEffect(() => {
+    const all = slides.value
+    if (!all?.length)
+      return
+    const urls = new Set<string>()
+    for (const route of all) {
+      for (const url of route.meta?.slide?.images ?? [])
+        urls.add(resolveUrl(url))
+    }
+    totalImagesCount.value = urls.size
+  })
 
   // Preload current + prev + next + look-ahead window
   watchEffect(() => {


### PR DESCRIPTION
## Summary

Expose reactive `preloadProgress` (0–1) and `preloadComplete` from `usePreloadImages`, so a deck or theme can show a "preloading…" indicator — or gate something on full preload, which is handy before presenting on a flaky/absent connection.

- `preloadProgress` = unique slide images loaded / total unique slide images in the deck (1 when the deck has no images).
- `preloadComplete` = `preloadProgress >= 1`.

Consumable via `import { preloadProgress, preloadComplete } from '@slidev/client/composables/usePreloadImages'`. No change to the package's public index, so no API-surface churn.

## Verification

`pnpm build` + `pnpm test` + `pnpm typecheck` + `pnpm lint` all pass.
