### PR TITLE
fix(client): keep v-click hidden state on annotated code and KaTeX blocks

### DIFF
--- a/cypress/e2e/examples/basic.spec.ts
+++ b/cypress/e2e/examples/basic.spec.ts
@@ -314,4 +314,15 @@ context('Basic', () => {
     cy.get(`${targets}:not(.slidev-vclick-hidden)`)
       .should('have.length', 4)
   })
+
+  it('annotated code block in v-click', () => {
+    goPage(17)
+
+    const wrapper = '#slideshow .slidev-page-17 .cy-code-in-vclick .slidev-code-wrapper'
+
+    cy.get(wrapper).should('have.class', 'slidev-vclick-hidden')
+
+    cy.rightArrow()
+    cy.get(wrapper).should('not.have.class', 'slidev-vclick-hidden')
+  })
 })

--- a/cypress/fixtures/basic/slides.md
+++ b/cypress/fixtures/basic/slides.md
@@ -210,3 +210,17 @@ clickAnimation: foo
   <div v-click.none>modifier-none-overrides-frontmatter</div>
   <div v-click.scale>modifier-scale-overrides-frontmatter</div>
 </div>
+
+---
+
+# Page 17
+
+<div class="cy-code-in-vclick">
+<v-click>
+
+```ts {*}
+const answer = 42
+```
+
+</v-click>
+</div>

--- a/packages/client/builtin/CodeBlockWrapper.vue
+++ b/packages/client/builtin/CodeBlockWrapper.vue
@@ -86,7 +86,7 @@ onMounted(() => {
 
     let rangeStr = props.ranges[index.value] ?? finallyRange.value
     const hide = rangeStr === 'hide'
-    // Don't clear a class we didn't set: a `v-click` on the same element owns it
+    // Only toggle the class when a `hide` range set it, so a click directive on the same element keeps control
     if (hide || hiddenByRange) {
       el.value.classList.toggle(CLASS_VCLICK_HIDDEN, hide)
       hiddenByRange = hide

--- a/packages/client/builtin/CodeBlockWrapper.vue
+++ b/packages/client/builtin/CodeBlockWrapper.vue
@@ -78,13 +78,19 @@ onMounted(() => {
     return props.finally === 'last' ? props.ranges.at(-1) : props.finally.toString()
   })
 
+  let hiddenByRange = false
+
   watchEffect(() => {
     if (!el.value)
       return
 
     let rangeStr = props.ranges[index.value] ?? finallyRange.value
     const hide = rangeStr === 'hide'
-    el.value.classList.toggle(CLASS_VCLICK_HIDDEN, hide)
+    // Don't clear a class we didn't set: a `v-click` on the same element owns it
+    if (hide || hiddenByRange) {
+      el.value.classList.toggle(CLASS_VCLICK_HIDDEN, hide)
+      hiddenByRange = hide
+    }
     if (hide)
       rangeStr = props.ranges[index.value + 1] ?? finallyRange.value
 

--- a/packages/client/builtin/KaTexBlockWrapper.vue
+++ b/packages/client/builtin/KaTexBlockWrapper.vue
@@ -76,7 +76,7 @@ onMounted(() => {
 
     let rangeStr = props.ranges[index.value] ?? finallyRange.value
     const hide = rangeStr === 'hide'
-    // Don't clear a class we didn't set: a `v-click` on the same element owns it
+    // Only toggle the class when a `hide` range set it, so a click directive on the same element keeps control
     if (hide || hiddenByRange) {
       el.value.classList.toggle(CLASS_VCLICK_HIDDEN, hide)
       hiddenByRange = hide

--- a/packages/client/builtin/KaTexBlockWrapper.vue
+++ b/packages/client/builtin/KaTexBlockWrapper.vue
@@ -68,13 +68,19 @@ onMounted(() => {
     return props.finally === 'last' ? props.ranges.at(-1) : props.finally.toString()
   })
 
+  let hiddenByRange = false
+
   watchEffect(() => {
     if (!el.value)
       return
 
     let rangeStr = props.ranges[index.value] ?? finallyRange.value
     const hide = rangeStr === 'hide'
-    el.value.classList.toggle(CLASS_VCLICK_HIDDEN, hide)
+    // Don't clear a class we didn't set: a `v-click` on the same element owns it
+    if (hide || hiddenByRange) {
+      el.value.classList.toggle(CLASS_VCLICK_HIDDEN, hide)
+      hiddenByRange = hide
+    }
     if (hide)
       rangeStr = props.ranges[index.value + 1] ?? finallyRange.value
 


### PR DESCRIPTION
A fenced code block with a line-highlight annotation (```` ```ts {*} ````) placed inside `<v-click>` was already visible on the slide's first render, while the rest of the `<v-click>` content stayed hidden. Navigating one click forward and back fixed it.

`CodeBlockWrapper` gets the `v-click` directive applied to its root element, and the directive's effect adds `slidev-vclick-hidden` there. The wrapper's own effect then calls `classList.toggle(CLASS_VCLICK_HIDDEN, hide)` for its ranges, and for any normal range (`*`, `1-3`, …) that removes the class the directive just added. On mount the wrapper's effect runs last, so the block ends up visible; on later click changes the directive wins, which is why navigating repairs it.

The wrapper now only touches the class when its own `hide` range put it there, so a click directive on the same element keeps ownership. `CLASS_VCLICK_HIDDEN_EXP` isn't usable for this, since `v-click` only sets it on the `.hide` path. `KaTexBlockWrapper` had the same code and gets the same fix.

Added a Cypress case (page 17 of the basic fixture) that asserts the wrapper is hidden on first render and revealed after one click. It fails on `main` and passes here. Also checked a `{hide|1|2}` deck by hand to confirm the `hide` range still hides and reveals as before.

Fixes #2711
