### PR TITLE
feat(vscode): sort projects tree by entry path

### DIFF
--- a/packages/vscode/src/views/projectsTree.ts
+++ b/packages/vscode/src/views/projectsTree.ts
@@ -46,12 +46,15 @@ function getFileTreeItem(file: string): TreeItem {
 
 export const useProjectsTree = defineService(() => {
   const treeData = computed(() => {
-    return [...projects.values()].map(project => ({
-      treeItem: getProjectTreeItem(project),
-      children: Object.keys(project.data.markdownFiles)
-        .filter(file => file.toLowerCase() !== project.entry.toLowerCase())
-        .map(file => ({ treeItem: getFileTreeItem(file) })),
-    }))
+    return [...projects.values()]
+      .sort((a, b) => a.entry.localeCompare(b.entry, undefined, { numeric: true }))
+      .map(project => ({
+        treeItem: getProjectTreeItem(project),
+        children: Object.keys(project.data.markdownFiles)
+          .filter(file => file.toLowerCase() !== project.entry.toLowerCase())
+          .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))
+          .map(file => ({ treeItem: getFileTreeItem(file) })),
+      }))
   })
 
   const treeItems = shallowRef<TreeViewNode[]>([])


### PR DESCRIPTION
Previously, the Projects tree view in the VS Code extension listed projects in `workspace.findFiles` traversal order, which is platform-dependent and effectively arbitrary. Entries added at runtime (via the file watcher) were always appended to the end of the list.

This PR sorts both the top-level projects and each project's child markdown files by path, using `localeCompare` with `{ numeric: true }`:

- The order is now deterministic and matches the VS Code Explorer's default numeric-aware sorting (e.g. `session-2` before `session-10`).
- Sorting is applied inside the `treeData` computed, so it covers both the initial scan and entries added/removed at runtime via the file watcher.

**Before** (scan order, new entries appended at the end):

```
topics/js.md
topics/html.md
topics/css.md
terms/session-10.md
terms/session-2.md
terms/session-4.md   ← added at runtime, dropped to the end
```

**After:**

```
terms/session-2.md
terms/session-4.md
terms/session-10.md
topics/css.md
topics/html.md
topics/js.md
```

Verified in the Extension Development Host: initial scan order, runtime file creation (inserted in place), deletion, and a new entry sorting to the top of the list. `pnpm verify` passes.
