### PR TITLE
fix: wrong import

### DIFF
--- a/packages/create-theme/template/layouts/cover.vue
+++ b/packages/create-theme/template/layouts/cover.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { handleBackground } from '@slidev/client/layoutHelper'
+import { handleBackground } from '@slidev/client'
 import { computed } from 'vue'
 
 const props = defineProps({


### PR DESCRIPTION
Wrong import in `cover` layout causes error when creating new theme.

<img width="959" height="541" alt="slidev-error" src="https://github.com/user-attachments/assets/8039b818-670b-43c3-b476-5b5ab1f386fe" />

How to reproduce:

1. run `pnpm create slidev-theme`
2. install dependencies
3. run project with `pnpm dev`
