### PR TITLE
fix: load setup/* from the project root when the entry is in a subdirectory

### DIFF
--- a/docs/custom/directory-structure.md
+++ b/docs/custom/directory-structure.md
@@ -19,6 +19,8 @@ your-slidev/
 
 All of them are optional.
 
+These paths are resolved relative to the directory holding your slides entry, so if you run `slidev slides/deck.md` they are looked up inside `slides/`. The `setup/` directory is the exception: it is also read from your project root (the closest directory with a `package.json`), so shared hooks keep working when the entry lives in a subdirectory. A `setup/` file next to the entry takes precedence over one in the project root.
+
 ## Components
 
 Pattern: `./components/*.{vue,js,ts,jsx,tsx,md}`

--- a/packages/parser/src/fs.ts
+++ b/packages/parser/src/fs.ts
@@ -42,6 +42,11 @@ export interface LoadRootsInfo {
   roots: string[]
   userRoot: string
   /**
+   * Roots to look up `setup/*` files in. Defaults to `roots`. Optional for
+   * backward compatibility with other `@slidev/parser` consumers.
+   */
+  setupRoots?: string[]
+  /**
    * When provided, `src:` includes resolving outside these roots are
    * rejected (recorded as an error) instead of being loaded. Optional for
    * backward compatibility with other `@slidev/parser` consumers.
@@ -79,7 +84,7 @@ export async function load(
       hm = lines.slice(1, hEnd).join('\n')
     }
     const o = YAML.parse(hm) as Record<string, unknown> ?? {}
-    extensions = await preparserExtensionLoader(options.roots, o, filepath, mode)
+    extensions = await preparserExtensionLoader(options.setupRoots ?? options.roots, o, filepath, mode)
   }
 
   const markdownFiles: Record<string, SlidevMarkdown> = {}

--- a/packages/slidev/node/cli.ts
+++ b/packages/slidev/node/cli.ts
@@ -6,6 +6,7 @@ import fs from 'node:fs/promises'
 import os from 'node:os'
 import process from 'node:process'
 import * as readline from 'node:readline'
+import { uniq } from '@antfu/utils'
 import { verifyConfig } from '@slidev/parser'
 import { blue, bold, cyan, cyanBright, dim, gray, green, underline, yellow } from 'ansis'
 import equal from 'fast-deep-equal'
@@ -35,13 +36,18 @@ const CONFIG_RESTART_FIELDS: (keyof SlidevConfig)[] = [
   'seoMeta',
 ]
 
-const FILES_CHANGE_RESTART = [
+// Watched under `setupRoots`, which also covers the project root
+const SETUP_FILES_CHANGE_RESTART = [
   'setup/shiki.ts',
   'setup/katex.ts',
   'setup/preparser.ts',
   'setup/transformers.ts',
   'setup/unocss.ts',
   'setup/vite-plugins.ts',
+]
+
+// Watched under `roots` only
+const FILES_CHANGE_RESTART = [
   'uno.config.ts',
   'unocss.config.ts',
   'vite.config.{js,ts,mjs,mts}',
@@ -315,14 +321,20 @@ cli.command(
       process.stdin.on('keypress', onKeyPress)
     }
 
-    const { roots } = await initServer()
+    const { roots, setupRoots } = await initServer()
     bindShortcut()
 
     // Start watcher to restart server on file changes
     const { watch } = await import('chokidar')
-    const watchGlobs = roots
-      .filter(i => !i.includes('node_modules'))
-      .flatMap(root => FILES_CHANGE_RESTART.map(i => path.join(root, i)))
+    const isWatchable = (root: string) => !root.includes('node_modules')
+    const watchGlobs = uniq([
+      ...roots
+        .filter(isWatchable)
+        .flatMap(root => FILES_CHANGE_RESTART.map(i => path.join(root, i))),
+      ...setupRoots
+        .filter(isWatchable)
+        .flatMap(root => SETUP_FILES_CHANGE_RESTART.map(i => path.join(root, i))),
+    ])
     const watcher = watch(watchGlobs, {
       ignored: ['node_modules', '.git'],
       ignoreInitial: true,

--- a/packages/slidev/node/mcp/stdio.ts
+++ b/packages/slidev/node/mcp/stdio.ts
@@ -1,3 +1,4 @@
+import { uniq } from '@antfu/utils'
 import { StdioServerTransport } from '@modelcontextprotocol/server/stdio'
 import { version } from '../../package.json'
 import { parser } from '../parser'
@@ -12,13 +13,17 @@ import { createSlidevMcpServer } from './server'
  * else may be printed to it.
  */
 export async function startMcpStdioServer(entry: string) {
-  const { userRoot } = await getRoots(entry)
+  const { userRoot, userProjectRoot } = await getRoots(entry)
   const server = createSlidevMcpServer({
     version,
     entry,
     // Reload from disk on every tool call, as the files may be edited
     // externally between calls
-    getData: () => parser.load({ userRoot, roots: [userRoot] }, entry),
+    getData: () => parser.load({
+      userRoot,
+      roots: [userRoot],
+      setupRoots: uniq([userProjectRoot, userRoot]),
+    }, entry),
   })
   await server.connect(new StdioServerTransport())
 }

--- a/packages/slidev/node/options.test.ts
+++ b/packages/slidev/node/options.test.ts
@@ -45,6 +45,7 @@ describe('resolveOptions', () => {
       clientRoot: '/client',
       userPkgJson: {},
       userRoot: '/project',
+      userProjectRoot: '/project',
       userWorkspaceRoot: '/workspace',
     })
     mocks.resolveTheme.mockResolvedValue(['slidev-theme-test', '/theme'])
@@ -114,6 +115,7 @@ describe('resolveOptions', () => {
     expect(mocks.load).toHaveBeenNthCalledWith(1, {
       allowedRoots: ['/workspace', '/project'],
       roots: ['/project'],
+      setupRoots: ['/project'],
       userRoot: '/project',
     }, '/project/slides.md', undefined, 'dev')
     expect(mocks.resolveTheme).toHaveBeenCalledWith('bootstrap', '/project/slides.md')
@@ -127,6 +129,7 @@ describe('resolveOptions', () => {
     expect(mocks.load).toHaveBeenNthCalledWith(2, {
       allowedRoots: ['/workspace', '/theme', '/addon', '/project'],
       roots: ['/theme', '/addon', '/project'],
+      setupRoots: ['/theme', '/addon', '/project'],
       userRoot: '/project',
     }, '/project/slides.md', undefined, 'dev')
     expect(mocks.resolveConfig).toHaveBeenNthCalledWith(
@@ -140,6 +143,7 @@ describe('resolveOptions', () => {
     expect(mocks.resolveAddons).toHaveBeenCalledTimes(1)
     expect(mocks.resolveConfig).toHaveBeenCalledTimes(2)
     expect(options.roots).toEqual(['/theme', '/addon', '/project'])
+    expect(options.setupRoots).toEqual(['/theme', '/addon', '/project'])
     expect(options.data.config).toBe(finalConfig)
     expect(options.data.config).toMatchObject({
       addons: ['slidev-addon-bootstrap'],
@@ -151,5 +155,40 @@ describe('resolveOptions', () => {
     expect(options.data.config.theme).toBe(options.themeRaw)
     expect(options.data.headmatter).toEqual(reloadedData.headmatter)
     expect(options.data.slides).toEqual(reloadedData.slides)
+  })
+
+  it('looks up setup files in the project root when the entry is in a subdirectory', async () => {
+    mocks.resolveEntry.mockResolvedValue('/project/slides/deck.md')
+    mocks.getRoots.mockResolvedValue({
+      clientRoot: '/client',
+      userPkgJson: {},
+      userRoot: '/project/slides',
+      userProjectRoot: '/project',
+      userWorkspaceRoot: '/workspace',
+    })
+    mocks.load.mockResolvedValue({ headmatter: {}, slides: [] })
+
+    const options = await resolveOptions({ entry: '/project/slides/deck.md' }, 'dev')
+
+    // `roots` is unchanged: generically named directories keep resolving
+    // relative to the entry only
+    expect(options.roots).toEqual(['/theme', '/addon', '/project/slides'])
+    // `setup/*` is additionally read from the project root, at a lower
+    // precedence than the entry's own directory
+    expect(options.setupRoots).toEqual(['/theme', '/addon', '/project', '/project/slides'])
+    expect(mocks.load).toHaveBeenNthCalledWith(1, {
+      allowedRoots: ['/workspace', '/project/slides'],
+      roots: ['/project/slides'],
+      setupRoots: ['/project', '/project/slides'],
+      userRoot: '/project/slides',
+    }, '/project/slides/deck.md', undefined, 'dev')
+  })
+
+  it('keeps setupRoots equal to roots when the entry sits in the project root', async () => {
+    mocks.load.mockResolvedValue({ headmatter: {}, slides: [] })
+
+    const options = await resolveOptions({ entry: '/project/slides.md' }, 'dev')
+
+    expect(options.setupRoots).toEqual(options.roots)
   })
 })

--- a/packages/slidev/node/options.ts
+++ b/packages/slidev/node/options.ts
@@ -26,6 +26,7 @@ export async function resolveOptions(
     {
       userRoot: rootsInfo.userRoot,
       roots: [rootsInfo.userRoot],
+      setupRoots: uniq([rootsInfo.userProjectRoot, rootsInfo.userRoot]),
       allowedRoots: uniq([rootsInfo.userWorkspaceRoot, rootsInfo.userRoot]),
     },
     entry,
@@ -43,10 +44,16 @@ export async function resolveOptions(
   const initialConfig = parser.resolveConfig(initialLoaded.headmatter, themeMeta, entryOptions.entry)
   const addonRoots = await resolveAddons(initialConfig.addons)
   const roots = uniq([...themeRoots, ...addonRoots, rootsInfo.userRoot])
+  // `setup/*` filenames belong to Slidev, so they are also read from the
+  // project root. Without this, every `setup/*` hook is silently skipped when
+  // the entry markdown lives in a subdirectory, because `userRoot` is the
+  // entry's own directory. See #2603.
+  const setupRoots = uniq([...themeRoots, ...addonRoots, rootsInfo.userProjectRoot, rootsInfo.userRoot])
   const loaded = await parser.load(
     {
       userRoot: rootsInfo.userRoot,
       roots,
+      setupRoots,
       allowedRoots: uniq([rootsInfo.userWorkspaceRoot, ...roots]),
     },
     entry,
@@ -78,6 +85,7 @@ export async function resolveOptions(
     themeRoots,
     addonRoots,
     roots,
+    setupRoots,
   })
 
   const data: SlidevData = {
@@ -97,6 +105,7 @@ export async function resolveOptions(
     themeRoots,
     addonRoots,
     roots,
+    setupRoots,
   }
 
   return {
@@ -113,8 +122,8 @@ export async function createDataUtils(resolved: Omit<ResolvedSlidevOptions, 'uti
   let _layouts_cache: Promise<Record<string, string>> | null = null
 
   return {
-    ...await setupShiki(resolved.roots),
-    katexOptions: await setupKatex(resolved.roots),
+    ...await setupShiki(resolved.setupRoots),
+    katexOptions: await setupKatex(resolved.setupRoots),
     indexHtml: await setupIndexHtml(resolved),
     define: getDefine(resolved),
     iconsResolvePath: [resolved.clientRoot, ...resolved.roots].reverse(),

--- a/packages/slidev/node/resolver.test.ts
+++ b/packages/slidev/node/resolver.test.ts
@@ -79,6 +79,19 @@ const fsMocks = vi.hoisted(() => {
 
 vi.mock('node:fs', () => fsMocks)
 
+describe('getRoots', () => {
+  it('exposes the closest package.json directory as userProjectRoot', async () => {
+    // `getRoots` memoizes its result, so load a fresh module instance
+    vi.resetModules()
+    const { getRoots: getFreshRoots } = await import('./resolver')
+
+    const roots = await getFreshRoots('/user/project/slides/deck.md')
+
+    expect(roots.userRoot).toBe('/user/project/slides')
+    expect(roots.userProjectRoot).toBe('/user/project')
+  })
+})
+
 describe('createResolver', () => {
   beforeEach(async () => {
     await getRoots('/user/project')

--- a/packages/slidev/node/resolver.ts
+++ b/packages/slidev/node/resolver.ts
@@ -451,6 +451,7 @@ export async function getRoots(entry?: string): Promise<RootsInfo> {
     cliRoot,
     clientRoot,
     userRoot,
+    userProjectRoot: closestPkgRoot,
     userPkgJson,
     userWorkspaceRoot,
   }

--- a/packages/slidev/node/setups/unocss.ts
+++ b/packages/slidev/node/setups/unocss.ts
@@ -9,9 +9,13 @@ import { loadSetups } from '../setups/load'
 import { loadModule } from '../utils'
 
 export default async function setupUnocss(
-  { clientRoot, roots, data, utils }: ResolvedSlidevOptions,
+  { clientRoot, roots, setupRoots, data, utils }: ResolvedSlidevOptions,
 ) {
   function loadFileConfigs(root: string) {
+    // `uno.config.ts` is not a Slidev-specific filename, so it stays on
+    // `roots` and is never picked up from the surrounding project root.
+    if (!roots.includes(root))
+      return []
     return [
       resolve(root, 'uno.config.ts'),
       resolve(root, 'unocss.config.ts'),
@@ -38,7 +42,7 @@ export default async function setupUnocss(
       safelist: await loadModule(resolve(clientRoot, '.generated/unocss-tokens.ts')),
     } satisfies VitePluginConfig,
     (await loadModule<{ default: VitePluginConfig }>(resolve(clientRoot, 'uno.config.ts'))).default,
-    ...await loadSetups<UnoSetup>(roots, 'unocss.ts', [], loadFileConfigs),
+    ...await loadSetups<UnoSetup>(setupRoots, 'unocss.ts', [], loadFileConfigs),
   ].filter(Boolean) as VitePluginConfig<Theme>[]
 
   const config = mergeConfigs(configs)

--- a/packages/slidev/node/setups/vite-plugins.ts
+++ b/packages/slidev/node/setups/vite-plugins.ts
@@ -3,6 +3,6 @@ import type { PluginOption } from 'vite'
 import { loadSetups } from './load'
 
 export default async function setupVitePlugins(options: ResolvedSlidevOptions): Promise<PluginOption> {
-  const plugins = await loadSetups<VitePluginsSetup>(options.roots, 'vite-plugins.ts', [options])
+  const plugins = await loadSetups<VitePluginsSetup>(options.setupRoots, 'vite-plugins.ts', [options])
   return plugins
 }

--- a/packages/slidev/node/virtual/setups.ts
+++ b/packages/slidev/node/virtual/setups.ts
@@ -5,9 +5,9 @@ function createSetupTemplate(name: string): VirtualModuleTemplate {
   const id = `/@slidev/setups/${name}`
   return {
     id,
-    getContent({ roots }) {
+    getContent({ setupRoots }) {
       const imports: string[] = []
-      const globs = roots.map((root) => {
+      const globs = setupRoots.map((root) => {
         const glob = join(root, `setup/${name}.{ts,js,mts,mjs}`)
         const importName = `__slidev_setup_${imports.length}`
         imports.push(`import ${importName} from ${JSON.stringify(this.makeAbsoluteImportGlob([glob], { import: 'default' }))}`)

--- a/packages/slidev/node/vite/markdown.ts
+++ b/packages/slidev/node/vite/markdown.ts
@@ -13,7 +13,7 @@ export async function createMarkdownPlugin(
   { markdown: mdOptions }: SlidevPluginOptions,
 ): Promise<Plugin> {
   const markdownTransformMap = new Map<string, MagicString>()
-  const extras = await setupTransformers(options.roots)
+  const extras = await setupTransformers(options.setupRoots)
   const transformers = [
     ...extras.pre,
     ...extras.preCodeblock,

--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -7,6 +7,12 @@ export interface RootsInfo {
   cliRoot: string
   clientRoot: string
   userRoot: string
+  /**
+   * Directory of the closest `package.json` at or above `userRoot`.
+   * Equals `userRoot` when the entry sits next to the `package.json`,
+   * and is an ancestor of it when the entry lives in a subdirectory.
+   */
+  userProjectRoot: string
   userPkgJson: Record<string, any>
   userWorkspaceRoot: string
 }
@@ -62,6 +68,16 @@ export interface ResolvedSlidevOptions extends RootsInfo, SlidevEntryOptions {
    * =`[...themeRoots, ...addonRoots, userRoot]` (`clientRoot` excluded)
    */
   roots: string[]
+  /**
+   * Roots to look up `setup/*` files in.
+   * =`[...themeRoots, ...addonRoots, userProjectRoot, userRoot]`
+   *
+   * `setup/*` filenames are owned by Slidev, so they are also read from
+   * `userProjectRoot`. That keeps them working when the entry markdown lives
+   * in a subdirectory of the project. Generically named files (`components/`,
+   * `layouts/`, `styles/`, `uno.config.ts`, `vite.config.ts`) stay on `roots`.
+   */
+  setupRoots: string[]
   mode: 'dev' | 'build' | 'export'
   utils: ResolvedSlidevUtils
 }

--- a/test/__snapshots__/tsnapi/@slidev/parser/fs.snapshot.d.ts
+++ b/test/__snapshots__/tsnapi/@slidev/parser/fs.snapshot.d.ts
@@ -5,6 +5,7 @@
 export interface LoadRootsInfo {
   roots: string[];
   userRoot: string;
+  setupRoots?: string[];
   allowedRoots?: string[];
 }
 export interface SlidevParserOptions {

--- a/test/mermaid-renderer.test.ts
+++ b/test/mermaid-renderer.test.ts
@@ -18,6 +18,7 @@ describe('mermaid-renderer virtual module', () => {
     const content = template.getContent.call(context, {
       userRoot: '/user/project',
       roots: ['/user/project'],
+      setupRoots: ['/user/project'],
     } as ResolvedSlidevOptions)
 
     expect(content).toContain('mermaid-renderer')


### PR DESCRIPTION
Fixes #2603

`getRoots` sets `userRoot = dirname(entry)`, `resolveOptions` builds `roots` as `[...themeRoots, ...addonRoots, userRoot]`, and every setup consumer probes `resolve(root, 'setup', filename)` over that list. The `existsSync` guard in `setups/load.ts` skips a missing path without reporting, so with `slidev slides/deck.md` the project-root `setup/*` files are passed over in silence. The reporter hit it through `setup/shiki.ts`; it applies to every hook, including the client-side ones.

**Why not fix `userRoot`.** It is not wrong: it is the Vite `root`, the `publicDir` base, the anchor for `@/` in `src:` resolution, and where build output lands (`--out dist-A` wrote to `slides/dist-A` in my repro). Moving it would relocate all four for every deck kept in a subdirectory.

The wrong part is which roots the `setup/` lookup walks. `RootsInfo` gains `userProjectRoot`, the closest `package.json` directory at or above `userRoot`, which `getRoots` already computed for `userPkgJson` and `userWorkspaceRoot` but never exposed. `setupRoots` is `[...themeRoots, ...addonRoots, userProjectRoot, userRoot]`, keeping `userRoot` last so a deck-local file still wins; for a root-level entry the two collapse under `uniq` and `setupRoots === roots`.

**The line I drew.** Only Slidev-owned filenames are read from the project root. Generically named things stay on `roots`: `components/`, `layouts/`, `styles/index.*`, `global-top.vue`, `uno.config.ts`, `vite.config.ts`. Several load eagerly, so a repo with a web app at the root and a deck in `slides/` would otherwise get its app stylesheet injected and its Vite config merged into the Slidev one; `loadFileConfigs` in `setups/unocss.ts` stays on `roots` for that reason while `setup/unocss.ts` moved. This leaves #1787 (`vite.config.ts` in the parent directory) unresolved, since that needs a decision about merging a possibly unrelated config.

`LoadRootsInfo.setupRoots` is optional and falls back to `roots`, so the VS Code extension and other `@slidev/parser` consumers are unaffected. The `cli.ts` restart watcher watched setup and config filenames over one list; I split it, otherwise editing a project-root setup file would not restart the server.

`resolver.test.ts` asserts `getRoots` reports `userProjectRoot` for a nested entry. `options.test.ts` asserts `roots` is unchanged while `setupRoots` picks up the project root at the right precedence and reaches `parser.load`, plus a case pinning `setupRoots === roots` for a root-level entry. By hand against real builds: a project-root `setup/shiki.ts`, `setup/preparser.ts` and `setup/main.ts` all apply, a deck-local file still overrides, and a root-level deck builds as before.

`pnpm verify` green: build, `vue-tsc --noEmit`, `eslint .`, 232 tests across 27 files. The `@slidev/parser` API snapshot was regenerated for the new optional field.
