### PR TITLE
fix(create-app): detect the running package manager via getUserAgent

### DIFF
--- a/packages/create-app/index.mjs
+++ b/packages/create-app/index.mjs
@@ -8,7 +8,7 @@ import process from 'node:process'
 import { fileURLToPath } from 'node:url'
 import { blue, bold, cyan, dim, green, yellow } from 'ansis'
 import minimist from 'minimist'
-import { detect } from 'package-manager-detector/detect'
+import { getUserAgent } from 'package-manager-detector/detect'
 import path from 'pathe'
 import prompts from 'prompts'
 import { x } from 'tinyexec'
@@ -96,7 +96,7 @@ async function init() {
 
   console.log(green('  Done.\n'))
 
-  const pkgManager = await detect().catch(() => undefined) ?? 'npm'
+  const pkgManager = getUserAgent() ?? 'npm'
 
   /**
    * @type {{ yes: boolean }}


### PR DESCRIPTION
## Summary

`create-slidev` currently stringifies the package manager as `[object Object]`, then crashes with `ERR_INVALID_ARG_TYPE` if you choose to install immediately.

This restores `getUserAgent()` (the package manager that is running `create-slidev`) instead of `detect()` (lockfile lookup up the directory tree). If nothing is detected, it still falls back to npm, which is the #2703 fix for `null install` when the script is run with plain Node.

## Background

On current `create-slidev` (v52.19.1), scaffolding succeeds but the follow-up install crashes:

```
❯ bun create slidev

  ●■▲
  Slidev Creator  v52.19.1

✔ Project name: … slidev-sample
  Scaffolding project in slidev-sample ...
  Done.

✔ Install and start it now using [object Object]? … yes
TypeError [ERR_INVALID_ARG_TYPE]: The "file" argument must be of type string. Received an instance of Object
    at normalizeSpawnArguments (node:child_process:539:3)
    at spawn (node:child_process:746:13)
    at ExecProcess.spawn (.../tinyexec/dist/main.mjs:321:18)
    at x (.../tinyexec/dist/main.mjs:404:7)
    at init (.../create-slidev/index.mjs:116:11)
    {
      code: 'ERR_INVALID_ARG_TYPE'
    }
```

The prompt shows `[object Object]`. Answering yes spawns that object as the command. Answering no prints `[object Object] install` / `[object Object] run dev`. The template is already written, so a manual `bun install` still works.

#2703 was meant to fix the case where running `create-slidev` directly with Node detects no package manager, so the later-install hints became `null install` / `null run dev`. The author, following review, used:

```js
const pkgManager = getUserAgent() ?? 'npm'
```

antfu suggested that same line. A later `chore: update` on the PR swapped it to `detect()` and then used the return value as a command name. There is no note that detection should switch to lockfiles.

That produced:

- `using [object Object]?` in the prompt
- a crash on yes, because `tinyexec` tries to spawn an object
- detection of the lockfile in cwd / parents, instead of the package manager that launched `create-slidev`

The intent recorded in #2516 was to detect the package manager running `create-slidev`.

## Change

`packages/create-app/index.mjs` only:

```js
const pkgManager = getUserAgent() ?? 'npm'
```

## Test plan

Verified locally:

- [x] `bun run create-slidev` (or `bun create slidev`) shows `using bun?` and does not throw if you answer yes
- [x] `pnpm create slidev` / `npm init slidev` show pnpm / npm respectively
- [x] `node packages/create-app/index.mjs` with no user agent shows `using npm?` (#2703 fallback)
- [x] Answering no writes the real package manager name into the hints and README, not `[object Object]`