### PR TITLE
fix: apply addon preparsers on initial load

### DIFF
--- a/packages/slidev/node/options.test.ts
+++ b/packages/slidev/node/options.test.ts
@@ -1,0 +1,155 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { resolveOptions } from './options'
+
+const mocks = vi.hoisted(() => ({
+  getRoots: vi.fn(),
+  getThemeMeta: vi.fn(),
+  load: vi.fn(),
+  resolveAddons: vi.fn(),
+  resolveConfig: vi.fn(),
+  resolveEntry: vi.fn(),
+  resolveTheme: vi.fn(),
+}))
+
+vi.mock('./integrations/addons', () => ({
+  resolveAddons: mocks.resolveAddons,
+}))
+
+vi.mock('./integrations/themes', () => ({
+  getThemeMeta: mocks.getThemeMeta,
+  resolveTheme: mocks.resolveTheme,
+}))
+
+vi.mock('./parser', () => ({
+  parser: {
+    load: mocks.load,
+    resolveConfig: mocks.resolveConfig,
+  },
+}))
+
+vi.mock('./resolver', () => ({
+  getRoots: mocks.getRoots,
+  resolveEntry: mocks.resolveEntry,
+  toAtFS: (value: string) => value,
+}))
+
+vi.mock('./setups/indexHtml', () => ({ default: vi.fn().mockResolvedValue('') }))
+vi.mock('./setups/katex', () => ({ default: vi.fn().mockResolvedValue({}) }))
+vi.mock('./setups/shiki', () => ({ default: vi.fn().mockResolvedValue({}) }))
+
+describe('resolveOptions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.resolveEntry.mockResolvedValue('/project/slides.md')
+    mocks.getRoots.mockResolvedValue({
+      clientRoot: '/client',
+      userPkgJson: {},
+      userRoot: '/project',
+      userWorkspaceRoot: '/workspace',
+    })
+    mocks.resolveTheme.mockResolvedValue(['slidev-theme-test', '/theme'])
+    mocks.getThemeMeta.mockResolvedValue({})
+    mocks.resolveAddons.mockResolvedValue(['/addon'])
+    mocks.resolveConfig.mockReturnValue({
+      addons: ['slidev-addon-test'],
+      browserExporter: false,
+      drawings: { enabled: false, persist: false },
+      monacoTypesIgnorePackages: [],
+      presenter: false,
+      pwa: false,
+      record: false,
+      routerMode: 'history',
+    })
+  })
+
+  it('reloads with bootstrap roots while resolving final non-discovery config', async () => {
+    const initialData = {
+      headmatter: {
+        addons: ['slidev-addon-bootstrap'],
+        routerMode: 'hash',
+        theme: 'bootstrap',
+        title: 'before',
+      },
+      slides: [{ content: 'before addon preparser' }],
+    }
+    const reloadedData = {
+      headmatter: {
+        addons: ['slidev-addon-final'],
+        routerMode: 'memory',
+        theme: 'final',
+        title: 'after',
+      },
+      slides: [{ content: 'after addon preparser' }],
+    }
+    const initialConfig = {
+      addons: ['slidev-addon-bootstrap'],
+      routerMode: 'hash',
+      theme: 'bootstrap',
+    }
+    const finalConfig = {
+      addons: ['slidev-addon-final'],
+      browserExporter: false,
+      download: false,
+      drawings: { enabled: false, persist: false },
+      monacoTypesIgnorePackages: [],
+      presenter: false,
+      pwa: false,
+      record: false,
+      routerMode: 'memory',
+      theme: 'final',
+      title: 'after',
+    }
+    mocks.load
+      .mockResolvedValueOnce(initialData)
+      .mockResolvedValueOnce(reloadedData)
+    mocks.resolveConfig
+      .mockReturnValueOnce(initialConfig)
+      .mockReturnValueOnce(finalConfig)
+
+    const options = await resolveOptions({
+      download: true,
+      entry: '/project/slides.md',
+    }, 'dev')
+
+    expect(mocks.load).toHaveBeenNthCalledWith(1, {
+      allowedRoots: ['/workspace', '/project'],
+      roots: ['/project'],
+      userRoot: '/project',
+    }, '/project/slides.md', undefined, 'dev')
+    expect(mocks.resolveTheme).toHaveBeenCalledWith('bootstrap', '/project/slides.md')
+    expect(mocks.resolveConfig).toHaveBeenNthCalledWith(
+      1,
+      initialData.headmatter,
+      {},
+      '/project/slides.md',
+    )
+    expect(mocks.resolveAddons).toHaveBeenCalledWith(initialConfig.addons)
+    expect(mocks.load).toHaveBeenNthCalledWith(2, {
+      allowedRoots: ['/workspace', '/theme', '/addon', '/project'],
+      roots: ['/theme', '/addon', '/project'],
+      userRoot: '/project',
+    }, '/project/slides.md', undefined, 'dev')
+    expect(mocks.resolveConfig).toHaveBeenNthCalledWith(
+      2,
+      reloadedData.headmatter,
+      {},
+      '/project/slides.md',
+    )
+    expect(mocks.load).toHaveBeenCalledTimes(2)
+    expect(mocks.resolveTheme).toHaveBeenCalledTimes(1)
+    expect(mocks.resolveAddons).toHaveBeenCalledTimes(1)
+    expect(mocks.resolveConfig).toHaveBeenCalledTimes(2)
+    expect(options.roots).toEqual(['/theme', '/addon', '/project'])
+    expect(options.data.config).toBe(finalConfig)
+    expect(options.data.config).toMatchObject({
+      addons: ['slidev-addon-bootstrap'],
+      download: true,
+      routerMode: 'memory',
+      theme: 'bootstrap',
+      title: 'after',
+    })
+    expect(options.data.config.theme).toBe(options.themeRaw)
+    expect(options.data.headmatter).toEqual(reloadedData.headmatter)
+    expect(options.data.slides).toEqual(reloadedData.slides)
+  })
+})

--- a/packages/slidev/node/options.ts
+++ b/packages/slidev/node/options.ts
@@ -22,7 +22,7 @@ export async function resolveOptions(
 ): Promise<ResolvedSlidevOptions> {
   const entry = await resolveEntry(entryOptions.entry)
   const rootsInfo = await getRoots(entry)
-  const loaded = await parser.load(
+  const initialLoaded = await parser.load(
     {
       userRoot: rootsInfo.userRoot,
       roots: [rootsInfo.userRoot],
@@ -34,15 +34,32 @@ export async function resolveOptions(
   )
 
   // Load theme data first, because it may affect the config
-  let themeRaw = entryOptions.theme || loaded.headmatter.theme as string | null | undefined
+  let themeRaw = entryOptions.theme || initialLoaded.headmatter.theme as string | null | undefined
   themeRaw = themeRaw === null ? 'none' : (themeRaw || 'default')
   const [theme, themeRoot] = await resolveTheme(themeRaw, entry)
   const themeRoots = themeRoot ? [themeRoot] : []
   const themeMeta = themeRoot ? await getThemeMeta(theme, themeRoot) : undefined
 
-  const config = parser.resolveConfig(loaded.headmatter, themeMeta, entryOptions.entry)
-  const addonRoots = await resolveAddons(config.addons)
+  const initialConfig = parser.resolveConfig(initialLoaded.headmatter, themeMeta, entryOptions.entry)
+  const addonRoots = await resolveAddons(initialConfig.addons)
   const roots = uniq([...themeRoots, ...addonRoots, rootsInfo.userRoot])
+  const loaded = await parser.load(
+    {
+      userRoot: rootsInfo.userRoot,
+      roots,
+      allowedRoots: uniq([rootsInfo.userWorkspaceRoot, ...roots]),
+    },
+    entry,
+    undefined,
+    mode,
+  )
+  const config = parser.resolveConfig(loaded.headmatter, themeMeta, entryOptions.entry)
+
+  // These fields selected the roots used for the final load. Keep the
+  // returned config aligned with the graph that was actually loaded if a
+  // preparser changes them.
+  config.theme = themeRaw
+  config.addons = initialConfig.addons
 
   if (entryOptions.download)
     config.download ||= entryOptions.download


### PR DESCRIPTION
## Summary

Addon `setup/preparser.ts` hooks were unavailable during Slidev's cold-start/static-build parse because `resolveOptions()` returned data loaded with only the project root.

This change:

- keeps the first parse as a bootstrap step for discovering the selected theme and addons
- reloads the deck with the complete theme/addon/project root set
- resolves the returned config from the final preparsed headmatter
- pins `theme` and `addons` to the graph that was actually loaded, while preserving final non-discovery fields and applying CLI overrides last

The regression makes bootstrap and final headmatter intentionally diverge, verifies the full-root second load, and catches stale-config or unloaded-root contradictions.

Closes #2646

## Validation

- Focused regression: 1/1 passed
- Slidev Node tests: 61/61 passed
- Full test suite: 218/218 passed
- `@slidev/cli` build passed
- ESLint on the two changed files and `git diff --check` passed
- Real addon cold-start spot-check passed

GitHub Actions completed with 16 successful and 2 neutral checks. The only failures were `typecheck` and `cypress`; the same two jobs also fail on upstream `main` at base SHA `905b44ba` ([base run](https://github.com/slidevjs/slidev/actions/runs/29066810589)), while the PR's Windows/macOS/Linux tests and all smoke matrices passed.

Locally, `pnpm verify` likewise reaches unchanged Cypress/VitePress/duplicate dependency type errors and CRLF lint errors in unchanged Markdown files. The production build, complete test suite, and changed-file lint all pass.

## AI assistance

Codex (GPT-5, autonomous) analyzed the issue, implemented and iteratively reviewed the change, and ran the validations above on behalf of @NgoQuocViet2001. The operator requested the contribution but did not manually author or line-by-line review the patch.