### PR TITLE
fix(vscode): prevent preview sync feedback loop

### DIFF
--- a/packages/vscode/src/views/previewWebview.ts
+++ b/packages/vscode/src/views/previewWebview.ts
@@ -191,13 +191,17 @@ export const usePreviewWebview = defineService(() => {
     },
   )
   watch(
-    [() => config['preview-sync'], focusedSlideNo, viewportSlideNo, previewMode],
-    ([enabled, focusedNo, viewportNo, mode]) => {
-      if (enabled && mode === 'slide' && focusedNo != null && previewNavState.no !== focusedNo) {
-        postSlidevMessage('navigate', { no: focusedNo, clicks: 999999 })
+    [
+      () => config['preview-sync'],
+      previewMode,
+      () => previewMode.value === 'slide' ? focusedSlideNo.value : viewportSlideNo.value,
+    ],
+    ([enabled, mode, no]) => {
+      if (enabled && mode === 'slide' && no != null && previewNavState.no !== no) {
+        postSlidevMessage('navigate', { no, clicks: 999999 })
       }
-      else if (enabled && mode === 'overview' && viewportNo != null) {
-        scrollOverviewToSlide(viewportNo)
+      else if (enabled && mode === 'overview' && no != null) {
+        scrollOverviewToSlide(no)
       }
     },
   )


### PR DESCRIPTION
Warning: this is mostly AI-generated (Codex 5.6 Sol Medium). Take or leave as you wish.

I was getting terrible oscillation jitter whenever I progressed through animations with cursor sync on. I confirmed the bad behavior in a fresh slidev project. With the fix, it has been working perfectly.

-- end human generated content --

## Summary

- watch the focused slide only while the preview is in slide mode
- watch the editor viewport only while the preview is in overview mode
- prevent preview navigation from being reversed by a stale editor viewport update

## Problem

With preview sync enabled, `Slidev: Navigate to next click in preview window` can oscillate between adjacent slides when the click crosses a slide boundary. The preview moves to slide N+1 and starts focusing that slide in the editor, but the editor's visible range can update before the debounced focused slide does. Because the same watcher observes both values, it sends the stale slide N back to the preview, creating a feedback loop that also moves the cursor repeatedly.

The overview viewport is irrelevant in slide mode, and the focused cursor slide is irrelevant in overview mode. Selecting the watched value based on the active preview mode removes the cross-trigger while preserving both sync directions.

## Reproduction

1. Run Slidev 52.18.0 with the VS Code extension 52.18.0 and preview sync enabled.
2. Put the preview on the final click of a slide.
3. Run `Slidev: Navigate to next click in preview window`.
4. The preview and editor cursor repeatedly jump between the current and next slides.

This also reproduces in a fresh project created with `pnpm create slidev`.

## Validation

- `pnpm -C packages/vscode build`
- `pnpm typecheck`
- `pnpm exec eslint packages/vscode/src/views/previewWebview.ts`
- manually installed the rebuilt extension in Cursor and confirmed the reproduction no longer oscillates
