### PR TITLE
fix: await Cypress after-run cleanup

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -8,7 +8,9 @@ export default defineConfig({
     specPattern: 'cypress/e2e/**/*.spec.*',
     supportFile: false,
     setupNodeEvents(on) {
-      on('after:run', () => stopBasePathServer())
+      on('after:run', async () => {
+        await stopBasePathServer()
+      })
       on('task', {
         startBasePathServer,
         stopBasePathServer,


### PR DESCRIPTION
## Summary

- await the base-path server cleanup inside the Cypress `after:run` lifecycle callback
- keep the shared task handler's `null` result unchanged

## Problem

`stopBasePathServer()` intentionally resolves to `null` because Cypress task handlers must return a defined value. Passing that promise through directly makes the `after:run` callback return `Promise<null>`, but Cypress types accept only `void | Promise<void>`. The root typecheck therefore reports `TS2769` at `cypress.config.ts`.

Awaiting the helper inside an async callback preserves the task contract while making the lifecycle callback resolve to `void`.

## Validation

- `pnpm exec tsc --ignoreConfig --noEmit --skipLibCheck --moduleResolution bundler --module esnext --target esnext --types node,cypress --esModuleInterop cypress.config.ts cypress/basePathServer.ts`
- `pnpm exec eslint cypress.config.ts`
- `git diff --check`
- `pnpm typecheck` no longer reports the Cypress overload error; the remaining four errors are the existing VitePress declaration and duplicate `markdown-exit` dependency errors on `main`