### PR TITLE
docs: add Studio addon to gallery

### DIFF
--- a/docs/.vitepress/addons.ts
+++ b/docs/.vitepress/addons.ts
@@ -314,6 +314,17 @@ export const community: AddonInfo[] = [
     },
     repo: 'https://github.com/nirtamir2/slidev-addon-sandpack',
   },
+  {
+    id: 'slidev-addon-studio',
+    name: 'Studio',
+    description: 'Edit slides on the canvas, with every change written back to your Markdown.',
+    tags: ['Editor', 'Tool'],
+    author: {
+      name: 'Daniel Christensen',
+      link: 'https://github.com/BobTheShoplifter',
+    },
+    repo: 'https://github.com/BobTheShoplifter/slidev-addon-studio',
+  },
   // Add yours here!
   {
     id: '',


### PR DESCRIPTION
## Summary

- add `slidev-addon-studio` to the curated Community Addons gallery
- links the published npm package and the repository through the existing card

## What it is

A visual editor that runs inside `slidev` while you are writing a deck. Click anything on the canvas to select it, drag or resize it, set a component's props from a panel, add click animations, pick a layout from thumbnails, reorder slides.

Every action is a small, readable edit to the `.md` file. There is no project format and no database: close the editor and the diff is something you could have typed by hand, which is what lets it coexist with version control and hand editing. It adds nothing to a slide while it is closed, and nothing at all to a built or exported deck.

![Studio open on a slide, with a component selected and the Element panel showing its props and the Markdown line it came from](https://raw.githubusercontent.com/BobTheShoplifter/slidev-addon-studio/main/docs/framed/studio.png)

Text is edited on the slide itself rather than in a box beside it, so it is already in the deck's font, at its size, wrapping where it will really wrap. A block is only offered that way when its markup can be written back to Markdown exactly; anything else, a table, a fenced code block, a heading holding a styled `<span>`, opens as Markdown instead, so components and directives are never lost to a round trip.

![Text being edited on the slide itself, in the deck's own type, with a small formatting toolbar floating above it](https://raw.githubusercontent.com/BobTheShoplifter/slidev-addon-studio/main/docs/framed/inline.png)

## Validation

- published on npm as `slidev-addon-studio@0.2.0`, with provenance, and carries the `slidev-addon` and `slidev` keywords
- `docs/.vitepress/addons.ts` still parses, ids stay unique, and the `Yours?` placeholder remains last
- the entry follows the shape of the surrounding ones: `id`, `name`, `description`, `tags`, `author`, `repo`
