### PR TITLE
feat(client): support post URLs in Tweet

### DIFF
--- a/docs/builtin/components.md
+++ b/docs/builtin/components.md
@@ -270,14 +270,18 @@ Embed a tweet.
 
 ```md
 <Tweet id="20" />
+<Tweet url="https://x.com/antfu7/status/1389604687502995457" />
 ```
 
 Props:
 
-- `id` (`number | string`, required): id of the tweet
+- `id` (`number | string`): id of the tweet
+- `url` (`string`): full `x.com` or `twitter.com` post URL
 - `scale` (`number | string`, default `1`): transform scale value
 - `conversation` (`string`, default `'none'`): [tweet embed parameter](https://developer.twitter.com/en/docs/twitter-for-websites/embedded-tweets/guides/embedded-tweet-parameter-reference)
 - `cards` (`'hidden' | 'visible'`, default `'visible'`): [tweet embed parameter](https://developer.twitter.com/en/docs/twitter-for-websites/embedded-tweets/guides/embedded-tweet-parameter-reference)
+
+Provide either `id` or `url`. When both are present, `id` takes precedence.
 
 ## `BlueSky`
 

--- a/packages/client/builtin/Tweet.vue
+++ b/packages/client/builtin/Tweet.vue
@@ -4,14 +4,17 @@ A simple wrapper for embedded Tweet
 Usage:
 
 <Tweet id="20" />
+<Tweet url="https://x.com/jack/status/20" />
 -->
 
 <script setup lang="ts">
 import { onMounted, ref } from 'vue'
 import { isDark } from '../logic/dark'
+import { resolveTweetId } from './tweet'
 
 const props = defineProps<{
-  id: string | number
+  id?: string | number
+  url?: string
   scale?: string | number
   conversation?: string
   cards?: 'hidden' | 'visible'
@@ -23,6 +26,14 @@ const loaded = ref(false)
 const tweetNotFound = ref(false)
 
 async function create(retries = 10) {
+  const tweetId = resolveTweetId(props.id, props.url)
+  if (!tweetId) {
+    loaded.value = true
+    tweetNotFound.value = true
+    console.error('Tweet requires a valid id or X post URL.')
+    return
+  }
+
   // @ts-expect-error global
   if (!window.twttr?.widgets?.createTweet) {
     if (retries <= 0)
@@ -32,7 +43,7 @@ async function create(retries = 10) {
   }
   // @ts-expect-error global
   const element = await window.twttr.widgets.createTweet(
-    props.id.toString(),
+    tweetId,
     tweet.value,
     {
       theme: isDark.value ? 'dark' : 'light',
@@ -56,7 +67,7 @@ onMounted(() => {
       <div v-if="!loaded || tweetNotFound" class="w-30 h-30 my-10px bg-gray-400 bg-opacity-10 rounded-lg flex opacity-50">
         <div class="m-auto animate-pulse text-4xl">
           <div class="i-carbon:logo-twitter" />
-          <span v-if="tweetNotFound">Could not load tweet with id="{{ props.id }}"</span>
+          <span v-if="tweetNotFound">Could not load tweet</span>
         </div>
       </div>
     </div>

--- a/packages/client/builtin/tweet.test.ts
+++ b/packages/client/builtin/tweet.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { resolveTweetId } from './tweet'
+
+describe('resolveTweetId', () => {
+  it('keeps the existing id input', () => {
+    expect(resolveTweetId(123, undefined)).toBe('123')
+    expect(resolveTweetId(' 456 ', undefined)).toBe('456')
+  })
+
+  it('prefers id when both inputs are present', () => {
+    expect(resolveTweetId('123', 'https://x.com/slidevjs/status/456')).toBe('123')
+  })
+
+  it.each([
+    'https://x.com/slidevjs/status/123',
+    'https://www.x.com/slidevjs/status/123?s=20',
+    'https://twitter.com/slidevjs/status/123',
+    'https://mobile.twitter.com/slidevjs/status/123/photo/1',
+    'https://x.com/i/web/status/123',
+  ])('extracts an id from %s', (url) => {
+    expect(resolveTweetId(undefined, url)).toBe('123')
+  })
+
+  it.each([
+    'https://example.com/slidevjs/status/123',
+    'https://x.com.example.com/slidevjs/status/123',
+    'https://x.com/slidevjs/status/not-a-number',
+    'javascript:alert(1)',
+    'not a URL',
+  ])('rejects an unsupported source URL: %s', (url) => {
+    expect(resolveTweetId(undefined, url)).toBeUndefined()
+  })
+})

--- a/packages/client/builtin/tweet.ts
+++ b/packages/client/builtin/tweet.ts
@@ -1,0 +1,37 @@
+const TWEET_HOSTS = new Set([
+  'mobile.twitter.com',
+  'mobile.x.com',
+  'twitter.com',
+  'www.twitter.com',
+  'www.x.com',
+  'x.com',
+])
+
+export function resolveTweetId(
+  id: string | number | undefined,
+  sourceUrl: string | undefined,
+): string | undefined {
+  if (typeof id === 'number')
+    return id.toString()
+
+  if (id?.trim())
+    return id.trim()
+
+  if (!sourceUrl)
+    return
+
+  try {
+    const url = new URL(sourceUrl)
+    if (!['http:', 'https:'].includes(url.protocol) || !TWEET_HOSTS.has(url.hostname))
+      return
+
+    const segments = url.pathname.split('/').filter(Boolean)
+    const statusIndex = segments.lastIndexOf('status')
+    const tweetId = segments[statusIndex + 1]
+    if (statusIndex < 1 || !tweetId || !/^\d+$/.test(tweetId))
+      return
+
+    return tweetId
+  }
+  catch {}
+}

--- a/skills/slidev/references/core-components.md
+++ b/skills/slidev/references/core-components.md
@@ -136,7 +136,10 @@ Props: `controls`, `autoplay`, `autoreset`, `poster`, `timestamp`
 ```md
 <Tweet id="1423789844234231808" />
 <Tweet id="1423789844234231808" :scale="0.8" />
+<Tweet url="https://x.com/antfu7/status/1389604687502995457" />
 ```
+
+Use either `id` or a full `x.com` or `twitter.com` post URL. When both are present, `id` takes precedence.
 
 ## Conditional
 


### PR DESCRIPTION
## Summary

- Accept full `x.com` and `twitter.com` post URLs in `<Tweet>`.
- Keep numeric and string IDs working.
- Prefer `id` when both props are present.
- Reject unsupported hosts and malformed post paths before loading the widget.
- Document URL usage in the component guide and Slidev Skill reference.

## Why

`<Tweet>` currently requires a bare status ID. Users who copy post URLs from browsers or structured research tools must parse the ID first. URL support matches the existing `<BlueSky>` input style and removes that manual step.

## Tests

- `pnpm typecheck`
- `pnpm lint`
- `pnpm vitest run packages/client/builtin/tweet.test.ts` (12 passed)
- `pnpm verify`: build, typecheck, and lint pass; 240 of 241 tests pass locally. The unchanged PlantUML snapshot emits a different compressed string on macOS. The exact base SHA passed [upstream CI](https://github.com/slidevjs/slidev/actions/runs/32223158673).