### PR TITLE
fix: parse nested code block options

### DIFF
--- a/packages/slidev/node/syntax/codeblock/parse.test.ts
+++ b/packages/slidev/node/syntax/codeblock/parse.test.ts
@@ -1,0 +1,32 @@
+import { expect, it } from 'vitest'
+import { parseCodeblockInfo } from './parse'
+
+it('parses nested code block options', () => {
+  expect(parseCodeblockInfo(`txt {editorOptions:{lineNumbers:'off'}}`)).toEqual({
+    lang: 'txt',
+    title: '',
+    rangeStr: '',
+    options: `{editorOptions:{lineNumbers:'off'}}`,
+    rest: '',
+  })
+})
+
+it('preserves existing code block info fields and trailing content', () => {
+  expect(parseCodeblockInfo(`ts [filename.ts]{1,2|3}{editorOptions:{lineNumbers:'off'}} trailing`)).toEqual({
+    lang: 'ts',
+    title: 'filename.ts',
+    rangeStr: '1,2|3',
+    options: `{editorOptions:{lineNumbers:'off'}}`,
+    rest: ' trailing',
+  })
+})
+
+it('ignores braces inside option strings', () => {
+  expect(parseCodeblockInfo(`txt {title:'}'}`)).toEqual({
+    lang: 'txt',
+    title: '',
+    rangeStr: '',
+    options: `{title:'}'}`,
+    rest: '',
+  })
+})

--- a/packages/slidev/node/syntax/codeblock/parse.ts
+++ b/packages/slidev/node/syntax/codeblock/parse.ts
@@ -1,0 +1,70 @@
+export interface ParsedCodeblockInfo {
+  lang: string
+  title: string
+  rangeStr: string
+  options?: string
+  rest: string
+}
+
+const RE_BLOCK_INFO_PREFIX = /^([\w'-]+)?(?:[ \t]*|[ \t][ \w\t'-]*)(?:\[([^\]]*)\])?[ \t]*(?:\{([\w,|\-*]+)\})?[ \t]*/
+
+function findBalancedBlockEnd(input: string) {
+  if (input[0] !== '{')
+    return
+
+  let depth = 0
+  let quote: string | undefined
+  let escaped = false
+
+  for (let i = 0; i < input.length; i++) {
+    const char = input[i]
+
+    if (quote) {
+      if (escaped)
+        escaped = false
+      else if (char === '\\')
+        escaped = true
+      else if (char === quote)
+        quote = undefined
+      continue
+    }
+
+    if (char === '"' || char === '\'' || char === '`') {
+      quote = char
+    }
+    else if (char === '{') {
+      depth++
+    }
+    else if (char === '}' && --depth === 0) {
+      return i
+    }
+  }
+}
+
+export function parseCodeblockInfo(info: string): ParsedCodeblockInfo {
+  const match = info.match(RE_BLOCK_INFO_PREFIX)
+  if (!match) {
+    return {
+      lang: '',
+      title: '',
+      rangeStr: '',
+      rest: '',
+    }
+  }
+
+  const [, lang = '', title = '', rangeStr = ''] = match
+  const remainder = info.slice(match[0].length)
+  const optionsEnd = findBalancedBlockEnd(remainder)
+
+  if (optionsEnd == null) {
+    return { lang, title, rangeStr, rest: remainder }
+  }
+
+  return {
+    lang,
+    title,
+    rangeStr,
+    options: remainder.slice(0, optionsEnd + 1),
+    rest: remainder.slice(optionsEnd + 1),
+  }
+}

--- a/packages/slidev/node/syntax/codeblock/wrapper.ts
+++ b/packages/slidev/node/syntax/codeblock/wrapper.ts
@@ -1,11 +1,9 @@
 import { defineCodeblockTransformer } from '@slidev/types'
 import { escapeVueInCode, normalizeRangeStr } from '../utils'
-
-// eslint-disable-next-line regexp/no-super-linear-backtracking
-const RE_BLOCK_INFO = /^([\w'-]+)?(?:[ \t]*|[ \t][ \w\t'-]*)(?:\[([^\]]*)\])?[ \t]*(?:\{([\w,|\-*]+)\})?[ \t]*(\{[^}]*\})?(.*)$/
+import { parseCodeblockInfo } from './parse'
 
 export default defineCodeblockTransformer(async ({ info, renderHighlighted }) => {
-  const [, lang = '', title = '', rangeStr = '', options, rest = ''] = info.match(RE_BLOCK_INFO) ?? []
+  const { lang, title, rangeStr, options, rest } = parseCodeblockInfo(info)
   const ranges = normalizeRangeStr(rangeStr)
   const optionsProp = options ? `v-bind="${options}"` : ''
   const code = await renderHighlighted({ info: `${lang} ${rest}` })


### PR DESCRIPTION
## Summary

Replace the single-level code-block option regex with a balanced parser. Nested object options and braces inside quoted strings are now consumed as one option block without leaving a trailing `}` in rendered code.

## Validation

- `pnpm verify`
- focused nested-option and syntax integration tests
- `git diff --check`

Fixes #1785.