### PR TITLE
docs: document background and class frontmatter options

### DIFF
--- a/docs/custom/index.md
+++ b/docs/custom/index.md
@@ -154,6 +154,10 @@ hide: false
 hideInToc: false
 # defines the layout component applied to the slide
 layout: <"cover" if the slide is the first slide, otherwise "default">
+# background of the slide, can be a color ('#fff', 'rgb(...)') or an image URL
+background: undefined # or string
+# custom class(es) added to the slide root element
+class: undefined # or string | string[] | Record<string, unknown>
 # override the title level for the <TitleRenderer> and <Toc> components
 # only if `title` has also been declared
 level: 1


### PR DESCRIPTION
`background` and `class` are both supported per-slide frontmatter but were missing from the frontmatter list in the customization docs. This adds them, noting that `background` takes a CSS color or an image URL.

Fixes #2652