### PR TITLE
fix(monaco): respect lineNumbers config and lines option

### DIFF
--- a/docs/features/monaco-editor.md
+++ b/docs/features/monaco-editor.md
@@ -47,3 +47,13 @@ console.log('Hello, World!')
 ````
 
 You can also set a specific height using CSS units like `{height:'300px'}` or `{height:'100%'}`.
+
+## Line Numbers
+
+Like other code blocks, the Monaco editor respects the global `lineNumbers` headmatter. You can also toggle line numbers for a single editor with `{lines:true}` while keeping it editable.
+
+````md
+```ts {monaco} {lines:true}
+console.log('HelloWorld')
+```
+````

--- a/packages/client/builtin/Monaco.vue
+++ b/packages/client/builtin/Monaco.vue
@@ -20,6 +20,7 @@ import lz from 'lz-string'
 import { computed, defineAsyncComponent, nextTick, onMounted, ref } from 'vue'
 import { useNav } from '../composables/useNav'
 import { useSlideContext } from '../context'
+import { configs } from '../env'
 import { makeId } from '../logic/utils'
 
 const props = withDefaults(
@@ -28,6 +29,7 @@ const props = withDefaults(
     diffLz?: string
     lang?: string
     readonly?: boolean
+    lines?: boolean
     lineNumbers?: 'on' | 'off' | 'relative' | 'interval'
     height?: number | string // Posible values: 'initial', 'auto', '100%', '200px', etc.
     editorOptions?: monaco.editor.IEditorOptions
@@ -44,7 +46,7 @@ const props = withDefaults(
     codeLz: '',
     lang: 'typescript',
     readonly: false,
-    lineNumbers: 'off',
+    lines: configs.lineNumbers,
     height: 'initial',
     ata: true,
     runnable: false,
@@ -58,6 +60,7 @@ const CodeRunner = defineAsyncComponent(() => import('../internals/CodeRunner.vu
 const code = ref(lz.decompressFromBase64(props.codeLz).trimEnd())
 const diff = props.diffLz && ref(lz.decompressFromBase64(props.diffLz).trimEnd())
 const isWritable = computed(() => props.writable && !props.readonly && __DEV__)
+const lineNumbers = props.lineNumbers ?? (props.lines ? 'on' : 'off')
 
 const langMap: Record<string, string> = {
   ts: 'typescript',
@@ -106,7 +109,7 @@ onMounted(async () => {
   const commonOptions = {
     automaticLayout: true,
     readOnly: props.readonly,
-    lineNumbers: props.lineNumbers,
+    lineNumbers,
     minimap: { enabled: false },
     overviewRulerBorder: false,
     overviewRulerLanes: 0,


### PR DESCRIPTION
The Monaco editor didn't pick up the global `lineNumbers` headmatter, and it ignored the per-block `lines` option that normal code blocks accept. So there was no way to show line numbers on an editable Monaco block. `{monaco} {lines: true}` just got dropped, since Monaco only knew about its own `lineNumbers` prop.

Now Monaco falls back to the global `lineNumbers` config and honors `{lines: true}` per block, the same way the static code block wrapper does. The `lineNumbers` prop still works when you need `relative` or `interval`.

Closes #2676