### PR TITLE
fix(client): guard useNav against a missing injection context

### DIFF
--- a/packages/client/composables/useNav.test.ts
+++ b/packages/client/composables/useNav.test.ts
@@ -127,4 +127,14 @@ describe('useNavBase', () => {
     expect(observedNav?.currentSlideRoute.value.meta.slide.frontmatter.title).toBe('Second')
     expect(observedNav?.tocTree.value[1].active).toBe(true)
   })
+
+  it('falls back to the shared nav when there is no injection context', () => {
+    // Directive hooks such as `v-motion`'s and `v-mark`'s `mounted` call
+    // `useNav()` while no component instance is current. There is no
+    // slide-local context to read there, so the shared nav is the answer.
+    vi.stubGlobal('location', { search: '' })
+
+    expect(() => useNav()).not.toThrow()
+    expect(useNav().currentSlideNo.value).toBe(1)
+  })
 })

--- a/packages/client/composables/useNav.ts
+++ b/packages/client/composables/useNav.ts
@@ -4,7 +4,7 @@ import type { RouteLocationNormalized, Router } from 'vue-router'
 import { clamp } from '@antfu/utils'
 import { parseRangeString } from '@slidev/parser/utils'
 import { createSharedComposable, injectLocal } from '@vueuse/core'
-import { computed, ref, toRaw, watch } from 'vue'
+import { computed, hasInjectionContext, ref, toRaw, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { slides } from '#slidev/slides'
 import { CLICKS_MAX, injectionSlidevContext } from '../constants'
@@ -404,7 +404,13 @@ const useSharedNav = createSharedComposable((): SlidevContextNavFull => {
 
 export function useNav(): SlidevContextNavFull {
   const nav = useSharedNav()
-  const context = injectLocal(injectionSlidevContext, undefined)
+  // `useNav()` is also called outside of `setup()`, most notably from the
+  // `mounted`/`created` hooks of the `v-motion` and `v-mark` directives.
+  // `injectLocal` throws there, and there is no slide-local context to read
+  // anyway, so fall back to the shared nav.
+  const context = hasInjectionContext()
+    ? injectLocal(injectionSlidevContext, undefined)
+    : undefined
   if (!context)
     return nav
 


### PR DESCRIPTION
Fixes #2693

### What happens

`useNav()` is called from directive hooks, which run outside of `setup()`:

| call site | hook |
| --- | --- |
| `packages/client/modules/v-motion.ts:22` | `v-motion`'s `mounted` |
| `packages/client/modules/v-mark.ts:82` | `v-mark`'s `mounted` |
| `packages/client/composables/useDragElements.ts:134` (via `useDragElement`) | `v-drag`'s `created` |

Since #2681, `useNav()` calls `injectLocal(injectionSlidevContext, undefined)` unconditionally, and `@vueuse/core` 14.x throws when there is neither an owner nor an injection context:

```js
const owner = instance ?? getCurrentScope();
if (owner == null && !hasInjectionContext()) throw new Error("injectLocal must be called in setup");
```

Directive hooks are exactly that case. Measured on `vue@3.5.40` by mounting through a custom (headless) renderer and sampling from a directive:

```
setup              hasInjectionContext=true   currentInstance=true   currentScope=true
directive.created  hasInjectionContext=false  currentInstance=false  currentScope=false
directive.mounted  hasInjectionContext=false  currentInstance=false  currentScope=false
```

The throw lands in Vue's post-flush phase, so the remaining post-flush jobs are dropped and the running slide transition never completes. That is the freeze in #2693: the route advances but the rendered slide does not.

### The fix

Skip the lookup when there is no injection context and fall back to the shared nav. There is no slide-local context to read there anyway, so this is the same result `useNav()` produced before #2681, when it did not inject at all.

`hasInjectionContext()` rather than `try`/`catch` because it is precisely the condition `injectLocal` tests before throwing, so nothing else gets swallowed.

This also keeps `v-drag` working end to end. `useDragElement` already routes its other lookups through `directiveInject` (`dir.instance.$.provides[key]`), which needs no injection context; `useNav()` on line 134 was the only lookup in that function that did not.

### Verification

Three-way probe on the new test:

| `useNav()` variant | new test (no injection context) | existing test (slide-local nav during export, from #2681) |
| --- | --- | --- |
| `main`, unguarded `injectLocal` | fails: `injectLocal must be called in setup` | passes |
| skip the lookup unconditionally | passes | fails |
| `hasInjectionContext()` guard (this PR) | passes | passes |

The middle row is there to show the new test is not satisfied by simply dropping the local-nav lookup that #2681 added.

`pnpm verify` on this branch: `build` ok, `typecheck` (`vue-tsc --noEmit`) ok, `lint` (`eslint .`) ok, `test` 228 passed / 1 failed (229).

The single failure is `packages/slidev/node/syntax/integration.test.ts > all syntax combined`, a PlantUML inline snapshot where only the encoded `code=` payload differs. It fails identically on unmodified `main` on this machine (checked by stashing this patch and re-running that file), so it is unrelated to this change. I did not investigate it further.

Reported and diagnosed by @shadyueh in #2693.
