### PR TITLE
docs: add Sandpack addon to gallery

### DIFF
--- a/docs/.vitepress/addons.ts
+++ b/docs/.vitepress/addons.ts
@@ -303,6 +303,17 @@ export const community: AddonInfo[] = [
     },
     repo: 'https://github.com/L-C-P/slidev-addon-second-screen',
   },
+  {
+    id: 'slidev-addon-sandpack',
+    name: 'Sandpack',
+    description: 'Build stepped, multi-file Sandpack live-code demos from readable Markdown.',
+    tags: ['Code runner', 'React', 'Integration'],
+    author: {
+      name: 'Nir Tamir',
+      link: 'https://github.com/nirtamir2',
+    },
+    repo: 'https://github.com/nirtamir2/slidev-addon-sandpack',
+  },
   // Add yours here!
   {
     id: '',


### PR DESCRIPTION
## Summary

- add `slidev-addon-sandpack` to Slidev's curated Community Addons gallery
- expose its npm package and GitHub repository through the existing gallery card

## Why

The addon provides stepped, multi-file CodeSandbox Sandpack live-code demos from readable Slidev Markdown.

## Validation

- verified the package is published on npm as `slidev-addon-sandpack`
- verified the required `slidev` and `slidev-addon` keywords
- checked `docs/.vitepress/addons.ts` formatting, syntax, and whitespace
