### PR TITLE
fix(client): use slide-local nav during export

### DIFF
--- a/packages/client/composables/useNav.test.ts
+++ b/packages/client/composables/useNav.test.ts
@@ -1,17 +1,36 @@
 import type { ClicksContext, SlideRoute } from '@slidev/types'
+import type { SlidevContextNav } from './useNav'
+import { renderToString } from '@vue/server-renderer'
+import { provideLocal } from '@vueuse/core'
 import { describe, expect, it, vi } from 'vitest'
-import { computed, ref } from 'vue'
-import { useNavBase } from './useNav'
+import { computed, createSSRApp, defineComponent, h, reactive, ref } from 'vue'
+import { injectionSlidevContext } from '../constants'
+import { useNav, useNavBase } from './useNav'
 
 vi.mock('#slidev/slides', async () => {
   const { ref } = await import('vue')
-  return { slides: ref([]) }
+  return {
+    slides: ref([
+      {
+        no: 1,
+        meta: {
+          slide: { frontmatter: { title: 'First' } },
+        },
+      },
+      {
+        no: 2,
+        meta: {
+          slide: { frontmatter: { title: 'Second' } },
+        },
+      },
+    ]),
+  }
 })
 
 vi.mock('../env', async () => {
   const { ref } = await import('vue')
   return {
-    configs: {},
+    configs: { remote: false },
     slideAspect: ref(16 / 9),
   }
 })
@@ -19,6 +38,24 @@ vi.mock('../env', async () => {
 vi.mock('../state', async () => {
   const { ref } = await import('vue')
   return { hmrSkipTransition: ref(false) }
+})
+
+vi.mock('vue-router', async () => {
+  const { reactive, ref } = await import('vue')
+  const route = reactive({
+    name: 'export',
+    params: { no: '1' },
+    query: {},
+  })
+  const router = {
+    currentRoute: ref(route),
+    push: vi.fn(),
+    replace: vi.fn(),
+  }
+  return {
+    useRoute: () => route,
+    useRouter: () => router,
+  }
 })
 
 function route(no: number, frontmatter: Record<string, any>): SlideRoute {
@@ -52,5 +89,42 @@ describe('useNavBase', () => {
       title: 'Details',
       section: 'body',
     })
+  })
+
+  it('uses the slide-local navigation context while rendering exported slides', async () => {
+    vi.stubGlobal('location', { search: '' })
+    let observedNav: SlidevContextNav | undefined
+    const localNav = {
+      currentSlideNo: computed(() => 2),
+      currentPage: computed(() => 2),
+      currentSlideRoute: computed(() => route(2, { title: 'Second' })),
+      tocTree: computed(() => [
+        { no: 1, active: false },
+        { no: 2, active: true },
+      ]),
+    } as unknown as SlidevContextNav
+
+    const Child = defineComponent({
+      setup() {
+        observedNav = useNav()
+        return () => h('span')
+      },
+    })
+    const App = defineComponent({
+      setup() {
+        provideLocal(injectionSlidevContext, reactive({
+          nav: localNav,
+          configs: {},
+          themeConfigs: {},
+        }) as any)
+        return () => h(Child)
+      },
+    })
+
+    await renderToString(createSSRApp(App))
+
+    expect(observedNav?.currentSlideNo.value).toBe(2)
+    expect(observedNav?.currentSlideRoute.value.meta.slide.frontmatter.title).toBe('Second')
+    expect(observedNav?.tocTree.value[1].active).toBe(true)
   })
 })

--- a/packages/client/composables/useNav.ts
+++ b/packages/client/composables/useNav.ts
@@ -3,11 +3,11 @@ import type { ComputedRef, Ref, TransitionGroupProps, WritableComputedRef } from
 import type { RouteLocationNormalized, Router } from 'vue-router'
 import { clamp } from '@antfu/utils'
 import { parseRangeString } from '@slidev/parser/utils'
-import { createSharedComposable } from '@vueuse/core'
-import { computed, ref, watch } from 'vue'
+import { createSharedComposable, injectLocal } from '@vueuse/core'
+import { computed, ref, toRaw, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { slides } from '#slidev/slides'
-import { CLICKS_MAX } from '../constants'
+import { CLICKS_MAX, injectionSlidevContext } from '../constants'
 import { configs } from '../env'
 import { useRouteQuery } from '../logic/route'
 import { getSlide, getSlidePath } from '../logic/slides'
@@ -365,7 +365,7 @@ const useNavState = createSharedComposable((): SlidevContextNavState => {
   }
 })
 
-export const useNav = createSharedComposable((): SlidevContextNavFull => {
+const useSharedNav = createSharedComposable((): SlidevContextNavFull => {
   const state = useNavState()
   const router = useRouter()
 
@@ -401,3 +401,16 @@ export const useNav = createSharedComposable((): SlidevContextNavFull => {
     ...state,
   }
 })
+
+export function useNav(): SlidevContextNavFull {
+  const nav = useSharedNav()
+  const context = injectLocal(injectionSlidevContext, undefined)
+  if (!context)
+    return nav
+
+  const localNav = toRaw(context).nav as unknown as SlidevContextNav
+  return {
+    ...nav,
+    ...localNav,
+  }
+}


### PR DESCRIPTION
### Description

During PDF/browser export, every slide is rendered at once under `/export`. `PrintSlideClick` already provides a fixed navigation context for each rendered slide, but the public `useNav()` composable always returned the application-wide shared nav instead. Components such as `slide-top.vue` therefore saw the route-level slide number (typically `1`) on every exported page, and `tocTree.active` stayed fixed as well.

This change keeps the existing shared nav as the global source of router/print state, then overlays the nearest slide-local nav when a rendered slide provides one. Normal play/presenter views continue to receive the same shared nav object; export children receive their fixed `currentSlideNo`, `currentSlideRoute`, clicks, and TOC state while retaining the full nav API.

### Tests

Added an SSR regression test that renders a child component under a slide-local export context while the global export route points at slide 1. It verifies that `useNav()` returns slide 2, its frontmatter, and the slide-2 active TOC entry.

- `pnpm exec vitest run packages/client` — 5 passed
- `pnpm typecheck`
- targeted ESLint for the changed files
- `pnpm build`

Closes #2670