### PR TITLE
fix: use import.meta.env.DEV instead of __DEV__ for mode detection

### DIFF
--- a/packages/client/env.ts
+++ b/packages/client/env.ts
@@ -4,7 +4,7 @@ import configs from '#slidev/configs'
 
 export { configs }
 
-export const mode = __DEV__ ? 'dev' : 'build'
+export const mode = import.meta.env.DEV ? 'dev' : 'build'
 
 export const slideAspect = computed(() => configs.aspectRatio)
 export const slideWidth = computed(() => configs.canvasWidth)


### PR DESCRIPTION
## Summary

Fixes #2665 — dev server renders blank page when `NODE_ENV=production` is set.

## Root Cause

`packages/client/env.ts` uses `__DEV__` to detect dev mode, but `__DEV__` is not auto-defined by Vite 8 when `NODE_ENV=production` is present in the environment.

## Fix

Replace the non-standard `__DEV__` with Vite's built-in `import.meta.env.DEV`:

```diff
- export const mode = __DEV__ ? 'dev' : 'build'
+ export const mode = import.meta.env.DEV ? 'dev' : 'build'
```

`import.meta.env.DEV` correctly reflects Vite's mode (dev server vs build) regardless of `NODE_ENV`.