### PR TITLE
docs: add new showcase entry for 'Reliability: Manual → Autopilot'

### DIFF
--- a/docs/.vitepress/showcases.ts
+++ b/docs/.vitepress/showcases.ts
@@ -322,6 +322,18 @@ export const showcases: ShowCaseInfo[] = [
     cover: 'https://raw.githubusercontent.com/momo5502/denuvo-slides/refs/heads/master/images/preview.png',
     datetime: '2025-10-03',
   },
+  {
+    title: 'Reliability: Manual → Autopilot',
+    author: {
+      name: 'Severin Neumann',
+      link: 'https://github.com/svrnm/'
+    },
+    at: 'Karlsruhe Cloud Native – Summer Edition 2026',
+    slidesLink: 'https://ai-sre-talk.vercel.app/',
+    sourcesLink: 'https://github.com/bronto-community/ai-sre-talk',
+    cover: 'https://raw.githubusercontent.com/bronto-community/ai-sre-talk/refs/heads/main/preview.png',
+    datetime: '2026-07-28',
+  },
   // Add yours here!
   {
     title: 'Yours?',


### PR DESCRIPTION
Adding a talk I gave July 28th, 2026 in Karlsruhe about AI SRE and Service Reliability. I switched from a Google Slides deck to Slidev, because it was much easier to drive a LLM to create the slides I was looking for, especially with some visual and interactive elements I wanted to realize, like two small "gamified" pages.

Going forward I will do more of my slides with this tool, kudos!:-) 