### PR TITLE
fix(client): declare markdown-it-github-alerts as a dependency

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -56,6 +56,7 @@
     "fuse.js": "catalog:frontend",
     "katex": "catalog:frontend",
     "lz-string": "catalog:frontend",
+    "markdown-it-github-alerts": "catalog:prod",
     "mermaid": "catalog:frontend",
     "monaco-editor": "catalog:monaco",
     "nanotar": "catalog:frontend",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -857,6 +857,9 @@ importers:
       lz-string:
         specifier: catalog:frontend
         version: 1.5.0
+      markdown-it-github-alerts:
+        specifier: catalog:prod
+        version: 1.0.1(markdown-it@14.3.0)
       mermaid:
         specifier: catalog:frontend
         version: 11.16.1


### PR DESCRIPTION
### Description

`packages/client/styles/index.ts` imports the stylesheets of `markdown-it-github-alerts` (since #2547):

```ts
import 'markdown-it-github-alerts/styles/github-colors-light.css'
import 'markdown-it-github-alerts/styles/github-colors-dark-media.css'
import 'markdown-it-github-alerts/styles/github-base.css'
```

but `@slidev/client` only gets the package through hoisting: it is declared in `packages/slidev/package.json`, not in `packages/client/package.json`. With a package manager layout that does not hoist transitive dependencies next to `@slidev/client` (e.g. Bun's isolated linker with its global store, where each package can only see its declared dependencies), `slidev build` fails with:

```
Error: [vite]: Rolldown failed to resolve import "markdown-it-github-alerts/styles/github-colors-light.css" from ".../node_modules/@slidev/client/styles/index.ts".
```

This PR declares `markdown-it-github-alerts` in `@slidev/client` via the existing `catalog:prod` entry, so the import resolves regardless of hoisting. `pnpm verify` passes locally.

### Linked Issues

Related to #2547 (which introduced the import).

### Additional context

Reproduced with `@slidev/cli@52.19.0` installed by Bun 1.4.0 with `linker = "isolated"` and `globalStore = true`.