### PR TITLE
fix: pre-bundle @fix-webm-duration/fix for dev recording import

### DIFF
--- a/packages/slidev/node/vite/extendConfig.ts
+++ b/packages/slidev/node/vite/extendConfig.ts
@@ -13,6 +13,7 @@ const RE_SLIDEV_VIRTUAL = /^#slidev\/(.*)/
 const RE_MONACO_EDITOR = /\/monaco-editor(?:-core)?\//
 
 const INCLUDE_GLOBAL = [
+  '@fix-webm-duration/fix',
   '@typescript/ata',
   'file-saver',
   'lz-string',


### PR DESCRIPTION
`@fix-webm-duration/fix` is a CommonJS dependency used by the client's recording logic, but unlike the sibling `recordrtc` dependency it wasn't added to Vite's `optimizeDeps.include`, so in dev it's served raw and the browser can't resolve its `fixWebmDuration` named export. Pre-bundling it alongside the other client CJS deps clears the runtime error without changing the import.

Fixes #2617
