### PR TITLE
docs: add background property to frontmatter customization guide

### DIFF
--- a/docs/custom/index.md
+++ b/docs/custom/index.md
@@ -146,6 +146,8 @@ Also every slide accepts the following configuration in its frontmatter block. T
 clicks: 0
 # custom start clicks count
 clicksStart: 0
+# background image URL, local asset path, or color/gradient
+background: undefined # or string (e.g. 'https://cover.sli.dev' or '/image.png')
 # completely disable and hide the slide
 disabled: false
 # the same as `disabled`


### PR DESCRIPTION
## Description
This PR resolves issue #2652 by documenting the `background` property in the [Per-slide Configs](https://sli.dev/custom/#frontmatter) section of `docs/custom/index.md`.

## Details
- Adds `background` property definition to slide frontmatter customization docs.