### PR TITLE
docs: update GitHub Actions versions and fix Pages permissions

### DIFF
--- a/docs/guide/hosting.md
+++ b/docs/guide/hosting.md
@@ -79,7 +79,7 @@ We recommend using `npm init slidev@latest` to scaffold your project, which cont
 
 To deploy your slides on [GitHub Pages](https://pages.github.com/) via GitHub Actions, follow these steps:
 
-1. In your repository, go to `Settings` > `Pages`. Under `Build and deployment`, select `GitHub Actions`. (Do not choose `Deploy from a branch` and upload the `dist` directory, which is not recommended.)
+1. In your repository, go to `Settings` > `Pages`. Under `Build and deployment`, select `GitHub Actions`. (Do not choose `Deploy from a branch` and upload the `dist` directory, which is not recommended.) Alternatively, the `enablement: true` option in `configure-pages` can auto-enable Pages for you.
 2. Create `.github/workflows/deploy.yml` with the following content to deploy your slides to GitHub Pages via GitHub Actions.
 
 ::: details deploy.yml
@@ -94,6 +94,8 @@ on:
 
 permissions:
   contents: read
+  pages: write
+  id-token: write
 
 concurrency:
   group: pages
@@ -104,9 +106,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 'lts/*'
 
@@ -120,16 +122,15 @@ jobs:
         run: nr build --base /${{github.event.repository.name}}/
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
+        with:
+          enablement: true
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: dist
 
   deploy:
-    permissions:
-      pages: write
-      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -139,7 +140,7 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
 ```
 
 :::


### PR DESCRIPTION
## Summary

- Bump all GitHub Actions to latest versions: `checkout@v7`, `setup-node@v6`, `configure-pages@v6`, `upload-pages-artifact@v5`, `deploy-pages@v5`
- Move `pages: write` and `id-token: write` from the `deploy` job to global `permissions`, so `configure-pages` (which runs in the `build` job) can access the Pages API
- Add `enablement: true` to `configure-pages` to auto-enable GitHub Pages without manual configuration in repository settings
- Update step 1 in the guide to mention the `enablement: true` alternative

## Motivation

The previous workflow failed to publish because `configure-pages` needs `pages: write` permission (scoped to the `deploy` job only) and the action versions were outdated. This fix was validated in a real repository — slides are now successfully published to GitHub Pages.