### PR TITLE
fix(client): hide goto dialog fully when closed

### DIFF
--- a/packages/client/internals/Goto.vue
+++ b/packages/client/internals/Goto.vue
@@ -111,7 +111,7 @@ watch(activeElement, () => {
     ref="container"
     class="fixed right-5 transition-all"
     w-90 max-w-90 min-w-90
-    :class="showGotoDialog ? 'top-5' : '-top-20'"
+    :class="showGotoDialog ? 'top-5' : '-top-20 op0 pointer-events-none'"
   >
     <div
       class="bg-main transform"


### PR DESCRIPTION
The goto dialog (#slidev-goto-dialog) stays in the DOM and is only shifted off-screen with `-top-20` when closed. The dialog peeks out the top edge in Safari 26.5.2 (21624.2.5.11.8).

Fade it out with `op0` (and `pointer-events-none`) in the closed state so the dialog disappears with it. `transition-all` already animates the change, so this also gives the dialog a smooth fade in/out instead of only sliding.

Before:

https://github.com/user-attachments/assets/58bcda8e-695b-46c4-8447-77384daf13c0

After:

https://github.com/user-attachments/assets/190e7ee9-619b-41c5-94c5-7cf457115db7


