### PR TITLE
docs(skills): fix broken draggable link in core-components reference

### DIFF
--- a/skills/slidev/references/core-components.md
+++ b/skills/slidev/references/core-components.md
@@ -184,7 +184,7 @@ Context values:
 </VDrag>
 ```
 
-See [draggable](draggable.md) for details.
+See [draggable](layout-draggable.md) for details.
 
 ## Component Auto-Import
 


### PR DESCRIPTION
`skills/slidev/references/core-components.md` links to `draggable.md`, but the file is named `layout-draggable.md` (per the category-prefix naming in `skills/GENERATION.md`). One-line fix; the only broken relative link in the `skills/` tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148GGGiLPmPBzxn1e3heG7S