### PR TITLE
feat: add `memory` router mode

### DIFF
--- a/docs/custom/index.md
+++ b/docs/custom/index.md
@@ -66,7 +66,7 @@ contextMenu: true
 wakeLock: true
 # take snapshot for each slide in the overview
 overviewSnapshots: false
-# router mode for vue-router, can be "history" or "hash"
+# router mode for vue-router, can be "history", "hash", or "memory"
 routerMode: history
 
 # force color schema for the slides, can be 'auto', 'light', or 'dark'

--- a/packages/client/setup/main.ts
+++ b/packages/client/setup/main.ts
@@ -2,7 +2,7 @@ import type { AppContext } from '@slidev/types'
 import type { App } from 'vue'
 import TwoSlashFloatingVue from '@shikijs/vitepress-twoslash/client'
 import { createHead } from '@unhead/vue/client'
-import { createRouter, createWebHashHistory, createWebHistory } from 'vue-router'
+import { createMemoryHistory, createRouter, createWebHashHistory, createWebHistory } from 'vue-router'
 import setups from '#slidev/setups/main'
 import { createVClickDirectives } from '../modules/v-click'
 import { createVDragDirective } from '../modules/v-drag'
@@ -21,9 +21,11 @@ export default async function setupMain(app: App) {
   window.addEventListener('resize', setMaxHeight)
 
   const router = createRouter({
-    history: __SLIDEV_HASH_ROUTE__
-      ? createWebHashHistory(import.meta.env.BASE_URL)
-      : createWebHistory(import.meta.env.BASE_URL),
+    history: __SLIDEV_MEMORY_ROUTE__
+      ? createMemoryHistory(import.meta.env.BASE_URL)
+      : __SLIDEV_HASH_ROUTE__
+        ? createWebHashHistory(import.meta.env.BASE_URL)
+        : createWebHistory(import.meta.env.BASE_URL),
     routes: setupRoutes(),
   })
 

--- a/packages/slidev/node/cli.ts
+++ b/packages/slidev/node/cli.ts
@@ -365,8 +365,8 @@ cli.command(
     })
     .option('router-mode', {
       type: 'string',
-      choices: ['hash', 'history'],
-      describe: 'override routerMode in the built output (hash for subdirectory deploys like GitHub Pages)',
+      choices: ['hash', 'history', 'memory'],
+      describe: 'override routerMode in the built output (hash for subdirectory deploys like GitHub Pages; memory keeps the slide number out of the URL, for kiosk/follower decks)',
     })
     .option('inspect', {
       default: false,
@@ -380,7 +380,7 @@ cli.command(
     const { build } = await import('./commands/build')
 
     for (const entryFile of entry as unknown as string[]) {
-      const options = await resolveOptions({ entry: entryFile, theme, inspect, download, base, withoutNotes, routerMode: routerMode as 'hash' | 'history' | undefined }, 'build')
+      const options = await resolveOptions({ entry: entryFile, theme, inspect, download, base, withoutNotes, routerMode: routerMode as 'hash' | 'history' | 'memory' | undefined }, 'build')
 
       printInfo(options)
       await build(

--- a/packages/slidev/node/commands/build.ts
+++ b/packages/slidev/node/commands/build.ts
@@ -100,7 +100,8 @@ export async function build(
         range: '1',
         width: options.data.config.canvasWidth,
         height: Math.round(options.data.config.canvasWidth / options.data.config.aspectRatio),
-        routerMode: options.data.config.routerMode,
+        // This renders slides by URL, so memory routing falls back to history.
+        routerMode: options.data.config.routerMode === 'memory' ? 'history' : options.data.config.routerMode,
         waitUntil: 'networkidle',
         timeout: args.timeout || 30000,
         perSlide: true,

--- a/packages/slidev/node/commands/export.ts
+++ b/packages/slidev/node/commands/export.ts
@@ -611,7 +611,8 @@ export function getExportOptions(args: ExportArgs, options: ResolvedSlidevOption
     wait: wait ?? 0,
     waitUntil: waitUntil === 'none' ? undefined : (waitUntil ?? 'networkidle') as 'networkidle' | 'load' | 'domcontentloaded',
     dark: dark || options.data.config.colorSchema === 'dark',
-    routerMode: options.data.config.routerMode,
+    // Export navigates by URL; memory routing ignores the URL, so fall back to history.
+    routerMode: options.data.config.routerMode === 'memory' ? 'history' : options.data.config.routerMode,
     width: options.data.config.canvasWidth,
     height: Math.round(options.data.config.canvasWidth / options.data.config.aspectRatio),
     withClicks: withClicks ?? format === 'pptx',

--- a/packages/slidev/node/options.ts
+++ b/packages/slidev/node/options.ts
@@ -127,6 +127,9 @@ function getDefine(options: Omit<ResolvedSlidevOptions, 'utils'>): Record<string
       __DEV__: options.mode === 'dev',
       __SLIDEV_CLIENT_ROOT__: toAtFS(options.clientRoot),
       __SLIDEV_HASH_ROUTE__: options.data.config.routerMode === 'hash',
+      // Export navigates by URL, so memory routing (which ignores the URL) is
+      // disabled during export and falls back to history.
+      __SLIDEV_MEMORY_ROUTE__: options.data.config.routerMode === 'memory' && options.mode !== 'export',
       __SLIDEV_FEATURE_DRAWINGS__: matchMode(options.data.config.drawings.enabled),
       __SLIDEV_FEATURE_EDITOR__: options.mode === 'dev' && options.data.config.editor !== false,
       __SLIDEV_FEATURE_DRAWINGS_PERSIST__: !!options.data.config.drawings.persist,

--- a/packages/types/src/frontmatter.ts
+++ b/packages/types/src/frontmatter.ts
@@ -100,9 +100,13 @@ export interface HeadmatterConfig extends TransitionOptions {
   /**
    * Router mode for vue-router
    *
+   * - `history`: the slide number is reflected in the URL path
+   * - `hash`: hash-based routing, for static hosts or subdirectory deploys
+   * - `memory`: routing is kept in memory, so the URL never reflects the slide number and cannot be used to navigate — useful for kiosk or externally driven "follower" decks (deep-links, `/presenter`, `/overview` and export-by-URL are unavailable)
+   *
    * @default 'history'
    */
-  routerMode?: 'hash' | 'history'
+  routerMode?: 'hash' | 'history' | 'memory'
   /**
    * Aspect ratio for slides
    * should be like `16/9` or `1:1`

--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -50,7 +50,7 @@ export interface SlidevEntryOptions {
   /**
    * Override routerMode at build time
    */
-  routerMode?: 'hash' | 'history'
+  routerMode?: 'hash' | 'history' | 'memory'
 }
 
 export interface ResolvedSlidevOptions extends RootsInfo, SlidevEntryOptions {

--- a/packages/vscode/schema/headmatter.json
+++ b/packages/vscode/schema/headmatter.json
@@ -258,10 +258,11 @@
           "type": "string",
           "enum": [
             "hash",
-            "history"
+            "history",
+            "memory"
           ],
-          "description": "Router mode for vue-router",
-          "markdownDescription": "Router mode for vue-router",
+          "description": "Router mode for vue-router\n\n- `history`: the slide number is reflected in the URL path\n- `hash`: hash-based routing, for static hosts or subdirectory deploys\n- `memory`: routing is kept in memory, so the URL never reflects the slide number and cannot be used to navigate — useful for kiosk or externally driven \"follower\" decks (deep-links, `/presenter`, `/overview` and export-by-URL are unavailable)",
+          "markdownDescription": "Router mode for vue-router\n\n- `history`: the slide number is reflected in the URL path\n- `hash`: hash-based routing, for static hosts or subdirectory deploys\n- `memory`: routing is kept in memory, so the URL never reflects the slide number and cannot be used to navigate — useful for kiosk or externally driven \"follower\" decks (deep-links, `/presenter`, `/overview` and export-by-URL are unavailable)",
           "default": "history"
         },
         "aspectRatio": {

--- a/shim.d.ts
+++ b/shim.d.ts
@@ -2,6 +2,7 @@ export {}
 declare global {
   const __DEV__: boolean
   const __SLIDEV_HASH_ROUTE__: boolean
+  const __SLIDEV_MEMORY_ROUTE__: boolean
   const __SLIDEV_CLIENT_ROOT__: string
   const __SLIDEV_FEATURE_DRAWINGS__: boolean
   const __SLIDEV_FEATURE_DRAWINGS_PERSIST__: boolean
@@ -18,6 +19,7 @@ declare module '@vue/runtime-core' {
   interface ComponentCustomProperties {
     __DEV__: boolean
     __SLIDEV_HASH_ROUTE__: boolean
+    __SLIDEV_MEMORY_ROUTE__: boolean
     __SLIDEV_CLIENT_ROOT__: string
     __SLIDEV_FEATURE_DRAWINGS__: boolean
     __SLIDEV_FEATURE_DRAWINGS_PERSIST__: boolean


### PR DESCRIPTION
## Summary

Adds a third `routerMode` value — `memory` — backed by vue-router's `createMemoryHistory`. Routing is kept entirely in memory, so:

- the URL never reflects the slide number (no `/1`, `/2`, … as the deck advances), and
- a hard-typed path like `/12` is ignored (the deck boots at slide 1).

Existing `history` (default) and `hash` behaviour is unchanged.

## Why

For **kiosk / public "follower" decks** — a deck shown on a shared screen or handed out as a public URL that's driven externally (e.g. via a sync addon). Keeping the slide number out of the URL stops viewers from reading their position or jumping ahead by editing the URL. This is URL hygiene, not navigation locking — arrow/click navigation still works; disabling that belongs to the follower layer, not core.

As a bonus it sidesteps the history-mode refresh-404 problem on plain static hosts (there's no path left to 404 on).

## Behaviour / limitations

Because memory mode has no URL routing, deep-links, `/presenter`, `/overview`, and export-by-URL aren't reachable in this mode. Export and the PNG/PDF build path therefore fall back to `history` routing (they navigate by URL). These are documented in the `routerMode` JSDoc.

## Changes

- `routerMode` type accepts `'memory'` (frontmatter config + build-time override)
- client selects `createMemoryHistory` via a new `__SLIDEV_MEMORY_ROUTE__` build flag (gated off during export)
- `--router-mode` CLI flag accepts `memory`
- export + PNG build coerce `memory` → `history`
- regenerated headmatter schema + updated docs

## Verified

`pnpm build`, `pnpm typecheck`, `pnpm lint`, and `pnpm test` pass. Manually verified in both dev and build: advancing the deck leaves the URL untouched, and a typed `/N` boots at slide 1.
