### PR TITLE
fix: discover components from paths containing pipes

### DIFF
--- a/packages/slidev/node/vite/components.test.ts
+++ b/packages/slidev/node/vite/components.test.ts
@@ -1,0 +1,29 @@
+import pm from 'picomatch'
+import { expect, it } from 'vitest'
+import { createPipePathComponentGlobs } from './components'
+
+it('keeps the default component discovery for ordinary paths', () => {
+  expect(createPipePathComponentGlobs(
+    ['/work/presentation/components'],
+    ['vue', 'ts'],
+  )).toBeUndefined()
+})
+
+it('leaves empty extension validation to the component plugin', () => {
+  expect(createPipePathComponentGlobs(
+    ['/work/|presentation/components'],
+    [],
+  )).toBeUndefined()
+})
+
+it('escapes pipe characters when building component globs', () => {
+  const globs = createPipePathComponentGlobs(
+    ['/work/|presentation/components'],
+    ['vue', 'md', 'ts'],
+  )
+
+  expect(globs).toEqual([
+    '/work/\\|presentation/components/**/*.{vue,md,ts}',
+  ])
+  expect(pm(globs![0])('/work/|presentation/components/Counter.vue')).toBe(true)
+})

--- a/packages/slidev/node/vite/components.ts
+++ b/packages/slidev/node/vite/components.ts
@@ -1,5 +1,6 @@
 import type { ResolvedSlidevOptions, SlidevPluginOptions } from '@slidev/types'
 import { join } from 'node:path'
+import { slash } from '@antfu/utils'
 import IconsResolver from 'unplugin-icons/resolver'
 import Components from 'unplugin-vue-components/vite'
 
@@ -8,12 +9,27 @@ const RE_VUE_QUERY_VUE = /\.vue\?vue/
 const RE_VUE_QUERY_V = /\.vue\?v=/
 const RE_MD_EXT = /\.md$/
 const RE_MD_QUERY_VUE = /\.md\?vue/
+const RE_GLOB_SPECIAL_PATH_CHARS = /[()|]/g
+
+export function createPipePathComponentGlobs(dirs: string[], extensions: string[]) {
+  if (!extensions.length || !dirs.some(dir => dir.includes('|')))
+    return
+
+  const extensionGlob = extensions.length === 1
+    ? extensions[0]
+    : `{${extensions.join(',')}}`
+
+  return dirs.map((dir) => {
+    const escapedDir = slash(dir).replace(RE_GLOB_SPECIAL_PATH_CHARS, '\\$&')
+    return `${escapedDir}/**/*.${extensionGlob}`
+  })
+}
 
 export function createComponentsPlugin(
   { clientRoot, roots }: ResolvedSlidevOptions,
   pluginOptions: SlidevPluginOptions,
 ) {
-  return Components({
+  const options = {
     extensions: ['vue', 'md', 'js', 'ts', 'jsx', 'tsx'],
 
     dirs: [
@@ -35,5 +51,13 @@ export function createComponentsPlugin(
     dts: false,
 
     ...pluginOptions.components,
-  })
+  }
+
+  if (options.globs == null) {
+    const dirs = Array.isArray(options.dirs) ? options.dirs : [options.dirs]
+    const extensions = Array.isArray(options.extensions) ? options.extensions : [options.extensions]
+    options.globs = createPipePathComponentGlobs(dirs, extensions)
+  }
+
+  return Components(options)
 }


### PR DESCRIPTION
## Summary

- preserve the existing component-discovery path for ordinary project directories
- generate escaped component globs when a resolved directory contains `|`
- cover the regression with a picomatch assertion against a real pipe-containing path

## Problem

`unplugin-vue-components` escapes parentheses in generated directory globs, but not pipe characters. In a Linux project such as `/work/|presentation`, the scanner therefore finds no built-in or local components and Slidev reports components such as `v-click`, `Mermaid`, and `Monaco` as unresolved.

The fallback is only enabled for pipe-containing directories. Explicit user `globs` remain authoritative, and ordinary paths continue through the plugin's existing `dirs` behavior.

## Validation

- `pnpm exec vitest run packages/slidev/node/vite/components.test.ts` — 3 passed
- `pnpm test -- --run` — 26 files, 221 tests passed
- `pnpm exec eslint packages/slidev/node/vite/components.ts packages/slidev/node/vite/components.test.ts`
- `pnpm -C packages/slidev build`
- Linux runtime at `/work/|presentation`: Vue component-resolution warnings dropped from 21 to 0 after applying the generated escaped globs

`pnpm typecheck` still reports the same five existing errors on `upstream/main` (the Cypress `after:run` overload, three VitePress declarations, and the markdown-exit duplicate type); none point to the changed files.

Fixes #2470