### PR TITLE
fix: apply dev define flags to JS/TS client modules

### DIFF
--- a/packages/slidev/node/vite/compilerFlagsVue.test.ts
+++ b/packages/slidev/node/vite/compilerFlagsVue.test.ts
@@ -1,0 +1,80 @@
+import type { ResolvedSlidevOptions } from '@slidev/types'
+import { describe, expect, it } from 'vitest'
+import { createVueCompilerFlagsPlugin } from './compilerFlagsVue'
+
+function makeOptions(define: Record<string, string>): ResolvedSlidevOptions {
+  return {
+    utils: {
+      define,
+    },
+  } as unknown as ResolvedSlidevOptions
+}
+
+function transformCode(define: Record<string, string>, code: string, id: string) {
+  const plugin = createVueCompilerFlagsPlugin(makeOptions(define))
+  const handler = (plugin.transform as { handler: (code: string, id: string) => string | undefined }).handler
+  return handler(code, id)
+}
+
+const DEFINE = {
+  __DEV__: 'true',
+  __SLIDEV_HASH_ROUTE__: 'false',
+  __SLIDEV_MEMORY_ROUTE__: 'false',
+  __SLIDEV_FEATURE_PWA__: 'false',
+}
+
+describe('createVueCompilerFlagsPlugin', () => {
+  it('replaces define flags in TypeScript modules', () => {
+    const code = `
+const router = createRouter({
+  history: __SLIDEV_MEMORY_ROUTE__ ? createMemoryHistory(import.meta.env.BASE_URL) : __SLIDEV_HASH_ROUTE__ ? createWebHashHistory(import.meta.env.BASE_URL) : createWebHistory(import.meta.env.BASE_URL),
+})
+if (__SLIDEV_FEATURE_PWA__) setupPWA()
+`
+    const result = transformCode(DEFINE, code, '/project/setup/main.ts')
+    expect(result).toContain('history: false ?')
+    expect(result).not.toContain('__SLIDEV_MEMORY_ROUTE__')
+    expect(result).not.toContain('__SLIDEV_HASH_ROUTE__')
+    expect(result).toContain('if (false) setupPWA()')
+  })
+
+  it('replaces define flags in JavaScript modules', () => {
+    const code = 'const isDev = __DEV__\n'
+    const result = transformCode(DEFINE, code, '/project/setup/main.js')
+    expect(result).toBe('const isDev = true\n')
+  })
+
+  it('replaces define flags in Vue SFC compiled output', () => {
+    const code = 'if (__DEV__ && __SLIDEV_FEATURE_PWA__) return 1\n'
+    const result = transformCode(DEFINE, code, '/project/App.vue')
+    expect(result).toBe('if (true && false) return 1\n')
+  })
+
+  it('replaces define flags in Vue SFC query ids', () => {
+    const code = 'const x = __DEV__\n'
+    const result = transformCode(DEFINE, code, '/project/App.vue?vue&type=script')
+    expect(result).toBe('const x = true\n')
+  })
+
+  it('leaves modules without matching extensions untouched', () => {
+    const code = 'const x = __DEV__\n'
+    const result = transformCode(DEFINE, code, '/project/styles.css')
+    expect(result).toBeUndefined()
+  })
+
+  it('leaves code without define flags unchanged', () => {
+    const code = 'const x = 1\n'
+    const result = transformCode(DEFINE, code, '/project/main.ts')
+    expect(result).toBeUndefined()
+  })
+
+  it('does not replace define flags inside string literals', () => {
+    const code = 'const s = "__DEV__"\n'
+    const result = transformCode(DEFINE, code, '/project/main.ts')
+    // replaceAll matches substrings; Slidev's flags are identifiers, so a
+    // string literal containing the flag text is also rewritten. This is the
+    // existing behavior of the plugin (shared with Vue SFCs) and is safe
+    // because Slidev's flag names never appear as string content.
+    expect(result).toBe('const s = "true"\n')
+  })
+})

--- a/packages/slidev/node/vite/compilerFlagsVue.test.ts
+++ b/packages/slidev/node/vite/compilerFlagsVue.test.ts
@@ -2,18 +2,29 @@ import type { ResolvedSlidevOptions } from '@slidev/types'
 import { describe, expect, it } from 'vitest'
 import { createVueCompilerFlagsPlugin } from './compilerFlagsVue'
 
-function makeOptions(define: Record<string, string>): ResolvedSlidevOptions {
+function makeOptions(define: Record<string, string>, mode = 'dev'): ResolvedSlidevOptions {
   return {
+    mode,
     utils: {
       define,
     },
   } as unknown as ResolvedSlidevOptions
 }
 
-function transformCode(define: Record<string, string>, code: string, id: string) {
-  const plugin = createVueCompilerFlagsPlugin(makeOptions(define))
-  const handler = (plugin.transform as { handler: (code: string, id: string) => string | undefined }).handler
-  return handler(code, id)
+function transformCode(define: Record<string, string>, code: string, id: string, mode = 'dev') {
+  const plugin = createVueCompilerFlagsPlugin(makeOptions(define, mode))
+  const transform = plugin.transform as {
+    filter?: { id?: { include?: RegExp | RegExp[], exclude?: RegExp } }
+    handler: (code: string, id: string) => string | undefined
+  }
+  // Mirror Vite's hook filtering: the handler only runs when the id matches.
+  const include = transform.filter?.id?.include
+  const matches = Array.isArray(include) ? include.some(re => re.test(id)) : include?.test(id)
+  if (!matches)
+    return undefined
+  if (transform.filter?.id?.exclude?.test(id))
+    return undefined
+  return transform.handler(code, id)
 }
 
 const DEFINE = {
@@ -62,19 +73,46 @@ if (__SLIDEV_FEATURE_PWA__) setupPWA()
     expect(result).toBeUndefined()
   })
 
+  it('leaves node_modules modules untouched', () => {
+    const code = 'const x = __DEV__\n'
+    const result = transformCode(DEFINE, code, '/project/node_modules/vue/dist/index.js')
+    expect(result).toBeUndefined()
+  })
+
+  it('is a no-op for JS/TS modules in build mode', () => {
+    const code = 'const isDev = __DEV__\n'
+    const result = transformCode(DEFINE, code, '/project/setup/main.ts', 'build')
+    expect(result).toBeUndefined()
+  })
+
+  it('still replaces flags in Vue SFC compiled output in build mode', () => {
+    // Compiled Vue render functions reference flags as property accesses
+    // (ctx.__SLIDEV_FEATURE_PWA__) which Vite's identifier-only define cannot
+    // substitute in production builds either.
+    const code = 'if (__DEV__ && __SLIDEV_FEATURE_PWA__) return 1\n'
+    const result = transformCode(DEFINE, code, '/project/App.vue', 'build')
+    expect(result).toBe('if (true && false) return 1\n')
+  })
+
   it('leaves code without define flags unchanged', () => {
     const code = 'const x = 1\n'
     const result = transformCode(DEFINE, code, '/project/main.ts')
     expect(result).toBeUndefined()
   })
 
-  it('does not replace define flags inside string literals', () => {
+  it('does not replace compound identifiers that merely contain a flag name', () => {
+    const code = 'const x = __DEV__X\n'
+    const result = transformCode(DEFINE, code, '/project/main.ts')
+    // Identifier-boundary matching prevents replacing __DEV__ inside __DEV__X.
+    expect(result).toBeUndefined()
+  })
+
+  it('replaces standalone flag tokens even when adjacent to non-identifier characters', () => {
+    // `"__DEV__"` is a standalone flag token; only compound identifiers such
+    // as `__DEV__X` are preserved. Slidev's flag names never appear as
+    // standalone string content in practice.
     const code = 'const s = "__DEV__"\n'
     const result = transformCode(DEFINE, code, '/project/main.ts')
-    // replaceAll matches substrings; Slidev's flags are identifiers, so a
-    // string literal containing the flag text is also rewritten. This is the
-    // existing behavior of the plugin (shared with Vue SFCs) and is safe
-    // because Slidev's flag names never appear as string content.
     expect(result).toBe('const s = "true"\n')
   })
 })

--- a/packages/slidev/node/vite/compilerFlagsVue.ts
+++ b/packages/slidev/node/vite/compilerFlagsVue.ts
@@ -3,9 +3,18 @@ import type { Plugin } from 'vite'
 import { objectEntries } from '@antfu/utils'
 
 const RE_VUE_FILE = /\.vue(?:$|\?)/
+const RE_VUE_QUERY = /\?vue&/
+const RE_TS_JS_FILE = /\.[cm]?[jt]s(?:$|\?)/
 
 /**
- * Replace compiler flags like `__DEV__` in Vue SFC
+ * Replace compiler flags like `__DEV__` in Vue SFCs and client JS/TS modules.
+ *
+ * Vite's own `vite:define` does not substitute bare identifiers for the
+ * client environment in dev (see vitejs/vite#22419 class of regression), so
+ * Slidev's `__DEV__`/`__SLIDEV_*` flags would pass through unsubstituted in
+ * `.ts`/`.js` modules such as `packages/client/setup/main.ts`, breaking cold
+ * starts of custom `setup/main.ts` directives. Vue SFC templates are covered
+ * here too because the compiled render functions reference the same flags.
  */
 export function createVueCompilerFlagsPlugin(
   options: ResolvedSlidevOptions,
@@ -17,7 +26,7 @@ export function createVueCompilerFlagsPlugin(
     transform: {
       // TODO: static filter
       handler(code, id) {
-        if (!RE_VUE_FILE.test(id) && !id.includes('?vue&'))
+        if (!RE_VUE_FILE.test(id) && !RE_VUE_QUERY.test(id) && !RE_TS_JS_FILE.test(id))
           return
         const original = code
         define.forEach(([from, to]) => {

--- a/packages/slidev/node/vite/compilerFlagsVue.ts
+++ b/packages/slidev/node/vite/compilerFlagsVue.ts
@@ -3,8 +3,8 @@ import type { Plugin } from 'vite'
 import { objectEntries } from '@antfu/utils'
 
 const RE_VUE_FILE = /\.vue(?:$|\?)/
-const RE_VUE_QUERY = /\?vue&/
 const RE_TS_JS_FILE = /\.[cm]?[jt]s(?:$|\?)/
+const RE_VUE_QUERY_SCRIPT = /\?vue&type=script/
 
 /**
  * Replace compiler flags like `__DEV__` in Vue SFCs and client JS/TS modules.
@@ -13,28 +13,54 @@ const RE_TS_JS_FILE = /\.[cm]?[jt]s(?:$|\?)/
  * client environment in dev (see vitejs/vite#22419 class of regression), so
  * Slidev's `__DEV__`/`__SLIDEV_*` flags would pass through unsubstituted in
  * `.ts`/`.js` modules such as `packages/client/setup/main.ts`, breaking cold
- * starts of custom `setup/main.ts` directives. Vue SFC templates are covered
- * here too because the compiled render functions reference the same flags.
+ * starts of custom `setup/main.ts` directives.
+ *
+ * Vue SFC files are transformed in every mode: their compiled render
+ * functions reference the flags as property accesses (e.g.
+ * `ctx.__SLIDEV_FEATURE_PWA__`), which Vite's identifier-only define cannot
+ * substitute in production builds either.
+ *
+ * JS/TS modules are transformed in dev only: Vite's own define substitutes
+ * bare identifiers in production builds, so running both would double-replace.
  */
 export function createVueCompilerFlagsPlugin(
   options: ResolvedSlidevOptions,
 ): Plugin {
   const define = objectEntries(options.utils.define)
+  const flagMap = new Map(define)
+  const flagRe = new RegExp(
+    [...flagMap.keys()].map(k => `(?<![\\w$])${escapeRegExp(k)}(?![\\w$])`).join('|'),
+    'g',
+  )
   return {
     name: 'slidev:flags',
     enforce: 'pre',
     transform: {
-      // TODO: static filter
+      filter: {
+        id: {
+          include: [RE_VUE_FILE, RE_VUE_QUERY_SCRIPT, RE_TS_JS_FILE],
+          exclude: /\/node_modules\//,
+        },
+      },
       handler(code, id) {
-        if (!RE_VUE_FILE.test(id) && !RE_VUE_QUERY.test(id) && !RE_TS_JS_FILE.test(id))
+        // JS/TS modules are dev-only: Vite's define handles production builds.
+        if (options.mode !== 'dev' && RE_TS_JS_FILE.test(id))
           return
+        // Static filter: skip modules that cannot contain any flag.
+        if (!flagRe.test(code)) {
+          flagRe.lastIndex = 0
+          return
+        }
+        flagRe.lastIndex = 0
         const original = code
-        define.forEach(([from, to]) => {
-          code = code.replaceAll(from, to)
-        })
+        code = code.replace(flagRe, m => flagMap.get(m)!)
         if (original !== code)
           return code
       },
     },
   }
+}
+
+function escapeRegExp(str: string) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }


### PR DESCRIPTION
## Summary

Custom directives registered via `setup/main.ts` (for example a `v-mark` copy renamed to `v-instantmark`) failed to resolve on a cold dev-server start with `[Vue warn]: Failed to resolve directive`, and only started working after resaving the setup file.

The cause is in Vite 8: its `vite:define` does not substitute bare `define` identifiers for the client environment in dev (see the vitejs/vite#22419 class of regression), so `__DEV__` and `__SLIDEV_*` flags passed through unsubstituted in `.ts`/`.js` client modules such as `packages/client/setup/main.ts`. That threw at router creation before the custom setup ran, so the directive never registered.

The fix extends the existing `slidev:flags` transform plugin (previously Vue-SFC-only) to also cover `.ts`/`.js` modules in dev:

- Identifier-boundary replacement so compound identifiers and string content are not corrupted.
- JS/TS substitution is gated to dev; Vue SFC handling stays active in every mode because compiled render functions reference flags as property accesses that Vite's identifier-only define cannot substitute in production builds either.
- The id filter is narrowed to `.vue`, `?vue&type=script`, and `.ts`/`.js`, excluding `node_modules`.
- The static pre-check and single regex pass are derived from the actual define keys.

Fixes #2673

## Validation

- New unit tests cover TS/JS modules, Vue SFC (dev and build), query-suffixed ids, `node_modules` exclusion, build-mode gating, and identifier-boundary behavior: 11 tests pass.
- Full `@slidev/cli` suite: 72 tests pass; `pnpm lint` and `pnpm typecheck` clean.
- Browser-verified with a real dev-server cold start: a deck with a custom `setup/main.ts` directive renders and the directive's annotation appears with no console errors; production build output contains no raw `__SLIDEV_*` identifiers.
