### PR TITLE
feat(export): editable PPTX export with native shapes and text

### DIFF
--- a/docs/builtin/cli.md
+++ b/docs/builtin/cli.md
@@ -70,7 +70,7 @@ Export slides to PDF (or other format). See <LinkInline link="guide/exporting" /
 Options:
 
 - `--output` (`string`, default: use `exportFilename` (see https://sli.dev/custom/#frontmatter-configures) or use `[entry]-export`): path to the output.
-- `--format` (`'pdf', 'png', 'pptx', 'md'`, default: `'pdf'`): output format.
+- `--format` (`'pdf', 'png', 'pptx', 'pptx-editable', 'md'`, default: `'pdf'`): output format. `pptx` exports each slide as an image; `pptx-editable` rebuilds them as native PowerPoint shapes with selectable text.
 - `--timeout` (`number`, default: `30000`): timeout for rendering the print page (see https://playwright.dev/docs/api/class-page#page-goto).
 - `--range` (`string`): page ranges to export (example: `'1,4-5,6'`).
 - `--dark` (`boolean`, default: `false`): export as dark theme.

--- a/docs/guide/exporting.md
+++ b/docs/guide/exporting.md
@@ -90,6 +90,7 @@ Two things worth knowing before you send the file on:
 
 - A `.pptx` names fonts, it does not embed them. The export prints which font families it referenced; recipients need those installed or PowerPoint will substitute.
 - PowerPoint does not measure text exactly as a browser does, so a long paragraph may wrap onto a different number of lines.
+- Decorations a theme draws with `::before` or `::after` in normal flow are left out, and the export lists them. Code block line numbers are one of these: they come from a CSS counter, which has no text and no box that a computed style can report.
 
 `--per-slide` is not supported with this format.
 

--- a/docs/guide/exporting.md
+++ b/docs/guide/exporting.md
@@ -72,6 +72,27 @@ Note that all the slides in the PPTX file will be exported as images, so the tex
 
 In this mode, the `--with-clicks` option is enabled by default. To disable it, pass `--with-clicks false`.
 
+### Editable PPTX
+
+If the recipient needs to edit the deck rather than only present it, export it with native shapes instead of pictures:
+
+```bash
+$ slidev export --format pptx-editable
+```
+
+The slides are measured in the browser and rebuilt as PowerPoint shapes, so text is selectable and editable, boxes can be moved and recoloured, and presenter notes are carried over as usual. This does not replace `--format pptx`, which stays the most visually faithful option.
+
+What stays a picture: anything PowerPoint has no equivalent for. That includes SVG (so Mermaid diagrams and icons), `<canvas>`, `<iframe>`, videos, CSS gradients, `filter`, `backdrop-filter`, `mix-blend-mode` and `clip-path`. Only the element concerned becomes a picture, not the whole slide.
+
+If a slide cannot be rebuilt safely, or ends up mostly pictures anyway, it falls back to the same image export used by `--format pptx`, for that slide alone, and the reason is printed.
+
+Two things worth knowing before you send the file on:
+
+- A `.pptx` names fonts, it does not embed them. The export prints which font families it referenced; recipients need those installed or PowerPoint will substitute.
+- PowerPoint does not measure text exactly as a browser does, so a long paragraph may wrap onto a different number of lines.
+
+`--per-slide` is not supported with this format.
+
 ### PNGs and Markdown
 
 When passing in the `--format png` option, Slidev will export PNG images for each slide instead of a PDF:

--- a/docs/guide/exporting.md
+++ b/docs/guide/exporting.md
@@ -80,19 +80,19 @@ If the recipient needs to edit the deck rather than only present it, export it w
 $ slidev export --format pptx-editable
 ```
 
-The slides are measured in the browser and rebuilt as PowerPoint shapes, so text is selectable and editable, boxes can be moved and recoloured, and presenter notes are carried over as usual. This does not replace `--format pptx`, which stays the most visually faithful option.
+The slides are measured in the browser and rebuilt as PowerPoint shapes, so text is selectable and editable, boxes can be moved and recolored, and presenter notes are carried over as usual. This does not replace `--format pptx`, which stays the most visually faithful option.
 
-What stays a picture: anything PowerPoint has no equivalent for. That includes SVG (so Mermaid diagrams and icons), `<canvas>`, `<iframe>`, videos, CSS gradients, `filter`, `backdrop-filter`, `mix-blend-mode` and `clip-path`. Only the element concerned becomes a picture, not the whole slide.
+What stays a picture: anything PowerPoint has no equivalent for. That includes SVG (so Mermaid diagrams and icons), `<canvas>`, `<iframe>`, videos, KaTeX formulas, CSS gradients, `filter`, `backdrop-filter`, `mix-blend-mode` and `clip-path`. Only the element concerned becomes a picture, not the whole slide.
 
 If a slide cannot be rebuilt safely, or ends up mostly pictures anyway, it falls back to the same image export used by `--format pptx`, for that slide alone, and the reason is printed.
 
-Two things worth knowing before you send the file on:
+Worth knowing before you send the file on:
 
 - A `.pptx` names fonts, it does not embed them. The export prints which font families it referenced; recipients need those installed or PowerPoint will substitute.
 - PowerPoint does not measure text exactly as a browser does, so a long paragraph may wrap onto a different number of lines.
 - Decorations a theme draws with `::before` or `::after` in normal flow are left out, and the export lists them. Code block line numbers are one of these: they come from a CSS counter, which has no text and no box that a computed style can report.
 
-`--per-slide` is not supported with this format.
+Like `--format pptx`, this exports one slide per click step unless you pass `--with-clicks false`. `--per-slide` is not supported with it.
 
 ### PNGs and Markdown
 

--- a/packages/slidev/node/cli.ts
+++ b/packages/slidev/node/cli.ts
@@ -633,7 +633,7 @@ function exportOptions<T>(args: Argv<T>) {
     })
     .option('format', {
       type: 'string',
-      choices: ['pdf', 'png', 'pptx', 'md'],
+      choices: ['pdf', 'png', 'pptx', 'pptx-editable', 'md'],
       describe: 'output format',
     })
     .option('timeout', {

--- a/packages/slidev/node/commands/export.ts
+++ b/packages/slidev/node/commands/export.ts
@@ -576,6 +576,10 @@ export async function exportSlides({
       console.warn(yellow(`  slide ${slide.no}: exported as an image (${slide.reason})`))
     if (result.imagesDropped)
       console.warn(yellow(`  ${result.imagesDropped} image(s) could not be read and were left out`))
+    // Silent until now. A failed capture leaves no shape and no picture, so a
+    // decoration just disappeared and nothing in the output said why.
+    if (result.rastersFailed)
+      console.warn(yellow(`  ${result.rastersFailed} element(s) could not be captured as a picture and were left out`))
     if (result.unparsedColors.length) {
       console.warn(yellow(`  ${result.unparsedColors.length} colour value(s) could not be read, so those fills are missing:`))
       console.warn(dim(`    ${result.unparsedColors.slice(0, 5).join(', ')}`))

--- a/packages/slidev/node/commands/export.ts
+++ b/packages/slidev/node/commands/export.ts
@@ -575,6 +575,10 @@ export async function exportSlides({
       console.warn(yellow(`  ${result.unparsedColors.length} colour value(s) could not be read, so those fills are missing:`))
       console.warn(dim(`    ${result.unparsedColors.slice(0, 5).join(', ')}`))
     }
+    if (result.unplaceablePseudos.length) {
+      console.warn(yellow(`  ${result.unplaceablePseudos.length} CSS decoration(s) could not be placed and were left out:`))
+      console.warn(dim(`    ${result.unplaceablePseudos.slice(0, 5).join(', ')}`))
+    }
     if (result.fontsNamed.length) {
       console.warn(dim(`  fonts named in this file: ${result.fontsNamed.join(', ')}`))
       console.warn(dim('  a .pptx names fonts rather than embedding them, so recipients need these installed'))

--- a/packages/slidev/node/commands/export.ts
+++ b/packages/slidev/node/commands/export.ts
@@ -547,54 +547,24 @@ export async function exportSlides({
     await fs.writeFile(output, buffer)
   }
 
-  // Native shapes and editable text, rather than one picture per slide.
-  //
-  // The implementation lives in ./pptx so this stays a delegation: the walker,
-  // the normalizer and the builder are each pure and separately testable, and
-  // none of them belongs inside this function.
+  // Native shapes and editable text, rather than one picture per slide. The
+  // walker, normalizer and builder live in ./pptx, so this is a delegation.
   async function genPagePptxEditable() {
     if (perSlide) {
-      // Per-slide mode navigates to one slide at a time and never renders the
-      // print page the measurement depends on. Failing loudly beats writing a
-      // deck that is silently missing every slide but the first.
+      // Per-slide mode never renders the print page the measurement depends
+      // on. Failing beats writing a deck missing every slide but the first.
       throw new Error('[slidev] `--per-slide` is not supported with `--format pptx-editable`')
     }
 
-    const { exportPptxEditable } = await import('./pptx')
+    const { exportPptxEditable, reportEditableExport } = await import('./pptx')
     const result = await exportPptxEditable({ page, slides, width, height, pages, go }, output)
     // So the "exported to ..." line names the file that was actually written.
     output = result.output
 
     // The progress bar repaints on a timer with the cursor hidden, so anything
-    // written while it is running is interleaved with it or overwritten. These
-    // are warnings the author has to actually read.
+    // written while it runs is interleaved with it or overwritten.
     progress.stop()
-
-    // Warnings, not progress: each line is a caveat the author has to know
-    // about before the file reaches anyone else.
-    for (const slide of result.fallbackSlides)
-      console.warn(yellow(`  slide ${slide.no}: exported as an image (${slide.reason})`))
-    if (result.imagesDropped)
-      console.warn(yellow(`  ${result.imagesDropped} image(s) could not be read and were left out`))
-    // Silent until now. A failed capture leaves no shape and no picture, so a
-    // decoration just disappeared and nothing in the output said why.
-    if (result.rastersFailed)
-      console.warn(yellow(`  ${result.rastersFailed} element(s) could not be captured as a picture and were left out`))
-    if (result.unparsedColors.length) {
-      console.warn(yellow(`  ${result.unparsedColors.length} colour value(s) could not be read, so those fills are missing:`))
-      console.warn(dim(`    ${result.unparsedColors.slice(0, 5).join(', ')}`))
-    }
-    if (result.isolationMissed) {
-      console.warn(yellow(`  ${result.isolationMissed} picture(s) could not be isolated, so their slide may show doubled text`))
-    }
-    if (result.unplaceablePseudos.length) {
-      console.warn(yellow(`  ${result.unplaceablePseudos.length} CSS decoration(s) could not be placed and were left out:`))
-      console.warn(dim(`    ${result.unplaceablePseudos.slice(0, 5).join(', ')}`))
-    }
-    if (result.fontsNamed.length) {
-      console.warn(dim(`  fonts named in this file: ${result.fontsNamed.join(', ')}`))
-      console.warn(dim('  a .pptx names fonts rather than embedding them, so recipients need these installed'))
-    }
+    reportEditableExport(result)
   }
 
   // Adds metadata (title, author, keywords) to PDF document, mutating it

--- a/packages/slidev/node/commands/export.ts
+++ b/packages/slidev/node/commands/export.ts
@@ -21,7 +21,7 @@ export interface ExportOptions {
   slides: SlideInfo[]
   port?: number
   base?: string
-  format?: 'pdf' | 'png' | 'pptx' | 'md'
+  format?: 'pdf' | 'png' | 'pptx' | 'pptx-editable' | 'md'
   output?: string
   timeout?: number
   wait?: number
@@ -220,6 +220,9 @@ export async function exportSlides({
     else if (format === 'pptx') {
       const buffers = await genPagePng(false)
       await genPagePptx(buffers)
+    }
+    else if (format === 'pptx-editable') {
+      await genPagePptxEditable()
     }
     else {
       throw new Error(`[slidev] Unsupported exporting format "${format}"`)
@@ -544,6 +547,40 @@ export async function exportSlides({
     await fs.writeFile(output, buffer)
   }
 
+  // Native shapes and editable text, rather than one picture per slide.
+  //
+  // The implementation lives in ./pptx so this stays a delegation: the walker,
+  // the normalizer and the builder are each pure and separately testable, and
+  // none of them belongs inside this function.
+  async function genPagePptxEditable() {
+    if (perSlide) {
+      // Per-slide mode navigates to one slide at a time and never renders the
+      // print page the measurement depends on. Failing loudly beats writing a
+      // deck that is silently missing every slide but the first.
+      throw new Error('[slidev] `--per-slide` is not supported with `--format pptx-editable`')
+    }
+
+    const { exportPptxEditable } = await import('./pptx')
+    const result = await exportPptxEditable({ page, slides, width, height, pages, go }, output)
+    // So the "exported to ..." line names the file that was actually written.
+    output = result.output
+
+    // Warnings, not progress: each line is a caveat the author has to know
+    // about before the file reaches anyone else.
+    for (const slide of result.fallbackSlides)
+      console.warn(yellow(`  slide ${slide.no}: exported as an image (${slide.reason})`))
+    if (result.imagesDropped)
+      console.warn(yellow(`  ${result.imagesDropped} image(s) could not be read and were left out`))
+    if (result.unparsedColors.length) {
+      console.warn(yellow(`  ${result.unparsedColors.length} colour value(s) could not be read, so those fills are missing:`))
+      console.warn(dim(`    ${result.unparsedColors.slice(0, 5).join(', ')}`))
+    }
+    if (result.fontsNamed.length) {
+      console.warn(dim(`  fonts named in this file: ${result.fontsNamed.join(', ')}`))
+      console.warn(dim('  a .pptx names fonts rather than embedding them, so recipients need these installed'))
+    }
+  }
+
   // Adds metadata (title, author, keywords) to PDF document, mutating it
   function addPdfMetadata(pdf: PDFDocument): void {
     const titleSlide = slides[0]
@@ -612,7 +649,7 @@ export function getExportOptions(args: ExportArgs, options: ResolvedSlidevOption
     slides: options.data.slides,
     total: options.data.slides.length,
     range,
-    format: (format || 'pdf') as 'pdf' | 'png' | 'pptx' | 'md',
+    format: (format || 'pdf') as 'pdf' | 'png' | 'pptx' | 'pptx-editable' | 'md',
     timeout: timeout ?? 30000,
     wait: wait ?? 0,
     waitUntil: waitUntil === 'none' ? undefined : (waitUntil ?? 'networkidle') as 'networkidle' | 'load' | 'domcontentloaded',
@@ -621,7 +658,9 @@ export function getExportOptions(args: ExportArgs, options: ResolvedSlidevOption
     routerMode: options.data.config.routerMode === 'memory' ? 'history' : options.data.config.routerMode,
     width: options.data.config.canvasWidth,
     height: Math.round(options.data.config.canvasWidth / options.data.config.aspectRatio),
-    withClicks: withClicks ?? format === 'pptx',
+    // Both pptx formats default to one slide per click step. Testing the
+    // exact string here silently collapsed click steps for the editable one.
+    withClicks: withClicks ?? !!format?.startsWith('pptx'),
     executablePath,
     withToc: withToc || false,
     perSlide: perSlide || false,

--- a/packages/slidev/node/commands/export.ts
+++ b/packages/slidev/node/commands/export.ts
@@ -565,6 +565,11 @@ export async function exportSlides({
     // So the "exported to ..." line names the file that was actually written.
     output = result.output
 
+    // The progress bar repaints on a timer with the cursor hidden, so anything
+    // written while it is running is interleaved with it or overwritten. These
+    // are warnings the author has to actually read.
+    progress.stop()
+
     // Warnings, not progress: each line is a caveat the author has to know
     // about before the file reaches anyone else.
     for (const slide of result.fallbackSlides)
@@ -574,6 +579,9 @@ export async function exportSlides({
     if (result.unparsedColors.length) {
       console.warn(yellow(`  ${result.unparsedColors.length} colour value(s) could not be read, so those fills are missing:`))
       console.warn(dim(`    ${result.unparsedColors.slice(0, 5).join(', ')}`))
+    }
+    if (result.isolationMissed) {
+      console.warn(yellow(`  ${result.isolationMissed} picture(s) could not be isolated, so their slide may show doubled text`))
     }
     if (result.unplaceablePseudos.length) {
       console.warn(yellow(`  ${result.unplaceablePseudos.length} CSS decoration(s) could not be placed and were left out:`))

--- a/packages/slidev/node/commands/pptx/build.test.ts
+++ b/packages/slidev/node/commands/pptx/build.test.ts
@@ -160,11 +160,11 @@ describe('text', () => {
     expect(xml).not.toContain('\v')
   })
 
-  it('keeps the midpoint of a centred line when adding slack', async () => {
-    const centred = { ...textNode([{ text: 'x', fontSize: 16, fontFamily: 'Arial' }]), align: 'center' }
-    const xml = await slideXml([slide([centred])])
+  it('keeps the midpoint of a centered line when adding slack', async () => {
+    const centered = { ...textNode([{ text: 'x', fontSize: 16, fontFamily: 'Arial' }]), align: 'center' }
+    const xml = await slideXml([slide([centered])])
     // The box is widened by 12px so PowerPoint's wider metrics do not force a
-    // wrap, so its origin moves left by half of that to hold the centre still.
+    // wrap, so its origin moves left by half of that to hold the center still.
     expect(xml).toContain('x="-57150"') // -6 * 9525
     expect(xml).toContain('cx="2019300"') // 212 * 9525
   })

--- a/packages/slidev/node/commands/pptx/build.test.ts
+++ b/packages/slidev/node/commands/pptx/build.test.ts
@@ -211,3 +211,24 @@ describe('slide assembly', () => {
     expect(xml).toContain('<a:t>Selectable</a:t>')
   })
 })
+
+describe('a hyperlink is not underlined unless CSS says so', () => {
+  it('suppresses the underline pptxgenjs adds to every link', async () => {
+    // pptxgenjs writes `u="sng"` for any run carrying a hyperlink unless
+    // `underline` is set. Slidev's own themes rule links with a dashed
+    // `border-bottom`, which is already drawn as its own shape, so the deck
+    // came out with two lines under every link.
+    const xml = await slideXml([
+      slide([textNode([{ text: 'Documentation', fontSize: 16, fontFamily: 'Arial', link: 'https://sli.dev' }])]),
+    ])
+    expect(xml).toContain('u="none"')
+    expect(xml).not.toContain('u="sng"')
+  })
+
+  it('still underlines a run whose CSS asks for it', async () => {
+    const xml = await slideXml([
+      slide([textNode([{ text: 'Documentation', fontSize: 16, fontFamily: 'Arial', link: 'https://sli.dev', underline: true }])]),
+    ])
+    expect(xml).toContain('u="sng"')
+  })
+})

--- a/packages/slidev/node/commands/pptx/build.test.ts
+++ b/packages/slidev/node/commands/pptx/build.test.ts
@@ -141,9 +141,12 @@ describe('fills and borders', () => {
         borders: [thick, undefined, undefined, undefined],
       }]),
     ])
-    // The box plus one edge. pptxgenjs gives a shape a single uniform border,
-    // so a left-accent bar or a single top rule has to be its own rectangle.
-    expect(xml.match(/<p:sp>/g)).toHaveLength(2)
+    // Just the edge. pptxgenjs gives a shape a single uniform border, so a
+    // left-accent bar or a single top rule has to be its own rectangle, and
+    // the box that would have carried it has neither fill nor border left to
+    // draw. Emitting it anyway left PowerPoint to resolve a shape with no fill
+    // and no outline from its default style.
+    expect(xml.match(/<p:sp>/g)).toHaveLength(1)
     expect(xml).toContain('cy="38100"') // the 4px edge: 4 * 9525
   })
 })
@@ -262,5 +265,27 @@ describe('a dashed border keeps its dashes', () => {
       }]),
     ])
     expect(xml).not.toContain('prst="line"')
+  })
+})
+
+describe('a fill is stated, never inherited', () => {
+  it('writes an explicit noFill for a shape that has none', async () => {
+    // pptxgenjs writes `<a:noFill/>` for an ABSENT fill and nothing at all for
+    // `{ type: 'none' }`, so the explicit-looking version was the one that
+    // inherited the default shape style.
+    const xml = await slideXml([
+      slide([{
+        kind: 'box',
+        sourceId: 1,
+        rect: { x: 0, y: 0, w: 100, h: 100 },
+        borders: [
+          { width: 1, color: BLACK, style: 'solid' as const },
+          { width: 1, color: BLACK, style: 'solid' as const },
+          { width: 1, color: BLACK, style: 'solid' as const },
+          { width: 1, color: BLACK, style: 'solid' as const },
+        ],
+      }]),
+    ])
+    expect(xml).toContain('<a:noFill/>')
   })
 })

--- a/packages/slidev/node/commands/pptx/build.test.ts
+++ b/packages/slidev/node/commands/pptx/build.test.ts
@@ -1,0 +1,213 @@
+import type { SlideIr } from './ir'
+import JSZip from 'jszip'
+import PptxGenJS from 'pptxgenjs'
+import { describe, expect, it } from 'vitest'
+import { buildPptx } from './build'
+
+/**
+ * These assert on the generated OOXML, not on the JavaScript that produced it.
+ *
+ * That is deliberate: every bug this file exists to catch is a unit conversion,
+ * and a unit conversion looks correct in the source right up until you read
+ * what it wrote. `sz="2400"` is checkable against the spec; `pt(fontSize)` is
+ * not.
+ */
+
+const BLACK = { r: 0, g: 0, b: 0, a: 1 }
+
+function slide(nodes: SlideIr['nodes']): SlideIr {
+  return { no: 1, clickIndex: 0, containerId: '001-01', size: { w: 980, h: 552 }, nodes }
+}
+
+async function slideXml(ir: SlideIr[]): Promise<string> {
+  const buffer = await buildPptx(PptxGenJS, ir, { width: 980, height: 552 })
+  const zip = await JSZip.loadAsync(buffer)
+  return await zip.file('ppt/slides/slide1.xml')!.async('string')
+}
+
+function textNode(runs: SlideIr['nodes'][number] extends never ? never : any): any {
+  return {
+    kind: 'text',
+    sourceId: 1,
+    rect: { x: 0, y: 0, w: 200, h: 40 },
+    elementRect: { x: 0, y: 0, w: 200, h: 40 },
+    lineCount: 1,
+    align: 'left',
+    lineHeight: 40,
+    runs,
+  }
+}
+
+describe('unit conversions', () => {
+  it('writes font size in points, not pixels', async () => {
+    const xml = await slideXml([
+      slide([textNode([{ text: 'Hello', fontSize: 32, fontFamily: 'Arial' }])]),
+    ])
+    // 32 CSS px at 96 px/in is 24 pt, and OOXML stores hundredths of a point.
+    // Getting this wrong makes every deck a third too large.
+    expect(xml).toContain('sz="2400"')
+  })
+
+  it('writes letter spacing in points and disables kerning', async () => {
+    const xml = await slideXml([
+      slide([textNode([{ text: 'WIDE', fontSize: 16, fontFamily: 'Arial', letterSpacing: 2 }])]),
+    ])
+    // 2px -> 1.5pt -> spc is hundredths of a point.
+    expect(xml).toContain('spc="150"')
+    expect(xml).toContain('kern="0"')
+  })
+
+  it('places geometry at exactly 9525 EMU per pixel', async () => {
+    const xml = await slideXml([
+      slide([{
+        kind: 'box',
+        sourceId: 1,
+        rect: { x: 100, y: 50, w: 200, h: 25 },
+        fill: BLACK,
+      }]),
+    ])
+    // Integer EMU throughout, so there is no rounding drift to chase later.
+    expect(xml).toContain('x="952500"') // 100 * 9525
+    expect(xml).toContain('y="476250"') // 50 * 9525
+    expect(xml).toContain('cx="1905000"') // 200 * 9525
+    expect(xml).toContain('cy="238125"') // 25 * 9525
+  })
+
+  it('writes a corner radius that is not zero', async () => {
+    const xml = await slideXml([
+      slide([{
+        kind: 'box',
+        sourceId: 1,
+        rect: { x: 0, y: 0, w: 200, h: 100 },
+        fill: BLACK,
+        radius: 12,
+      }]),
+    ])
+    expect(xml).toContain('prst="roundRect"')
+    // OOXML states the corner adjustment as hundred-thousandths of the shorter
+    // side. 12px of a 100px side is 12%, so exactly 12000.
+    //
+    // Asserted exactly, not as "greater than zero": `rectRadius` is documented
+    // as a 0.0-1.0 fraction but is really inches, and the wrong reading still
+    // produces a non-zero adjustment (11520 here). A loose assertion passes on
+    // both and pins nothing, which is what this test caught the first time.
+    expect(xml).toContain('<a:gd name="adj" fmla="val 12000"/>')
+  })
+})
+
+describe('fills and borders', () => {
+  it('maps alpha to transparency', async () => {
+    const xml = await slideXml([
+      slide([{
+        kind: 'box',
+        sourceId: 1,
+        rect: { x: 0, y: 0, w: 10, h: 10 },
+        fill: { r: 255, g: 0, b: 0, a: 0.6 },
+      }]),
+    ])
+    // 0.6 opacity is 40% transparent, and OOXML alpha is the inverse again,
+    // in thousandths of a percent.
+    expect(xml).toContain('<a:alpha val="60000"/>')
+  })
+
+  it('emits no alpha element for an opaque fill', async () => {
+    const xml = await slideXml([
+      slide([{ kind: 'box', sourceId: 1, rect: { x: 0, y: 0, w: 10, h: 10 }, fill: BLACK }]),
+    ])
+    expect(xml).not.toContain('<a:alpha')
+  })
+
+  it('uses one uniform line when all four borders match', async () => {
+    const border = { width: 2, color: BLACK, style: 'solid' as const }
+    const xml = await slideXml([
+      slide([{
+        kind: 'box',
+        sourceId: 1,
+        rect: { x: 0, y: 0, w: 100, h: 100 },
+        borders: [border, border, border, border],
+      }]),
+    ])
+    // One shape, not five.
+    expect(xml.match(/<p:sp>/g)).toHaveLength(1)
+  })
+
+  it('splits differing borders into one rectangle per side', async () => {
+    const thick = { width: 4, color: BLACK, style: 'solid' as const }
+    const xml = await slideXml([
+      slide([{
+        kind: 'box',
+        sourceId: 1,
+        rect: { x: 0, y: 0, w: 100, h: 100 },
+        borders: [thick, undefined, undefined, undefined],
+      }]),
+    ])
+    // The box plus one edge. pptxgenjs gives a shape a single uniform border,
+    // so a left-accent bar or a single top rule has to be its own rectangle.
+    expect(xml.match(/<p:sp>/g)).toHaveLength(2)
+    expect(xml).toContain('cy="38100"') // the 4px edge: 4 * 9525
+  })
+})
+
+describe('text', () => {
+  it('emits a real line break for a soft break, not a vertical tab', async () => {
+    const xml = await slideXml([
+      slide([textNode([
+        { text: 'first', fontSize: 16, fontFamily: 'Arial' },
+        { text: 'second', fontSize: 16, fontFamily: 'Arial', breakBefore: true },
+      ])]),
+    ])
+    expect(xml).toContain('<a:br/>')
+    expect(xml).not.toContain('\v')
+  })
+
+  it('keeps the midpoint of a centred line when adding slack', async () => {
+    const centred = { ...textNode([{ text: 'x', fontSize: 16, fontFamily: 'Arial' }]), align: 'center' }
+    const xml = await slideXml([slide([centred])])
+    // The box is widened by 12px so PowerPoint's wider metrics do not force a
+    // wrap, so its origin moves left by half of that to hold the centre still.
+    expect(xml).toContain('x="-57150"') // -6 * 9525
+    expect(xml).toContain('cx="2019300"') // 212 * 9525
+  })
+
+  it('turns off wrapping for a single line and on for several', async () => {
+    const one = await slideXml([slide([textNode([{ text: 'x', fontSize: 16, fontFamily: 'Arial' }])])])
+    expect(one).toContain('wrap="none"')
+
+    const many = await slideXml([
+      slide([{ ...textNode([{ text: 'x', fontSize: 16, fontFamily: 'Arial' }]), lineCount: 3 }]),
+    ])
+    expect(many).not.toContain('wrap="none"')
+  })
+})
+
+describe('slide assembly', () => {
+  it('writes notes into the notes slide', async () => {
+    const buffer = await buildPptx(
+      PptxGenJS,
+      [{ ...slide([]), note: 'Say this part out loud.' }],
+      { width: 980, height: 552 },
+    )
+    const zip = await JSZip.loadAsync(buffer)
+    const notes = await zip.file('ppt/notesSlides/notesSlide1.xml')!.async('string')
+    expect(notes).toContain('Say this part out loud.')
+  })
+
+  it('falls back to a background picture and draws nothing else', async () => {
+    const png = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=='
+    const xml = await slideXml([{
+      ...slide([{ kind: 'box', sourceId: 1, rect: { x: 0, y: 0, w: 10, h: 10 }, fill: BLACK }]),
+      fallbackPng: png,
+      fallbackReason: 'walker timed out',
+    }])
+    // The safety valve has to be exclusive. Drawing the shapes as well would
+    // put half-measured content on top of a correct picture of the same thing.
+    expect(xml).not.toContain('<p:sp>')
+  })
+
+  it('produces a non-empty shape tree, which the image exporter never does', async () => {
+    const xml = await slideXml([
+      slide([textNode([{ text: 'Selectable', fontSize: 16, fontFamily: 'Arial' }])]),
+    ])
+    expect(xml).toContain('<a:t>Selectable</a:t>')
+  })
+})

--- a/packages/slidev/node/commands/pptx/build.test.ts
+++ b/packages/slidev/node/commands/pptx/build.test.ts
@@ -232,3 +232,35 @@ describe('a hyperlink is not underlined unless CSS says so', () => {
     expect(xml).toContain('u="sng"')
   })
 })
+
+describe('a dashed border keeps its dashes', () => {
+  const dashed = { width: 1, color: BLACK, style: 'dashed' as const }
+
+  it('draws a dashed edge as a line, not a filled bar', async () => {
+    // A filled rectangle cannot carry a dash pattern. Slidev rules its links
+    // with `border-bottom: 1px dashed`, so every link in a deck came out with
+    // a solid bar under it.
+    const xml = await slideXml([
+      slide([{
+        kind: 'box',
+        sourceId: 1,
+        rect: { x: 0, y: 0, w: 100, h: 20 },
+        borders: [undefined, undefined, dashed, undefined],
+      }]),
+    ])
+    expect(xml).toContain('<a:prstDash val="dash"/>')
+    expect(xml).toContain('prst="line"')
+  })
+
+  it('leaves a solid edge as a filled bar', async () => {
+    const xml = await slideXml([
+      slide([{
+        kind: 'box',
+        sourceId: 1,
+        rect: { x: 0, y: 0, w: 100, h: 20 },
+        borders: [undefined, undefined, { width: 1, color: BLACK, style: 'solid' as const }, undefined],
+      }]),
+    ])
+    expect(xml).not.toContain('prst="line"')
+  })
+})

--- a/packages/slidev/node/commands/pptx/build.ts
+++ b/packages/slidev/node/commands/pptx/build.ts
@@ -259,6 +259,21 @@ function addPicture(slide: any, node: IrImage | IrRaster): void {
       options.altText = node.alt
     if (node.link)
       options.hyperlink = { url: node.link }
+    // `sizing.crop` reads `w`/`h` as the picture's FULL display size and takes
+    // the visible window from `sizing`, which is the opposite way round from
+    // every other option here: the shape ends up at `sizing.w` by `sizing.h`,
+    // and `<a:srcRect>` trims the rest away.
+    if (node.crop) {
+      options.w = inch(node.crop.w)
+      options.h = inch(node.crop.h)
+      options.sizing = {
+        type: 'crop',
+        x: inch(node.crop.x),
+        y: inch(node.crop.y),
+        w: inch(node.rect.w),
+        h: inch(node.rect.h),
+      }
+    }
   }
   else {
     // A rasterized element is unreadable to a screen reader without this, and

--- a/packages/slidev/node/commands/pptx/build.ts
+++ b/packages/slidev/node/commands/pptx/build.ts
@@ -144,6 +144,26 @@ function addEdge(slide: PptxGenJS.Slide, shapeType: typeof PptxGenJS.ShapeType, 
           ? { x, y: y + h - t, w, h: t }
           : { x, y, w: t, h }
 
+  // A filled rectangle cannot carry a dash pattern, so a dashed or dotted rule
+  // came out solid: Slidev rules its links this way, and every link in a deck
+  // gained a solid bar. A line can be dashed, and for a hairline the half
+  // stroke that falls outside the box is well under a pixel.
+  if (border.style !== 'solid') {
+    slide.addShape(shapeType.line, {
+      x: inch(rect.x),
+      y: inch(rect.y),
+      w: inch(side === 0 || side === 2 ? rect.w : 0),
+      h: inch(side === 0 || side === 2 ? 0 : rect.h),
+      line: {
+        color: hex(border.color),
+        transparency: transparency(border.color),
+        width: pt(border.width),
+        dashType: border.style === 'dotted' ? 'sysDot' : 'dash',
+      },
+    })
+    return
+  }
+
   slide.addShape(shapeType.rect, {
     x: inch(rect.x),
     y: inch(rect.y),

--- a/packages/slidev/node/commands/pptx/build.ts
+++ b/packages/slidev/node/commands/pptx/build.ts
@@ -170,7 +170,6 @@ function addEdge(slide: PptxGenJS.Slide, shapeType: typeof PptxGenJS.ShapeType, 
     w: inch(rect.w),
     h: inch(rect.h),
     fill: { color: hex(border.color), transparency: transparency(border.color) },
-    line: { type: 'none' },
   })
 }
 
@@ -190,21 +189,31 @@ function addBox(slide: PptxGenJS.Slide, shapeType: typeof PptxGenJS.ShapeType, n
       && sameBorder(borders[1], borders[2])
       && sameBorder(borders[2], borders[3])
 
+  // With no fill and no uniform border there is nothing for this shape to
+  // carry: its only border is drawn as its own edge below. Emitting it anyway
+  // left a rectangle with neither fill nor outline specified, which PowerPoint
+  // resolves from its default shape style rather than leaving blank.
+  if (!node.fill && !uniform && !node.shadow) {
+    for (const side of [0, 1, 2, 3] as const) {
+      const border = borders?.[side]
+      if (border && border.width > 0)
+        addEdge(slide, shapeType, node, side, border)
+    }
+    return
+  }
+
   const options: Record<string, unknown> = {
     x: inch(node.rect.x),
     y: inch(node.rect.y),
     w: inch(node.rect.w),
     h: inch(node.rect.h),
-    line: { type: 'none' },
   }
 
-  if (node.fill) {
+  // `fill` and `line` are omitted rather than set to `{ type: 'none' }`.
+  // pptxgenjs writes `<a:noFill/>` for an ABSENT fill and nothing at all for
+  // that object, so the explicit-looking version was the one that inherited.
+  if (node.fill)
     options.fill = { color: hex(node.fill), transparency: transparency(node.fill) }
-  }
-  else {
-    // A shape with no fill still paints white unless told otherwise.
-    options.fill = { type: 'none' }
-  }
 
   if (uniform && borders[0]) {
     options.line = {

--- a/packages/slidev/node/commands/pptx/build.ts
+++ b/packages/slidev/node/commands/pptx/build.ts
@@ -68,6 +68,11 @@ function runProps(run: IrRun): Record<string, unknown> {
     options.strike = true
   if (run.underline)
     options.underline = { style: 'sng' }
+  else if (run.link)
+    // pptxgenjs underlines every hyperlink run unless told otherwise. CSS said
+    // not to: a theme that rules its links with a `border-bottom` already has
+    // that drawn as its own shape, so the default added a second line.
+    options.underline = { style: 'none' }
   if (run.color) {
     options.color = hex(run.color)
     const alpha = transparency(run.color)

--- a/packages/slidev/node/commands/pptx/build.ts
+++ b/packages/slidev/node/commands/pptx/build.ts
@@ -67,7 +67,7 @@ function runProps(run: IrRun): Record<string, unknown> {
   if (run.strike)
     options.strike = true
   if (run.underline)
-    options.underline = { style: 'sng' }
+    options.underline = { style: run.underlineStyle ?? 'sng' }
   else if (run.link)
     // pptxgenjs underlines every hyperlink run unless told otherwise. CSS said
     // not to: a theme that rules its links with a `border-bottom` already has

--- a/packages/slidev/node/commands/pptx/build.ts
+++ b/packages/slidev/node/commands/pptx/build.ts
@@ -1,16 +1,11 @@
 /**
- * `SlideIr[]` to a `.pptx` buffer, through `pptxgenjs`.
- *
- * Pure: no DOM, no Playwright, no filesystem. Everything it needs is in the
- * IR, which is plain JSON, so every rule in here is unit-testable by building
- * a fixture and unzipping the result.
- *
- * The three conversions this file owns are the ones most likely to be broken
- * silently by a future edit, so each has a test that asserts on the generated
- * XML rather than on the JavaScript.
+ * `SlideIr[]` to a `.pptx` buffer, through `pptxgenjs`. Pure: no DOM,
+ * Playwright or filesystem, so every rule is unit-testable by building a
+ * fixture and unzipping the result.
  */
 
 import type { Buffer } from 'node:buffer'
+import type PptxGenJS from 'pptxgenjs'
 import type {
   Border,
   IrBox,
@@ -24,17 +19,10 @@ import type {
 import { INCHES_PER_PX, PT_PER_PX } from './ir'
 
 /**
- * Extra width given to a text box beyond its measured glyph bounds.
- *
- * PowerPoint's text metrics are not Chromium's: the same string in the same
- * font at the same size sets to a slightly different width. Without slack, a
- * single-line label that measured 200.0px wide re-wraps in PowerPoint and the
- * slide gains a line nobody asked for.
- *
- * Single-line boxes get the generous value AND `wrap: false`, because they are
- * the case where a wrap is always wrong. Multi-line boxes get a token amount:
- * they are going to re-wrap differently no matter what, and widening them
- * pushes text into the neighbouring column.
+ * Extra width beyond the measured glyph bounds: PowerPoint sets the same
+ * string slightly wider than Chromium, so a tight single-line box re-wraps.
+ * Single-line boxes get the generous value and `wrap: false`; multi-line
+ * boxes re-wrap anyway, and widening them pushes into the next column.
  */
 const SLACK_SINGLE_LINE_PX = 12
 const SLACK_MULTI_LINE_PX = 2
@@ -48,11 +36,8 @@ function hex(color: Rgba): string {
 }
 
 /**
- * CSS alpha (0 opaque..1) to PowerPoint transparency (0 opaque..100).
- *
- * Returned as undefined when fully opaque: `pptxgenjs` tests this field for
- * truthiness, so an explicit 0 and an absent value behave the same, and
- * omitting it keeps the generated XML free of no-op alpha elements.
+ * CSS alpha (0 opaque..1) to PowerPoint transparency (0 opaque..100), or
+ * undefined when fully opaque: `pptxgenjs` tests the field for truthiness.
  */
 function transparency(color: Rgba): number | undefined {
   if (color.a >= 1)
@@ -95,18 +80,17 @@ function runProps(run: IrRun): Record<string, unknown> {
     options.hyperlink = { url: run.link }
   if (run.endsParagraph)
     options.breakLine = true
-  // `softBreakBefore` emits a real <a:br/> inside one paragraph, which is what
-  // a <br> is. The alternative people reach for is a \v in the text, which
-  // PowerPoint renders but Keynote and LibreOffice do not.
+  // `softBreakBefore` emits a real <a:br/> inside one paragraph; a \v in the
+  // text renders in PowerPoint but not in Keynote or LibreOffice.
   if (run.breakBefore)
     options.softBreakBefore = true
   return options
 }
 
-function addText(slide: any, node: IrText): void {
+function addText(slide: PptxGenJS.Slide, node: IrText): void {
   const slack = node.lineCount === 1 ? SLACK_SINGLE_LINE_PX : SLACK_MULTI_LINE_PX
 
-  // Widening a box moves its content unless the origin moves too: a centred
+  // Widening a box moves its content unless the origin moves too: a centered
   // line would drift right by half the slack, a right-aligned one by all of it.
   let x = node.rect.x
   if (node.align === 'center')
@@ -122,36 +106,28 @@ function addText(slide: any, node: IrText): void {
       w: inch(node.rect.w + slack),
       h: inch(node.rect.h),
       align: node.align,
-      // PowerPoint's default text inset is 0.05in top/bottom and 0.1in
-      // left/right. The IR position is glyph bounds, which already excludes
-      // padding, so any inset here is a visible offset.
+      // PowerPoint's default inset is 0.05in/0.1in; the IR position is glyph
+      // bounds, so any inset here is a visible offset.
       margin: 0,
-      // The default is 'middle', which would centre a one-line box inside a
-      // height that was measured from the glyphs themselves.
+      // The default 'middle' would center a one-line box measured from the glyphs.
       valign: node.valign ?? 'top',
-      // No autofit. Autofit rescales type to fit the box, which would undo the
-      // measured font size the moment PowerPoint disagrees about metrics.
+      // Autofit would rescale type the moment PowerPoint disagrees about metrics.
       fit: 'none',
       isTextBox: true,
       wrap: node.lineCount > 1,
-      // Only for text that actually has more than one line. A single-line box
-      // is measured from the glyph ink, which is shorter than the CSS line
-      // box, so asking PowerPoint to lay out the taller line box inside it
-      // shifts the baseline and can clip descenders.
+      // Only for multi-line text: a single-line box is measured from glyph ink,
+      // shorter than the CSS line box, and the taller value clips descenders.
       ...(node.lineCount > 1 ? { lineSpacing: pt(node.lineHeight) } : {}),
     },
   )
 }
 
 /**
- * One side of a border, as its own filled rectangle.
- *
- * Not a line: `pptxgenjs` gives a shape one uniform `line`, and the four-sided
- * form exists only on table cells. Not `addShape(LINE)` either, because a
- * line's stroke is centred on its geometry, so half of a 2px border would sit
- * outside the element box it is supposed to bound.
+ * One side of a border, as its own filled rectangle: `pptxgenjs` gives a shape
+ * one uniform `line`, and `addShape(LINE)` centers its stroke on the geometry,
+ * putting half the border outside the element box.
  */
-function addEdge(slide: any, shapeType: any, box: IrBox, side: 0 | 1 | 2 | 3, border: Border): void {
+function addEdge(slide: PptxGenJS.Slide, shapeType: typeof PptxGenJS.ShapeType, box: IrBox, side: 0 | 1 | 2 | 3, border: Border): void {
   const { x, y, w, h } = box.rect
   const t = border.width
   const rect
@@ -180,7 +156,7 @@ function sameBorder(a?: Border, b?: Border): boolean {
     && a.color.a === b.color.a
 }
 
-function addBox(slide: any, shapeType: any, node: IrBox): void {
+function addBox(slide: PptxGenJS.Slide, shapeType: typeof PptxGenJS.ShapeType, node: IrBox): void {
   const borders = node.borders
   const uniform
     = borders
@@ -210,11 +186,8 @@ function addBox(slide: any, shapeType: any, node: IrBox): void {
       color: hex(borders[0].color),
       width: pt(borders[0].width),
       dashType: borders[0].style === 'solid' ? 'solid' : borders[0].style === 'dotted' ? 'sysDot' : 'dash',
-      // `ShapeLineProps extends ShapeFillProps`, so a line takes the same
-      // transparency a fill does. Without it a uniform hairline set in
-      // `rgba(0, 0, 0, 0.1)` came out solid black, while the SAME border with
-      // one side a different width went through `addEdge` and rendered
-      // correctly, which made it look like anything but a missing property.
+      // `ShapeLineProps extends ShapeFillProps`: without `transparency` a
+      // hairline set in `rgba(0, 0, 0, 0.1)` comes out solid black.
       transparency: transparency(borders[0].color),
     }
   }
@@ -231,10 +204,9 @@ function addBox(slide: any, shapeType: any, node: IrBox): void {
   }
 
   if (node.radius) {
-    // `rectRadius` is documented as "values: 0.0 to 1.0". It is not. The
-    // runtime multiplies it by EMU before dividing by the shorter side, so a
-    // value in the documented range rounds to zero and every corner comes out
-    // square. It is an inch measurement like every other coordinate.
+    // `rectRadius` is documented as "values: 0.0 to 1.0" but is an inch
+    // measurement: the runtime multiplies it by EMU before dividing by the
+    // shorter side, so a value in the documented range rounds to zero.
     const shorter = Math.min(node.rect.w, node.rect.h)
     options.rectRadius = inch(Math.min(node.radius, shorter / 2))
     slide.addShape(shapeType.roundRect, options)
@@ -252,7 +224,7 @@ function addBox(slide: any, shapeType: any, node: IrBox): void {
   }
 }
 
-function addPicture(slide: any, node: IrImage | IrRaster): void {
+function addPicture(slide: PptxGenJS.Slide, node: IrImage | IrRaster): void {
   const options: Record<string, unknown> = {
     data: node.data,
     x: inch(node.rect.x),
@@ -265,10 +237,9 @@ function addPicture(slide: any, node: IrImage | IrRaster): void {
       options.altText = node.alt
     if (node.link)
       options.hyperlink = { url: node.link }
-    // `sizing.crop` reads `w`/`h` as the picture's FULL display size and takes
-    // the visible window from `sizing`, which is the opposite way round from
-    // every other option here: the shape ends up at `sizing.w` by `sizing.h`,
-    // and `<a:srcRect>` trims the rest away.
+    // `sizing.crop` reads `w`/`h` as the picture's full display size and the
+    // visible window from `sizing`, the opposite of every other option here;
+    // `<a:srcRect>` trims the rest away.
     if (node.crop) {
       options.w = inch(node.crop.w)
       options.h = inch(node.crop.h)
@@ -282,8 +253,7 @@ function addPicture(slide: any, node: IrImage | IrRaster): void {
     }
   }
   else {
-    // A rasterized element is unreadable to a screen reader without this, and
-    // "why it is a picture" is the most useful thing to say about it.
+    // The reason is the most useful alt text a rasterized element can carry.
     options.altText = `Rendered as an image because of CSS ${node.reason}`
   }
   slide.addImage(options)
@@ -300,22 +270,18 @@ export interface BuildOptions {
 }
 
 /**
- * Build the deck.
- *
- * `PptxGenJS` is passed in rather than imported so this module stays pure and
- * so the caller keeps the existing dynamic `import('pptxgenjs')`, which is
- * what keeps it off the CLI's startup path.
+ * Build the deck. The constructor is passed in so the caller keeps its dynamic
+ * `import('pptxgenjs')`, which keeps the library off the CLI's startup path.
  */
 export async function buildPptx(
-  PptxGenJS: any,
+  Pptx: typeof PptxGenJS,
   slides: SlideIr[],
   options: BuildOptions,
 ): Promise<Buffer> {
-  const pptx = new PptxGenJS()
+  const pptx = new Pptx()
 
-  // Same layout the image exporter defines, deliberately. Changing it here
-  // would silently change `--format pptx` output too, since both read the
-  // deck's canvas size.
+  // Same layout the image exporter defines; changing it here would silently
+  // change `--format pptx` output too.
   const layoutName = `${options.width}x${options.height}`
   pptx.defineLayout({
     name: layoutName,
@@ -336,9 +302,8 @@ export async function buildPptx(
     const slide = pptx.addSlide()
 
     if (ir.fallbackPng) {
-      // Exactly what `--format pptx` produces, for this slide only. A theme
-      // the walker cannot handle degrades to today's behaviour rather than to
-      // a slide that is subtly wrong.
+      // Exactly what `--format pptx` produces, for this slide only: a theme
+      // the walker cannot handle degrades to today's behavior.
       slide.background = { data: ir.fallbackPng }
     }
     else {

--- a/packages/slidev/node/commands/pptx/build.ts
+++ b/packages/slidev/node/commands/pptx/build.ts
@@ -128,7 +128,7 @@ function addText(slide: any, node: IrText): void {
       margin: 0,
       // The default is 'middle', which would centre a one-line box inside a
       // height that was measured from the glyphs themselves.
-      valign: 'top',
+      valign: node.valign ?? 'top',
       // No autofit. Autofit rescales type to fit the box, which would undo the
       // measured font size the moment PowerPoint disagrees about metrics.
       fit: 'none',

--- a/packages/slidev/node/commands/pptx/build.ts
+++ b/packages/slidev/node/commands/pptx/build.ts
@@ -134,7 +134,11 @@ function addText(slide: any, node: IrText): void {
       fit: 'none',
       isTextBox: true,
       wrap: node.lineCount > 1,
-      lineSpacing: pt(node.lineHeight),
+      // Only for text that actually has more than one line. A single-line box
+      // is measured from the glyph ink, which is shorter than the CSS line
+      // box, so asking PowerPoint to lay out the taller line box inside it
+      // shifts the baseline and can clip descenders.
+      ...(node.lineCount > 1 ? { lineSpacing: pt(node.lineHeight) } : {}),
     },
   )
 }

--- a/packages/slidev/node/commands/pptx/build.ts
+++ b/packages/slidev/node/commands/pptx/build.ts
@@ -210,6 +210,12 @@ function addBox(slide: any, shapeType: any, node: IrBox): void {
       color: hex(borders[0].color),
       width: pt(borders[0].width),
       dashType: borders[0].style === 'solid' ? 'solid' : borders[0].style === 'dotted' ? 'sysDot' : 'dash',
+      // `ShapeLineProps extends ShapeFillProps`, so a line takes the same
+      // transparency a fill does. Without it a uniform hairline set in
+      // `rgba(0, 0, 0, 0.1)` came out solid black, while the SAME border with
+      // one side a different width went through `addEdge` and rendered
+      // correctly, which made it look like anything but a missing property.
+      transparency: transparency(borders[0].color),
     }
   }
 

--- a/packages/slidev/node/commands/pptx/build.ts
+++ b/packages/slidev/node/commands/pptx/build.ts
@@ -1,0 +1,347 @@
+/**
+ * `SlideIr[]` to a `.pptx` buffer, through `pptxgenjs`.
+ *
+ * Pure: no DOM, no Playwright, no filesystem. Everything it needs is in the
+ * IR, which is plain JSON, so every rule in here is unit-testable by building
+ * a fixture and unzipping the result.
+ *
+ * The three conversions this file owns are the ones most likely to be broken
+ * silently by a future edit, so each has a test that asserts on the generated
+ * XML rather than on the JavaScript.
+ */
+
+import type { Buffer } from 'node:buffer'
+import type {
+  Border,
+  IrBox,
+  IrImage,
+  IrRaster,
+  IrRun,
+  IrText,
+  Rgba,
+  SlideIr,
+} from './ir'
+import { INCHES_PER_PX, PT_PER_PX } from './ir'
+
+/**
+ * Extra width given to a text box beyond its measured glyph bounds.
+ *
+ * PowerPoint's text metrics are not Chromium's: the same string in the same
+ * font at the same size sets to a slightly different width. Without slack, a
+ * single-line label that measured 200.0px wide re-wraps in PowerPoint and the
+ * slide gains a line nobody asked for.
+ *
+ * Single-line boxes get the generous value AND `wrap: false`, because they are
+ * the case where a wrap is always wrong. Multi-line boxes get a token amount:
+ * they are going to re-wrap differently no matter what, and widening them
+ * pushes text into the neighbouring column.
+ */
+const SLACK_SINGLE_LINE_PX = 12
+const SLACK_MULTI_LINE_PX = 2
+
+function hex(color: Rgba): string {
+  const channel = (v: number) => Math.max(0, Math.min(255, Math.round(v)))
+    .toString(16)
+    .padStart(2, '0')
+    .toUpperCase()
+  return `${channel(color.r)}${channel(color.g)}${channel(color.b)}`
+}
+
+/**
+ * CSS alpha (0 opaque..1) to PowerPoint transparency (0 opaque..100).
+ *
+ * Returned as undefined when fully opaque: `pptxgenjs` tests this field for
+ * truthiness, so an explicit 0 and an absent value behave the same, and
+ * omitting it keeps the generated XML free of no-op alpha elements.
+ */
+function transparency(color: Rgba): number | undefined {
+  if (color.a >= 1)
+    return undefined
+  return Math.round((1 - color.a) * 100)
+}
+
+/** Canvas pixels to inches, which is what every `pptxgenjs` coordinate wants. */
+function inch(px: number): number {
+  return px * INCHES_PER_PX
+}
+
+/** Canvas pixels to points, which is what every `pptxgenjs` type size wants. */
+function pt(px: number): number {
+  return px * PT_PER_PX
+}
+
+function runProps(run: IrRun): Record<string, unknown> {
+  const options: Record<string, unknown> = {
+    fontFace: run.fontFamily,
+    fontSize: pt(run.fontSize),
+  }
+  if (run.bold)
+    options.bold = true
+  if (run.italic)
+    options.italic = true
+  if (run.strike)
+    options.strike = true
+  if (run.underline)
+    options.underline = { style: 'sng' }
+  if (run.color) {
+    options.color = hex(run.color)
+    const alpha = transparency(run.color)
+    if (alpha !== undefined)
+      options.transparency = alpha
+  }
+  if (run.letterSpacing)
+    options.charSpacing = pt(run.letterSpacing)
+  if (run.link)
+    options.hyperlink = { url: run.link }
+  if (run.endsParagraph)
+    options.breakLine = true
+  // `softBreakBefore` emits a real <a:br/> inside one paragraph, which is what
+  // a <br> is. The alternative people reach for is a \v in the text, which
+  // PowerPoint renders but Keynote and LibreOffice do not.
+  if (run.breakBefore)
+    options.softBreakBefore = true
+  return options
+}
+
+function addText(slide: any, node: IrText): void {
+  const slack = node.lineCount === 1 ? SLACK_SINGLE_LINE_PX : SLACK_MULTI_LINE_PX
+
+  // Widening a box moves its content unless the origin moves too: a centred
+  // line would drift right by half the slack, a right-aligned one by all of it.
+  let x = node.rect.x
+  if (node.align === 'center')
+    x -= slack / 2
+  else if (node.align === 'right')
+    x -= slack
+
+  slide.addText(
+    node.runs.map(run => ({ text: run.text, options: runProps(run) })),
+    {
+      x: inch(x),
+      y: inch(node.rect.y),
+      w: inch(node.rect.w + slack),
+      h: inch(node.rect.h),
+      align: node.align,
+      // PowerPoint's default text inset is 0.05in top/bottom and 0.1in
+      // left/right. The IR position is glyph bounds, which already excludes
+      // padding, so any inset here is a visible offset.
+      margin: 0,
+      // The default is 'middle', which would centre a one-line box inside a
+      // height that was measured from the glyphs themselves.
+      valign: 'top',
+      // No autofit. Autofit rescales type to fit the box, which would undo the
+      // measured font size the moment PowerPoint disagrees about metrics.
+      fit: 'none',
+      isTextBox: true,
+      wrap: node.lineCount > 1,
+      lineSpacing: pt(node.lineHeight),
+    },
+  )
+}
+
+/**
+ * One side of a border, as its own filled rectangle.
+ *
+ * Not a line: `pptxgenjs` gives a shape one uniform `line`, and the four-sided
+ * form exists only on table cells. Not `addShape(LINE)` either, because a
+ * line's stroke is centred on its geometry, so half of a 2px border would sit
+ * outside the element box it is supposed to bound.
+ */
+function addEdge(slide: any, shapeType: any, box: IrBox, side: 0 | 1 | 2 | 3, border: Border): void {
+  const { x, y, w, h } = box.rect
+  const t = border.width
+  const rect
+    = side === 0
+      ? { x, y, w, h: t }
+      : side === 1
+        ? { x: x + w - t, y, w: t, h }
+        : side === 2
+          ? { x, y: y + h - t, w, h: t }
+          : { x, y, w: t, h }
+
+  slide.addShape(shapeType.rect, {
+    x: inch(rect.x),
+    y: inch(rect.y),
+    w: inch(rect.w),
+    h: inch(rect.h),
+    fill: { color: hex(border.color), transparency: transparency(border.color) },
+    line: { type: 'none' },
+  })
+}
+
+function sameBorder(a?: Border, b?: Border): boolean {
+  if (!a || !b)
+    return a === b
+  return a.width === b.width && a.style === b.style && hex(a.color) === hex(b.color)
+    && a.color.a === b.color.a
+}
+
+function addBox(slide: any, shapeType: any, node: IrBox): void {
+  const borders = node.borders
+  const uniform
+    = borders
+      && borders[0]
+      && sameBorder(borders[0], borders[1])
+      && sameBorder(borders[1], borders[2])
+      && sameBorder(borders[2], borders[3])
+
+  const options: Record<string, unknown> = {
+    x: inch(node.rect.x),
+    y: inch(node.rect.y),
+    w: inch(node.rect.w),
+    h: inch(node.rect.h),
+    line: { type: 'none' },
+  }
+
+  if (node.fill) {
+    options.fill = { color: hex(node.fill), transparency: transparency(node.fill) }
+  }
+  else {
+    // A shape with no fill still paints white unless told otherwise.
+    options.fill = { type: 'none' }
+  }
+
+  if (uniform && borders[0]) {
+    options.line = {
+      color: hex(borders[0].color),
+      width: pt(borders[0].width),
+      dashType: borders[0].style === 'solid' ? 'solid' : borders[0].style === 'dotted' ? 'sysDot' : 'dash',
+    }
+  }
+
+  if (node.shadow) {
+    options.shadow = {
+      type: 'outer',
+      blur: pt(node.shadow.blur),
+      offset: pt(node.shadow.offset),
+      angle: node.shadow.angle,
+      color: hex(node.shadow.color),
+      opacity: node.shadow.color.a,
+    }
+  }
+
+  if (node.radius) {
+    // `rectRadius` is documented as "values: 0.0 to 1.0". It is not. The
+    // runtime multiplies it by EMU before dividing by the shorter side, so a
+    // value in the documented range rounds to zero and every corner comes out
+    // square. It is an inch measurement like every other coordinate.
+    const shorter = Math.min(node.rect.w, node.rect.h)
+    options.rectRadius = inch(Math.min(node.radius, shorter / 2))
+    slide.addShape(shapeType.roundRect, options)
+  }
+  else {
+    slide.addShape(shapeType.rect, options)
+  }
+
+  if (borders && !uniform) {
+    for (const side of [0, 1, 2, 3] as const) {
+      const border = borders[side]
+      if (border && border.width > 0)
+        addEdge(slide, shapeType, node, side, border)
+    }
+  }
+}
+
+function addPicture(slide: any, node: IrImage | IrRaster): void {
+  const options: Record<string, unknown> = {
+    data: node.data,
+    x: inch(node.rect.x),
+    y: inch(node.rect.y),
+    w: inch(node.rect.w),
+    h: inch(node.rect.h),
+  }
+  if (node.kind === 'image') {
+    if (node.alt)
+      options.altText = node.alt
+    if (node.link)
+      options.hyperlink = { url: node.link }
+  }
+  else {
+    // A rasterized element is unreadable to a screen reader without this, and
+    // "why it is a picture" is the most useful thing to say about it.
+    options.altText = `Rendered as an image because of CSS ${node.reason}`
+  }
+  slide.addImage(options)
+}
+
+export interface BuildOptions {
+  /** Canvas width in pixels. The slide becomes `width / 96` inches wide. */
+  width: number
+  /** Canvas height in pixels. */
+  height: number
+  title?: string
+  author?: string
+  subject?: string
+}
+
+/**
+ * Build the deck.
+ *
+ * `PptxGenJS` is passed in rather than imported so this module stays pure and
+ * so the caller keeps the existing dynamic `import('pptxgenjs')`, which is
+ * what keeps it off the CLI's startup path.
+ */
+export async function buildPptx(
+  PptxGenJS: any,
+  slides: SlideIr[],
+  options: BuildOptions,
+): Promise<Buffer> {
+  const pptx = new PptxGenJS()
+
+  // Same layout the image exporter defines, deliberately. Changing it here
+  // would silently change `--format pptx` output too, since both read the
+  // deck's canvas size.
+  const layoutName = `${options.width}x${options.height}`
+  pptx.defineLayout({
+    name: layoutName,
+    width: inch(options.width),
+    height: inch(options.height),
+  })
+  pptx.layout = layoutName
+
+  pptx.company = 'Created using Slidev'
+  if (options.title)
+    pptx.title = options.title
+  if (options.author)
+    pptx.author = options.author
+  if (options.subject)
+    pptx.subject = options.subject
+
+  for (const ir of slides) {
+    const slide = pptx.addSlide()
+
+    if (ir.fallbackPng) {
+      // Exactly what `--format pptx` produces, for this slide only. A theme
+      // the walker cannot handle degrades to today's behaviour rather than to
+      // a slide that is subtly wrong.
+      slide.background = { data: ir.fallbackPng }
+    }
+    else {
+      if (ir.background) {
+        slide.background = {
+          color: hex(ir.background),
+          transparency: transparency(ir.background),
+        }
+      }
+      for (const node of ir.nodes) {
+        switch (node.kind) {
+          case 'box':
+            addBox(slide, pptx.ShapeType, node)
+            break
+          case 'text':
+            addText(slide, node)
+            break
+          case 'image':
+          case 'raster':
+            addPicture(slide, node)
+            break
+        }
+      }
+    }
+
+    if (ir.note)
+      slide.addNotes(ir.note)
+  }
+
+  return await pptx.write({ outputType: 'nodebuffer' }) as Buffer
+}

--- a/packages/slidev/node/commands/pptx/capture.test.ts
+++ b/packages/slidev/node/commands/pptx/capture.test.ts
@@ -1,5 +1,8 @@
+import type { Page } from 'playwright-chromium'
+import type { RasterRequest } from './normalize'
+import { Buffer } from 'node:buffer'
 import { describe, expect, it } from 'vitest'
-import { isUsableDataUri } from './capture'
+import { capture, isUsableDataUri, shootClip } from './capture'
 
 /**
  * `capture.ts` needs a live browser, so only its pure predicates are unit
@@ -21,5 +24,94 @@ describe('isUsableDataUri', () => {
     // pptxgenjs writes a broken raster fallback for SVG from Node, so these
     // are screenshotted rather than embedded.
     expect(isUsableDataUri('data:image/svg+xml;base64,PHN2Zz4=')).toBe(false)
+  })
+})
+
+/**
+ * A page just real enough for the two things that geometry depends on: how far
+ * it actually scrolled, and how tall its viewport is.
+ */
+function fakePage(options: { documentHeight: number, viewportHeight: number }) {
+  const calls: { clips: { x: number, y: number, width: number, height: number }[], viewports: number[] } = {
+    clips: [],
+    viewports: [],
+  }
+  let scrollY = 0
+  let viewportHeight = options.viewportHeight
+  const page = {
+    viewportSize: () => ({ width: 980, height: viewportHeight }),
+    async setViewportSize({ height }: { height: number }) {
+      viewportHeight = height
+      calls.viewports.push(height)
+    },
+    async evaluate(fn: any, arg: any) {
+      // Only the scroll calls reach here; both are written as a function of
+      // `window`, which this stands in for.
+      if (typeof arg === 'number') {
+        scrollY = Math.max(0, Math.min(arg, options.documentHeight - viewportHeight))
+        return scrollY
+      }
+      scrollY = 0
+      return undefined
+    },
+    async screenshot({ clip }: any) {
+      calls.clips.push(clip)
+      return Buffer.from('png')
+    },
+  }
+  return { page: page as unknown as Page, calls, scrollY: () => scrollY }
+}
+
+describe('a clip is taken relative to the scroll the page actually reached', () => {
+  it('rebases the clip onto the real scroll position', () => {
+    // `clip` is in DOCUMENT coordinates while Playwright reads it as
+    // viewport-relative, so the difference has to come from where the browser
+    // ended up, not from where it was asked to go.
+    const { page, calls } = fakePage({ documentHeight: 28152, viewportHeight: 2000 })
+    return shootClip(page, { x: 100, y: 20000, w: 300, h: 150 }).then(() => {
+      expect(calls.clips).toEqual([{ x: 100, y: 1, width: 300, height: 150 }])
+    })
+  })
+
+  it('does not scroll past the end of the document', () => {
+    // At the very bottom the browser stops short of the requested offset. A
+    // clip rebased on the REQUESTED offset lands above the region and
+    // Playwright answers "clipped area is empty", which the caller swallows,
+    // so the picture silently goes missing.
+    const { page, calls } = fakePage({ documentHeight: 28152, viewportHeight: 2000 })
+    return shootClip(page, { x: 0, y: 28100, w: 100, h: 50 }).then(() => {
+      // Scroll stops at 26152, so the region is 1948 down the viewport.
+      expect(calls.clips).toEqual([{ x: 0, y: 1948, width: 100, height: 50 }])
+    })
+  })
+})
+
+describe('clip captures run through a shortened viewport', () => {
+  const request = (sourceId: number, clip?: { x: number, y: number, w: number, h: number }): RasterRequest =>
+    ({ sourceId, isolate: false, hideDescendants: false, ...(clip ? { clip } : {}) })
+
+  it('shortens the viewport for the clips and puts it back', async () => {
+    // The print route sizes its viewport to the WHOLE deck, and past roughly
+    // twenty thousand pixels Chromium truncates the capture surface, so every
+    // clip in the last third of a long deck failed and its picture vanished
+    // with nothing in the log to say so.
+    const { page, calls } = fakePage({ documentHeight: 28152, viewportHeight: 28152 })
+    const slides = [{
+      no: 1,
+      clickIndex: 0,
+      containerId: '001-01',
+      size: { w: 980, h: 552 },
+      nodes: [{ kind: 'raster' as const, sourceId: 1, rect: { x: 0, y: 0, w: 10, h: 10 }, data: '', reason: 'svg' as const, isolate: false, hideDescendants: false }],
+    }]
+    const report = await capture(page, slides as any, [request(1, { x: 0, y: 20000, w: 10, h: 10 })])
+    expect(calls.viewports).toEqual([2000, 28152])
+    expect(report.rastersCaptured).toBe(1)
+    expect(report.rastersFailed).toBe(0)
+  })
+
+  it('leaves the viewport alone when nothing needs a clip', async () => {
+    const { page, calls } = fakePage({ documentHeight: 28152, viewportHeight: 28152 })
+    await capture(page, [], [])
+    expect(calls.viewports).toEqual([])
   })
 })

--- a/packages/slidev/node/commands/pptx/capture.test.ts
+++ b/packages/slidev/node/commands/pptx/capture.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { isUsableDataUri } from './capture'
+
+/**
+ * `capture.ts` needs a live browser, so only its pure predicates are unit
+ * tested here. This one guards a real failure: pptxgenjs answers a data URI it
+ * cannot parse by printing to stderr and writing no picture at all, so the
+ * image is missing and the export still reports success.
+ */
+describe('isUsableDataUri', () => {
+  it('accepts a base64 raster', () => {
+    expect(isUsableDataUri('data:image/png;base64,iVBORw0KGgo=')).toBe(true)
+    expect(isUsableDataUri('data:image/jpeg;base64,/9j/4AAQ')).toBe(true)
+  })
+
+  it('rejects a URL-encoded data URI, which is how inline SVG is usually written', () => {
+    expect(isUsableDataUri('data:image/svg+xml,%3c!--%20icon%20--%3e')).toBe(false)
+  })
+
+  it('rejects SVG even when it is base64', () => {
+    // pptxgenjs writes a broken raster fallback for SVG from Node, so these
+    // are screenshotted rather than embedded.
+    expect(isUsableDataUri('data:image/svg+xml;base64,PHN2Zz4=')).toBe(false)
+  })
+})

--- a/packages/slidev/node/commands/pptx/capture.test.ts
+++ b/packages/slidev/node/commands/pptx/capture.test.ts
@@ -31,11 +31,13 @@ describe('isUsableDataUri', () => {
  * A page just real enough for the two things that geometry depends on: how far
  * it actually scrolled, and how tall its viewport is.
  */
-function fakePage(options: { documentHeight: number, viewportHeight: number }) {
-  const calls: { clips: { x: number, y: number, width: number, height: number }[], viewports: number[] } = {
-    clips: [],
-    viewports: [],
-  }
+function fakePage(options: { documentHeight: number, viewportHeight: number, box?: { x: number, y: number, width: number, height: number } }) {
+  const calls: {
+    clips: { x: number, y: number, width: number, height: number }[]
+    viewports: number[]
+    locators: string[]
+    elementShots: number
+  } = { clips: [], viewports: [], locators: [], elementShots: 0 }
   let scrollY = 0
   let viewportHeight = options.viewportHeight
   const page = {
@@ -45,18 +47,36 @@ function fakePage(options: { documentHeight: number, viewportHeight: number }) {
       calls.viewports.push(height)
     },
     async evaluate(fn: any, arg: any) {
-      // Only the scroll calls reach here; both are written as a function of
-      // `window`, which this stands in for.
+      // Only scroll calls reach here, and they are told apart by their source
+      // because all three are no-argument functions of `window`, which this
+      // stands in for.
       if (typeof arg === 'number') {
         scrollY = Math.max(0, Math.min(arg, options.documentHeight - viewportHeight))
         return scrollY
       }
-      scrollY = 0
-      return undefined
+      if (String(fn).includes('scrollTo')) {
+        scrollY = 0
+        return undefined
+      }
+      return scrollY
     },
     async screenshot({ clip }: any) {
       calls.clips.push(clip)
       return Buffer.from('png')
+    },
+    locator(selector: string) {
+      calls.locators.push(selector)
+      return {
+        first: () => ({
+          count: async () => (options.box ? 1 : 0),
+          // Viewport-relative, exactly as Playwright reports it.
+          boundingBox: async () => (options.box ? { ...options.box, y: options.box.y - scrollY } : null),
+          screenshot: async () => {
+            calls.elementShots++
+            return Buffer.from('png')
+          },
+        }),
+      }
     },
   }
   return { page: page as unknown as Page, calls, scrollY: () => scrollY }
@@ -113,5 +133,55 @@ describe('clip captures run through a shortened viewport', () => {
     const { page, calls } = fakePage({ documentHeight: 28152, viewportHeight: 28152 })
     await capture(page, [], [])
     expect(calls.viewports).toEqual([])
+  })
+})
+
+describe('an element is captured by clipping the page at its box', () => {
+  const request = (sourceId: number): RasterRequest => ({ sourceId, isolate: false, hideDescendants: false })
+  const slide = (sourceId: number) => ({
+    no: 1,
+    clickIndex: 0,
+    containerId: '001-01',
+    size: { w: 980, h: 552 },
+    nodes: [{ kind: 'raster' as const, sourceId, rect: { x: 0, y: 0, w: 10, h: 10 }, data: '', reason: 'svg' as const, isolate: false, hideDescendants: false }],
+  })
+
+  it('clips rather than calling locator.screenshot', async () => {
+    // `locator.screenshot()` is the obvious call and returns a region from
+    // somewhere else entirely on a print page far taller than its viewport:
+    // Slidev's own starter deck came back with a picture of slide one pasted
+    // into slide four.
+    const { page, calls } = fakePage({
+      documentHeight: 28152,
+      viewportHeight: 28152,
+      box: { x: 100, y: 2049, width: 320, height: 194 },
+    })
+    const report = await capture(page, [slide(166)] as any, [request(166)])
+    expect(calls.elementShots).toBe(0)
+    expect(calls.clips).toEqual([{ x: 100, y: 1, width: 320, height: 194 }])
+    expect(report.rastersCaptured).toBe(1)
+  })
+
+  it('reports a failure when the element is not there', async () => {
+    const { page } = fakePage({ documentHeight: 28152, viewportHeight: 28152 })
+    const report = await capture(page, [slide(166)] as any, [request(166)])
+    expect(report.rastersFailed).toBe(1)
+  })
+})
+
+describe('shootClip', () => {
+  it('clamps a box that starts left of the page', async () => {
+    // An absolutely positioned decoration can hang off the left edge, and
+    // Chromium cannot capture a negative origin: it rejects the whole
+    // screenshot, so the picture went missing rather than being trimmed.
+    const { page, calls } = fakePage({ documentHeight: 5000, viewportHeight: 2000 })
+    await shootClip(page, { x: -28, y: 100, w: 320, h: 194 })
+    expect(calls.clips).toEqual([{ x: 0, y: 1, width: 292, height: 194 }])
+  })
+
+  it('gives up on a box with nothing left to capture', async () => {
+    const { page, calls } = fakePage({ documentHeight: 5000, viewportHeight: 2000 })
+    expect(await shootClip(page, { x: -400, y: 100, w: 320, h: 194 })).toBeUndefined()
+    expect(calls.clips).toEqual([])
   })
 })

--- a/packages/slidev/node/commands/pptx/capture.ts
+++ b/packages/slidev/node/commands/pptx/capture.ts
@@ -61,6 +61,18 @@ async function isolate(page: Page, id: number, hideDescendants: boolean): Promis
         html.style.visibility = 'hidden'
       }
 
+      // `omitBackground` only drops the browser's DEFAULT backdrop. A slide
+      // container paints its own white, and an ancestor's background is not a
+      // sibling, so hiding siblings alone still captured it. A mostly
+      // transparent element, an `<svg>` arrow spanning half the slide say,
+      // then became an opaque white rectangle that covered everything under it
+      // once PowerPoint painted it in front.
+      const clear = (el: Element) => {
+        const html = el as HTMLElement
+        html.setAttribute(`${restoreAttribute}-bg`, html.style.backgroundColor || '')
+        html.style.backgroundColor = 'transparent'
+      }
+
       // The target's own descendants, but ONLY when they are redrawn as
       // shapes afterwards. That holds for a backdrop, whose children are
       // walked, and not for a leaf such as an `<svg>`, whose children ARE its
@@ -83,6 +95,9 @@ async function isolate(page: Page, id: number, hideDescendants: boolean): Promis
             continue
           hide(sibling)
         }
+        // The target keeps its own background: for a backdrop that IS the
+        // thing being captured.
+        clear(node.parentElement)
         node = node.parentElement
       }
       return true
@@ -100,6 +115,15 @@ async function isolate(page: Page, id: number, hideDescendants: boolean): Promis
  */
 async function restore(page: Page): Promise<void> {
   await page.evaluate((restoreAttribute) => {
+    for (const el of Array.from(document.querySelectorAll(`[${restoreAttribute}-bg]`))) {
+      const previous = el.getAttribute(`${restoreAttribute}-bg`) ?? ''
+      const style = (el as HTMLElement).style
+      if (previous)
+        style.backgroundColor = previous
+      else
+        style.removeProperty('background-color')
+      el.removeAttribute(`${restoreAttribute}-bg`)
+    }
     for (const el of Array.from(document.querySelectorAll(`[${restoreAttribute}-color]`))) {
       const previous = el.getAttribute(`${restoreAttribute}-color`) ?? ''
       const style = (el as HTMLElement).style

--- a/packages/slidev/node/commands/pptx/capture.ts
+++ b/packages/slidev/node/commands/pptx/capture.ts
@@ -143,24 +143,43 @@ async function shoot(page: Page, selector: string): Promise<string | undefined> 
 }
 
 /**
+ * The tallest viewport a clip screenshot is taken through.
+ *
+ * The print route sizes its viewport to the WHOLE deck, and Chromium can only
+ * rasterize a surface so large: past roughly twenty thousand CSS pixels the
+ * capture is silently truncated and every clip below that point answers
+ * "Clipped area is either empty or outside the resulting image". On a fifty
+ * slide deck that is the last third of the presentation, and because the
+ * caller swallows the failure those pictures simply went missing.
+ *
+ * So clips are taken through a short viewport that is scrolled instead. Small
+ * enough to be far under the limit, tall enough to hold any single element
+ * worth capturing whole.
+ */
+const CLIP_VIEWPORT_HEIGHT = 2000
+
+/**
  * Screenshot a rectangle of the document.
  *
- * `clip` is in DOCUMENT coordinates, while Playwright reads it as
- * viewport-relative. The two agree only at scroll origin, and element
- * screenshots scroll their target into view, so the page is returned to the
- * origin first.
+ * `clip` is in DOCUMENT coordinates while Playwright reads it as
+ * viewport-relative, so the region is scrolled to first and the clip is
+ * rebased onto the scroll position the browser actually reached, which is not
+ * the one asked for at the very bottom of the page.
  *
- * `fullPage` would remove the need for that and is wrong here: the print route
- * sizes its viewport to the whole deck, so a full-page capture of a forty
- * slide deck asks Chromium for a bitmap of some twenty-two thousand pixels
- * squared at `deviceScaleFactor: 2`, and the page dies with "Target page,
- * context or browser has been closed".
+ * `fullPage` would avoid the arithmetic and is wrong here for the same reason
+ * the short viewport exists: a full-page capture of a forty slide deck asks
+ * Chromium for a bitmap of some twenty-two thousand pixels squared at
+ * `deviceScaleFactor: 2`, and the page dies with "Target page, context or
+ * browser has been closed".
  */
-async function shootClip(page: Page, clip: Rect): Promise<string | undefined> {
+export async function shootClip(page: Page, clip: Rect): Promise<string | undefined> {
   try {
-    await page.evaluate(() => window.scrollTo(0, 0))
+    const scrollY = await page.evaluate((y) => {
+      window.scrollTo(0, y)
+      return window.scrollY
+    }, Math.max(0, clip.y - 1))
     const buffer = await page.screenshot({
-      clip: { x: clip.x, y: clip.y, width: clip.w, height: clip.h },
+      clip: { x: clip.x, y: clip.y - scrollY, width: clip.w, height: clip.h },
       omitBackground: true,
       timeout: 10_000,
     })
@@ -266,7 +285,7 @@ export async function capture(
     }
   }
 
-  for (const request of requests) {
+  const fulfil = async (request: RasterRequest): Promise<void> => {
     let data: string | undefined
     try {
       if (request.isolate && !(await isolate(page, request.isolateId ?? request.sourceId, request.hideDescendants)))
@@ -293,6 +312,29 @@ export async function capture(
       else {
         report.rastersFailed++
       }
+    }
+  }
+
+  for (const request of requests.filter(request => !request.clip))
+    await fulfil(request)
+
+  // Every clip together, through one short viewport, because resizing reflows
+  // the page and doing it per request would cost more than the captures.
+  // Element captures are left on the full-height viewport they were measured
+  // through, so only the path that has to scroll is affected.
+  const clips = requests.filter(request => !!request.clip)
+  if (clips.length) {
+    const viewport = page.viewportSize()
+    try {
+      if (viewport && viewport.height > CLIP_VIEWPORT_HEIGHT)
+        await page.setViewportSize({ width: viewport.width, height: CLIP_VIEWPORT_HEIGHT })
+      for (const request of clips)
+        await fulfil(request)
+    }
+    finally {
+      if (viewport)
+        await page.setViewportSize(viewport)
+      await page.evaluate(() => window.scrollTo(0, 0))
     }
   }
 

--- a/packages/slidev/node/commands/pptx/capture.ts
+++ b/packages/slidev/node/commands/pptx/capture.ts
@@ -29,9 +29,9 @@ const RESTORE_ATTRIBUTE = 'data-slidev-export-restore'
  * `visibility` rather than `display`, because `display: none` removes the box
  * and reflows the siblings, which would move the very element being captured.
  */
-async function isolate(page: Page, id: number): Promise<void> {
+async function isolate(page: Page, id: number, hideDescendants: boolean): Promise<void> {
   await page.evaluate(
-    ({ id, idAttribute, restoreAttribute }) => {
+    ({ id, idAttribute, restoreAttribute, hideDescendants }) => {
       const target = document.querySelector(`[${idAttribute}="${id}"]`)
       if (!target)
         return
@@ -42,13 +42,14 @@ async function isolate(page: Page, id: number): Promise<void> {
         html.style.visibility = 'hidden'
       }
 
-      // The target's own DESCENDANTS, first. Hiding only siblings left the
-      // content sitting on top of a backdrop visible, so it was baked into the
-      // backdrop's picture AND drawn again as text shapes, doubling every word
-      // on the slide. `visibility` is inherited but overridable, so the
-      // children go hidden while the element itself keeps painting.
-      for (const child of Array.from(target.children))
-        hide(child)
+      // The target's own descendants, but ONLY when they are redrawn as
+      // shapes afterwards. That holds for a backdrop, whose children are
+      // walked, and not for a leaf such as an `<svg>`, whose children ARE its
+      // artwork: hiding those emptied the decorative chrome out of the slide.
+      if (hideDescendants) {
+        for (const child of Array.from(target.children))
+          hide(child)
+      }
 
       let node: Element | null = target
       while (node && node.parentElement) {
@@ -60,7 +61,7 @@ async function isolate(page: Page, id: number): Promise<void> {
         node = node.parentElement
       }
     },
-    { id, idAttribute: ID_ATTRIBUTE, restoreAttribute: RESTORE_ATTRIBUTE },
+    { id, idAttribute: ID_ATTRIBUTE, restoreAttribute: RESTORE_ATTRIBUTE, hideDescendants },
   )
 }
 
@@ -171,7 +172,7 @@ export async function capture(
     let data: string | undefined
     try {
       if (request.isolate)
-        await isolate(page, request.sourceId)
+        await isolate(page, request.sourceId, request.hideDescendants)
       data = await shoot(page, `[${ID_ATTRIBUTE}="${request.sourceId}"]`)
     }
     catch {

--- a/packages/slidev/node/commands/pptx/capture.ts
+++ b/packages/slidev/node/commands/pptx/capture.ts
@@ -173,7 +173,15 @@ export async function capture(
     try {
       if (request.isolate)
         await isolate(page, request.sourceId, request.hideDescendants)
-      data = await shoot(page, `[${ID_ATTRIBUTE}="${request.sourceId}"]`)
+      data = request.clip
+        // A pseudo-element has no element to point at, so the page is clipped
+        // to the box the walker computed for it instead.
+        ? `data:image/png;base64,${(await page.screenshot({
+          clip: { x: request.clip.x, y: request.clip.y, width: request.clip.w, height: request.clip.h },
+          omitBackground: true,
+          timeout: 10_000,
+        })).toString('base64')}`
+        : await shoot(page, `[${ID_ATTRIBUTE}="${request.sourceId}"]`)
     }
     catch {
       data = undefined

--- a/packages/slidev/node/commands/pptx/capture.ts
+++ b/packages/slidev/node/commands/pptx/capture.ts
@@ -1,5 +1,5 @@
 import type { Page } from 'playwright-chromium'
-import type { IrImage, IrRaster, SlideIr } from './ir'
+import type { IrImage, IrRaster, Rect, SlideIr } from './ir'
 import type { RasterRequest } from './normalize'
 import { Buffer } from 'node:buffer'
 
@@ -29,12 +29,31 @@ const RESTORE_ATTRIBUTE = 'data-slidev-export-restore'
  * `visibility` rather than `display`, because `display: none` removes the box
  * and reflows the siblings, which would move the very element being captured.
  */
-async function isolate(page: Page, id: number, hideDescendants: boolean): Promise<void> {
-  await page.evaluate(
+async function isolate(page: Page, id: number, hideDescendants: boolean): Promise<boolean> {
+  return await page.evaluate(
     ({ id, idAttribute, restoreAttribute, hideDescendants }) => {
-      const target = document.querySelector(`[${idAttribute}="${id}"]`)
+      // `document.querySelector` does not pierce shadow DOM, and Mermaid
+      // renders into one. `page.locator` in `shoot()` DOES pierce, so the
+      // screenshot succeeded while isolation silently did nothing, which is
+      // the doubling this whole mechanism exists to prevent.
+      const find = (root: Document | ShadowRoot): Element | null => {
+        const hit = root.querySelector(`[${idAttribute}="${id}"]`)
+        if (hit)
+          return hit
+        for (const el of Array.from(root.querySelectorAll('*'))) {
+          const shadow = (el as any).shadowRoot
+          if (shadow) {
+            const nested = find(shadow)
+            if (nested)
+              return nested
+          }
+        }
+        return null
+      }
+
+      const target = find(document)
       if (!target)
-        return
+        return false
 
       const hide = (el: Element) => {
         const html = el as HTMLElement
@@ -49,6 +68,12 @@ async function isolate(page: Page, id: number, hideDescendants: boolean): Promis
       if (hideDescendants) {
         for (const child of Array.from(target.children))
           hide(child)
+        // A direct text child has no element to hide, so it would still be
+        // baked into the picture and then drawn again as a shape. Its own
+        // colour is what makes it visible.
+        const html = target as HTMLElement
+        html.setAttribute(`${restoreAttribute}-color`, html.style.color || '')
+        html.style.color = 'transparent'
       }
 
       let node: Element | null = target
@@ -60,6 +85,7 @@ async function isolate(page: Page, id: number, hideDescendants: boolean): Promis
         }
         node = node.parentElement
       }
+      return true
     },
     { id, idAttribute: ID_ATTRIBUTE, restoreAttribute: RESTORE_ATTRIBUTE, hideDescendants },
   )
@@ -74,6 +100,15 @@ async function isolate(page: Page, id: number, hideDescendants: boolean): Promis
  */
 async function restore(page: Page): Promise<void> {
   await page.evaluate((restoreAttribute) => {
+    for (const el of Array.from(document.querySelectorAll(`[${restoreAttribute}-color]`))) {
+      const previous = el.getAttribute(`${restoreAttribute}-color`) ?? ''
+      const style = (el as HTMLElement).style
+      if (previous)
+        style.color = previous
+      else
+        style.removeProperty('color')
+      el.removeAttribute(`${restoreAttribute}-color`)
+    }
     for (const el of Array.from(document.querySelectorAll(`[${restoreAttribute}]`))) {
       const previous = el.getAttribute(restoreAttribute) ?? ''
       const style = (el as HTMLElement).style
@@ -86,12 +121,60 @@ async function restore(page: Page): Promise<void> {
   }, RESTORE_ATTRIBUTE)
 }
 
+/**
+ * Screenshot an element, or return undefined.
+ *
+ * Never throws. A detached, zero-sized or slow element makes
+ * `locator.screenshot()` reject, and two of the three call sites are the
+ * FALLBACK paths, so an unhandled rejection there crashed the whole export at
+ * the exact moment it was trying to degrade gracefully.
+ */
 async function shoot(page: Page, selector: string): Promise<string | undefined> {
-  const locator = page.locator(selector).first()
-  if (!(await locator.count()))
+  try {
+    const locator = page.locator(selector).first()
+    if (!(await locator.count()))
+      return undefined
+    const buffer = await locator.screenshot({ omitBackground: true, timeout: 10_000 })
+    return `data:image/png;base64,${buffer.toString('base64')}`
+  }
+  catch {
     return undefined
-  const buffer = await locator.screenshot({ omitBackground: true, timeout: 10_000 })
-  return `data:image/png;base64,${buffer.toString('base64')}`
+  }
+}
+
+/**
+ * Screenshot a rectangle of the document.
+ *
+ * `clip` is in DOCUMENT coordinates, which is why `fullPage` is set: without
+ * it Playwright reads the rectangle as viewport-relative and trims it to the
+ * viewport, and the print route is far taller than the viewport as soon as
+ * every click step has its own container.
+ */
+async function shootClip(page: Page, clip: Rect): Promise<string | undefined> {
+  try {
+    const buffer = await page.screenshot({
+      fullPage: true,
+      clip: { x: clip.x, y: clip.y, width: clip.w, height: clip.h },
+      omitBackground: true,
+      timeout: 10_000,
+    })
+    return `data:image/png;base64,${buffer.toString('base64')}`
+  }
+  catch {
+    return undefined
+  }
+}
+
+/**
+ * Whether a data URI can be embedded as-is.
+ *
+ * pptxgenjs needs `image/<type>;base64,`. A URL-encoded data URI, which is how
+ * an inline SVG icon is usually written, makes it print "Image `data` value
+ * lacks a base64 header!" and emit nothing at all. SVG is rasterized on this
+ * path regardless, so both cases fall through to a screenshot instead.
+ */
+export function isUsableDataUri(url: string): boolean {
+  return /^data:image\/(?!svg\+xml)[\w.+-]+;base64,/.test(url)
 }
 
 /**
@@ -103,7 +186,7 @@ async function shoot(page: Page, selector: string): Promise<string | undefined> 
  */
 async function fetchImage(page: Page, url: string): Promise<string | undefined> {
   if (url.startsWith('data:'))
-    return url
+    return isUsableDataUri(url) ? url : undefined
   try {
     const response = await page.context().request.get(url, { timeout: 15_000 })
     if (!response.ok())
@@ -128,6 +211,14 @@ export interface CaptureReport {
   imagesFetched: number
   /** Images that could be neither fetched nor screenshotted. */
   imagesDropped: number
+  /**
+   * Captures that asked for isolation and could not find their element.
+   *
+   * Counted rather than ignored: an isolation that silently does nothing
+   * produces a picture with the slide's own text baked into it, which is then
+   * drawn again as shapes.
+   */
+  isolationMissed: number
   fallbackSlides: { no: number, reason: string }[]
 }
 
@@ -148,6 +239,7 @@ export async function capture(
     rastersFailed: 0,
     imagesFetched: 0,
     imagesDropped: 0,
+    isolationMissed: 0,
     fallbackSlides: [],
   }
 
@@ -171,16 +263,12 @@ export async function capture(
   for (const request of requests) {
     let data: string | undefined
     try {
-      if (request.isolate)
-        await isolate(page, request.sourceId, request.hideDescendants)
+      if (request.isolate && !(await isolate(page, request.isolateId ?? request.sourceId, request.hideDescendants)))
+        report.isolationMissed++
+      // A pseudo-element has no element to point at, so the page is clipped to
+      // the box the walker computed for it instead.
       data = request.clip
-        // A pseudo-element has no element to point at, so the page is clipped
-        // to the box the walker computed for it instead.
-        ? `data:image/png;base64,${(await page.screenshot({
-          clip: { x: request.clip.x, y: request.clip.y, width: request.clip.w, height: request.clip.h },
-          omitBackground: true,
-          timeout: 10_000,
-        })).toString('base64')}`
+        ? await shootClip(page, request.clip)
         : await shoot(page, `[${ID_ATTRIBUTE}="${request.sourceId}"]`)
     }
     catch {

--- a/packages/slidev/node/commands/pptx/capture.ts
+++ b/packages/slidev/node/commands/pptx/capture.ts
@@ -124,18 +124,30 @@ async function restore(page: Page): Promise<void> {
 /**
  * Screenshot an element, or return undefined.
  *
- * Never throws. A detached, zero-sized or slow element makes
- * `locator.screenshot()` reject, and two of the three call sites are the
- * FALLBACK paths, so an unhandled rejection there crashed the whole export at
- * the exact moment it was trying to degrade gracefully.
+ * Never throws. A detached, zero-sized or slow element makes the underlying
+ * screenshot reject, and two of the three call sites are the FALLBACK paths,
+ * so an unhandled rejection there crashed the whole export at the exact
+ * moment it was trying to degrade gracefully.
+ *
+ * `locator.screenshot()` would be the obvious call and is WRONG here. On a
+ * print page far taller than its viewport, and every deck with click steps is
+ * one, it returns a region from somewhere else on the page entirely: Slidev's
+ * own starter deck came back with a picture of slide one pasted into slide
+ * four. Reading the element's live box and clipping the page at it returns the
+ * right pixels, and is the same primitive a pseudo-element already uses.
  */
 async function shoot(page: Page, selector: string): Promise<string | undefined> {
   try {
     const locator = page.locator(selector).first()
     if (!(await locator.count()))
       return undefined
-    const buffer = await locator.screenshot({ omitBackground: true, timeout: 10_000 })
-    return `data:image/png;base64,${buffer.toString('base64')}`
+    const box = await locator.boundingBox()
+    if (!box || box.width <= 0 || box.height <= 0)
+      return undefined
+    // `boundingBox()` is viewport-relative, and `shootClip` wants document
+    // coordinates, so whatever the page is scrolled to has to be added back.
+    const scrollY = await page.evaluate(() => window.scrollY)
+    return await shootClip(page, { x: box.x, y: box.y + scrollY, w: box.width, h: box.height })
   }
   catch {
     return undefined
@@ -173,13 +185,19 @@ const CLIP_VIEWPORT_HEIGHT = 2000
  * browser has been closed".
  */
 export async function shootClip(page: Page, clip: Rect): Promise<string | undefined> {
+  // An element can start left of the page, and Chromium cannot capture a
+  // negative origin. Clamping keeps the picture rather than losing it.
+  const x = Math.max(0, clip.x)
+  const w = clip.w - (x - clip.x)
+  if (w <= 0 || clip.h <= 0)
+    return undefined
   try {
     const scrollY = await page.evaluate((y) => {
       window.scrollTo(0, y)
       return window.scrollY
     }, Math.max(0, clip.y - 1))
     const buffer = await page.screenshot({
-      clip: { x: clip.x, y: clip.y - scrollY, width: clip.w, height: clip.h },
+      clip: { x, y: clip.y - scrollY, width: w, height: clip.h },
       omitBackground: true,
       timeout: 10_000,
     })
@@ -245,6 +263,31 @@ export interface CaptureReport {
    */
   isolationMissed: number
   fallbackSlides: { no: number, reason: string }[]
+}
+
+/**
+ * Run every capture through one short, scrollable viewport.
+ *
+ * Resizing reflows the page, so it happens once around all of them rather than
+ * per capture. Boxes are read live inside this viewport, so they stay
+ * consistent with it even on a deck the resize does move.
+ */
+async function throughShortViewport(page: Page, needed: boolean, fn: () => Promise<void>): Promise<void> {
+  if (!needed) {
+    await fn()
+    return
+  }
+  const viewport = page.viewportSize()
+  try {
+    if (viewport && viewport.height > CLIP_VIEWPORT_HEIGHT)
+      await page.setViewportSize({ width: viewport.width, height: CLIP_VIEWPORT_HEIGHT })
+    await fn()
+  }
+  finally {
+    if (viewport)
+      await page.setViewportSize(viewport)
+    await page.evaluate(() => window.scrollTo(0, 0))
+  }
 }
 
 /**
@@ -315,48 +358,30 @@ export async function capture(
     }
   }
 
-  for (const request of requests.filter(request => !request.clip))
-    await fulfil(request)
+  await throughShortViewport(page, !!requests.length || !!imagesBySource.size, async () => {
+    for (const request of requests)
+      await fulfil(request)
 
-  // Every clip together, through one short viewport, because resizing reflows
-  // the page and doing it per request would cost more than the captures.
-  // Element captures are left on the full-height viewport they were measured
-  // through, so only the path that has to scroll is affected.
-  const clips = requests.filter(request => !!request.clip)
-  if (clips.length) {
-    const viewport = page.viewportSize()
-    try {
-      if (viewport && viewport.height > CLIP_VIEWPORT_HEIGHT)
-        await page.setViewportSize({ width: viewport.width, height: CLIP_VIEWPORT_HEIGHT })
-      for (const request of clips)
-        await fulfil(request)
-    }
-    finally {
-      if (viewport)
-        await page.setViewportSize(viewport)
-      await page.evaluate(() => window.scrollTo(0, 0))
-    }
-  }
-
-  for (const [sourceId, nodes] of imagesBySource) {
-    const url = nodes[0].data
-    const data = await fetchImage(page, url)
-    for (const node of nodes) {
-      if (data) {
-        node.data = data
-        report.imagesFetched++
-      }
-      else {
-        // Could not be fetched, or is an SVG that pptxgenjs would embed with a
-        // broken fallback. Either way, a picture of the element is honest.
-        const shot = await shoot(page, `[${ID_ATTRIBUTE}="${sourceId}"]`)
-        if (shot) {
-          node.data = shot
-          report.rastersCaptured++
+    for (const [sourceId, nodes] of imagesBySource) {
+      const url = nodes[0].data
+      const data = await fetchImage(page, url)
+      for (const node of nodes) {
+        if (data) {
+          node.data = data
+          report.imagesFetched++
+        }
+        else {
+          // Could not be fetched, or is an SVG that pptxgenjs would embed with
+          // a broken fallback. Either way, a picture of the element is honest.
+          const shot = await shoot(page, `[${ID_ATTRIBUTE}="${sourceId}"]`)
+          if (shot) {
+            node.data = shot
+            report.rastersCaptured++
+          }
         }
       }
     }
-  }
+  })
 
   // Anything without real image data would reach pptxgenjs as a bare URL or an
   // empty string. It answers with `Image 'data' value lacks a base64 header!`
@@ -374,28 +399,31 @@ export async function capture(
     })
   }
 
-  for (const slide of slides) {
-    if (!slide.fallbackReason)
-      continue
-    // The exact container id. A prefix match plus `.first()` handed every
-    // click step of a slide the picture of step one.
-    const shot = await shoot(page, `[id="${slide.containerId}"]`)
-    if (shot) {
-      slide.fallbackPng = shot
-      report.fallbackSlides.push({ no: slide.no, reason: slide.fallbackReason })
+  await throughShortViewport(page, slides.some(slide => !!slide.fallbackReason), async () => {
+    for (const slide of slides) {
+      if (!slide.fallbackReason)
+        continue
+      // The exact container id. A prefix match plus `.first()` handed every
+      // click step of a slide the picture of step one.
+      const shot = await shoot(page, `[id="${slide.containerId}"]`)
+      if (shot) {
+        slide.fallbackPng = shot
+        report.fallbackSlides.push({ no: slide.no, reason: slide.fallbackReason })
+      }
+      else {
+        // No picture either. The slide falls back to whatever shapes it has,
+        // but `normalize` withheld its raster requests, so its pictures were
+        // already dropped. Clearing the reason here hid that: the slide came
+        // out gutted and the warning that would have explained it was
+        // suppressed.
+        report.fallbackSlides.push({
+          no: slide.no,
+          reason: `${slide.fallbackReason}, and the replacement screenshot failed, so the slide is incomplete`,
+        })
+        slide.fallbackReason = undefined
+      }
     }
-    else {
-      // No picture either. The slide falls back to whatever shapes it has, but
-      // `normalize` withheld its raster requests, so its pictures were already
-      // dropped. Clearing the reason here hid that: the slide came out gutted
-      // and the warning that would have explained it was suppressed.
-      report.fallbackSlides.push({
-        no: slide.no,
-        reason: `${slide.fallbackReason}, and the replacement screenshot failed, so the slide is incomplete`,
-      })
-      slide.fallbackReason = undefined
-    }
-  }
+  })
 
   return report
 }

--- a/packages/slidev/node/commands/pptx/capture.ts
+++ b/packages/slidev/node/commands/pptx/capture.ts
@@ -1,0 +1,256 @@
+import type { Page } from 'playwright-chromium'
+import type { IrImage, IrRaster, SlideIr } from './ir'
+import type { RasterRequest } from './normalize'
+import { Buffer } from 'node:buffer'
+
+/**
+ * The only Playwright glue in the exporter.
+ *
+ * Measurement happens in one `page.evaluate`, but rasterization cannot: an
+ * element screenshot has to be driven from Node, and isolating an element for
+ * one means mutating the DOM of a live Vue app. So this is deliberately a
+ * second phase, run strictly after every measurement is already in hand. No
+ * geometry is ever read from a page this module has touched.
+ */
+
+export const ID_ATTRIBUTE = 'data-slidev-export-id'
+
+/** Marks an element this module hid, and remembers what to put back. */
+const RESTORE_ATTRIBUTE = 'data-slidev-export-restore'
+
+/**
+ * Hide everything except the target and its ancestors.
+ *
+ * `locator.screenshot()` CLIPS THE PAGE to the element's box; it does not
+ * isolate the element. Without this, a backdrop's picture contains whatever is
+ * painted on top of it, and that content is then drawn again as shapes, so
+ * every word on the slide appears twice.
+ *
+ * `visibility` rather than `display`, because `display: none` removes the box
+ * and reflows the siblings, which would move the very element being captured.
+ */
+async function isolate(page: Page, id: number): Promise<void> {
+  await page.evaluate(
+    ({ id, idAttribute, restoreAttribute }) => {
+      const target = document.querySelector(`[${idAttribute}="${id}"]`)
+      if (!target)
+        return
+
+      const hide = (el: Element) => {
+        const html = el as HTMLElement
+        html.setAttribute(restoreAttribute, html.style.visibility || '')
+        html.style.visibility = 'hidden'
+      }
+
+      // The target's own DESCENDANTS, first. Hiding only siblings left the
+      // content sitting on top of a backdrop visible, so it was baked into the
+      // backdrop's picture AND drawn again as text shapes, doubling every word
+      // on the slide. `visibility` is inherited but overridable, so the
+      // children go hidden while the element itself keeps painting.
+      for (const child of Array.from(target.children))
+        hide(child)
+
+      let node: Element | null = target
+      while (node && node.parentElement) {
+        for (const sibling of Array.from(node.parentElement.children)) {
+          if (sibling === node)
+            continue
+          hide(sibling)
+        }
+        node = node.parentElement
+      }
+    },
+    { id, idAttribute: ID_ATTRIBUTE, restoreAttribute: RESTORE_ATTRIBUTE },
+  )
+}
+
+/**
+ * Put back everything `isolate` hid.
+ *
+ * Driven off an attribute rather than a remembered list, so it is correct even
+ * if a previous restore was interrupted. It runs in a `finally`: leaving the
+ * deck half-hidden would corrupt every capture after it.
+ */
+async function restore(page: Page): Promise<void> {
+  await page.evaluate((restoreAttribute) => {
+    for (const el of Array.from(document.querySelectorAll(`[${restoreAttribute}]`))) {
+      const previous = el.getAttribute(restoreAttribute) ?? ''
+      const style = (el as HTMLElement).style
+      if (previous)
+        style.visibility = previous
+      else
+        style.removeProperty('visibility')
+      el.removeAttribute(restoreAttribute)
+    }
+  }, RESTORE_ATTRIBUTE)
+}
+
+async function shoot(page: Page, selector: string): Promise<string | undefined> {
+  const locator = page.locator(selector).first()
+  if (!(await locator.count()))
+    return undefined
+  const buffer = await locator.screenshot({ omitBackground: true, timeout: 10_000 })
+  return `data:image/png;base64,${buffer.toString('base64')}`
+}
+
+/**
+ * Fetch an image through Playwright rather than through the page.
+ *
+ * The in-page route is `canvas.toDataURL()`, which THROWS on a cross-origin
+ * image because the canvas is tainted, and Slidev's own starter deck uses a
+ * remote cover photo. `APIRequestContext` is not subject to CORS.
+ */
+async function fetchImage(page: Page, url: string): Promise<string | undefined> {
+  if (url.startsWith('data:'))
+    return url
+  try {
+    const response = await page.context().request.get(url, { timeout: 15_000 })
+    if (!response.ok())
+      return undefined
+    const type = response.headers()['content-type']?.split(';')[0] ?? 'image/png'
+    // An SVG fetched here would be embedded as an SVG picture, and pptxgenjs
+    // writes a broken raster fallback for those from Node. Let the caller
+    // screenshot the element instead.
+    if (type.includes('svg'))
+      return undefined
+    const body = await response.body()
+    return `data:${type};base64,${Buffer.from(body).toString('base64')}`
+  }
+  catch {
+    return undefined
+  }
+}
+
+export interface CaptureReport {
+  rastersCaptured: number
+  rastersFailed: number
+  imagesFetched: number
+  /** Images that could be neither fetched nor screenshotted. */
+  imagesDropped: number
+  fallbackSlides: { no: number, reason: string }[]
+}
+
+/**
+ * Fill in every picture the IR asked for, and shoot whole-slide fallbacks.
+ *
+ * Mutates `slides` in place, because the IR is a private intermediate and
+ * copying a deck's worth of base64 to stay pure would be a real cost for no
+ * real benefit.
+ */
+export async function capture(
+  page: Page,
+  slides: SlideIr[],
+  requests: RasterRequest[],
+): Promise<CaptureReport> {
+  const report: CaptureReport = {
+    rastersCaptured: 0,
+    rastersFailed: 0,
+    imagesFetched: 0,
+    imagesDropped: 0,
+    fallbackSlides: [],
+  }
+
+  const rasterBySource = new Map<number, IrRaster[]>()
+  const imagesBySource = new Map<number, IrImage[]>()
+  for (const slide of slides) {
+    for (const node of slide.nodes) {
+      if (node.kind === 'raster') {
+        const list = rasterBySource.get(node.sourceId) ?? []
+        list.push(node)
+        rasterBySource.set(node.sourceId, list)
+      }
+      else if (node.kind === 'image') {
+        const list = imagesBySource.get(node.sourceId) ?? []
+        list.push(node)
+        imagesBySource.set(node.sourceId, list)
+      }
+    }
+  }
+
+  for (const request of requests) {
+    let data: string | undefined
+    try {
+      if (request.isolate)
+        await isolate(page, request.sourceId)
+      data = await shoot(page, `[${ID_ATTRIBUTE}="${request.sourceId}"]`)
+    }
+    catch {
+      data = undefined
+    }
+    finally {
+      if (request.isolate)
+        await restore(page)
+    }
+
+    for (const node of rasterBySource.get(request.sourceId) ?? []) {
+      if (data) {
+        node.data = data
+        report.rastersCaptured++
+      }
+      else {
+        report.rastersFailed++
+      }
+    }
+  }
+
+  for (const [sourceId, nodes] of imagesBySource) {
+    const url = nodes[0].data
+    const data = await fetchImage(page, url)
+    for (const node of nodes) {
+      if (data) {
+        node.data = data
+        report.imagesFetched++
+      }
+      else {
+        // Could not be fetched, or is an SVG that pptxgenjs would embed with a
+        // broken fallback. Either way, a picture of the element is honest.
+        const shot = await shoot(page, `[${ID_ATTRIBUTE}="${sourceId}"]`)
+        if (shot) {
+          node.data = shot
+          report.rastersCaptured++
+        }
+      }
+    }
+  }
+
+  // Anything without real image data would reach pptxgenjs as a bare URL or an
+  // empty string. It answers with `Image 'data' value lacks a base64 header!`
+  // on stderr and writes nothing, so the picture is missing either way and the
+  // export looks like it crashed.
+  for (const slide of slides) {
+    slide.nodes = slide.nodes.filter((node) => {
+      if (node.kind === 'raster')
+        return !!node.data
+      if (node.kind === 'image' && !node.data.startsWith('data:')) {
+        report.imagesDropped++
+        return false
+      }
+      return true
+    })
+  }
+
+  for (const slide of slides) {
+    if (!slide.fallbackReason)
+      continue
+    // The exact container id. A prefix match plus `.first()` handed every
+    // click step of a slide the picture of step one.
+    const shot = await shoot(page, `[id="${slide.containerId}"]`)
+    if (shot) {
+      slide.fallbackPng = shot
+      report.fallbackSlides.push({ no: slide.no, reason: slide.fallbackReason })
+    }
+    else {
+      // No picture either. The slide falls back to whatever shapes it has, but
+      // `normalize` withheld its raster requests, so its pictures were already
+      // dropped. Clearing the reason here hid that: the slide came out gutted
+      // and the warning that would have explained it was suppressed.
+      report.fallbackSlides.push({
+        no: slide.no,
+        reason: `${slide.fallbackReason}, and the replacement screenshot failed, so the slide is incomplete`,
+      })
+      slide.fallbackReason = undefined
+    }
+  }
+
+  return report
+}

--- a/packages/slidev/node/commands/pptx/capture.ts
+++ b/packages/slidev/node/commands/pptx/capture.ts
@@ -19,6 +19,44 @@ export const ID_ATTRIBUTE = 'data-slidev-export-id'
 const RESTORE_ATTRIBUTE = 'data-slidev-export-restore'
 
 /**
+ * Install a cached list of every root that can hold a captured element.
+ *
+ * The document plus every open shadow root, found by one tree walk and kept on
+ * `window` for the rest of the export. `isolate` and `restore` both need it,
+ * and both used to be written against `document` alone: the first found its
+ * target through a fresh recursive scan per capture, and the second could not
+ * see inside a shadow root at all, so anything hidden in one stayed hidden.
+ *
+ * Recomputed if a diagram renders late: the count of hosts is cheap to check
+ * against the cache only by rescanning, so instead the cache is simply built
+ * on first use, after every slide has already rendered.
+ */
+async function installRootFinder(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    if ((window as any).__slidevExportRoots)
+      return
+    let cache: (Document | ShadowRoot)[] | undefined
+    ;(window as any).__slidevExportRoots = () => {
+      if (cache)
+        return cache
+      const found: (Document | ShadowRoot)[] = [document]
+      const collect = (root: Document | ShadowRoot) => {
+        for (const el of Array.from(root.querySelectorAll('*'))) {
+          const shadow = (el as any).shadowRoot
+          if (shadow) {
+            found.push(shadow)
+            collect(shadow)
+          }
+        }
+      }
+      collect(document)
+      cache = found
+      return cache
+    }
+  })
+}
+
+/**
  * Hide everything except the target and its ancestors.
  *
  * `locator.screenshot()` CLIPS THE PAGE to the element's box; it does not
@@ -33,25 +71,23 @@ async function isolate(page: Page, id: number, hideDescendants: boolean): Promis
   return await page.evaluate(
     ({ id, idAttribute, restoreAttribute, hideDescendants }) => {
       // `document.querySelector` does not pierce shadow DOM, and Mermaid
-      // renders into one. `page.locator` in `shoot()` DOES pierce, so the
-      // screenshot succeeded while isolation silently did nothing, which is
-      // the doubling this whole mechanism exists to prevent.
-      const find = (root: Document | ShadowRoot): Element | null => {
+      // renders into one. `page.locator` DOES pierce, so the screenshot
+      // succeeded while isolation silently did nothing, which is the doubling
+      // this whole mechanism exists to prevent.
+      //
+      // The light DOM is tried first because that is where all but a handful
+      // of elements live, and the shadow roots are found once and cached on
+      // `window` rather than rescanning every element in the document for each
+      // capture, which is a full tree walk per picture on a deck that has none.
+      const roots = (window as any).__slidevExportRoots() as (Document | ShadowRoot)[]
+      let target: Element | null = null
+      for (const root of roots) {
         const hit = root.querySelector(`[${idAttribute}="${id}"]`)
-        if (hit)
-          return hit
-        for (const el of Array.from(root.querySelectorAll('*'))) {
-          const shadow = (el as any).shadowRoot
-          if (shadow) {
-            const nested = find(shadow)
-            if (nested)
-              return nested
-          }
+        if (hit) {
+          target = hit
+          break
         }
-        return null
       }
-
-      const target = find(document)
       if (!target)
         return false
 
@@ -88,17 +124,32 @@ async function isolate(page: Page, id: number, hideDescendants: boolean): Promis
         html.style.color = 'transparent'
       }
 
-      let node: Element | null = target
-      while (node && node.parentElement) {
-        for (const sibling of Array.from(node.parentElement.children)) {
-          if (sibling === node)
-            continue
-          hide(sibling)
+      // Climbs THROUGH a shadow boundary. `parentElement` is null at the top
+      // of a shadow tree, so a loop conditioned on it hid nothing at all for a
+      // target inside one, and still reported success: a Mermaid diagram with
+      // a title over it kept the title in its picture and drew it again.
+      let node: Element = target
+      for (;;) {
+        const parent: HTMLElement | null = node.parentElement
+        if (parent) {
+          for (const sibling of Array.from(parent.children)) {
+            if (sibling !== node)
+              hide(sibling)
+          }
+          // The target keeps its own background: for a backdrop that IS the
+          // thing being captured.
+          clear(parent)
+          node = parent
+          continue
         }
-        // The target keeps its own background: for a backdrop that IS the
-        // thing being captured.
-        clear(node.parentElement)
-        node = node.parentElement
+        const root = node.getRootNode() as ShadowRoot
+        if (!root || !root.host)
+          break
+        for (const sibling of Array.from(root.children)) {
+          if (sibling !== node)
+            hide(sibling)
+        }
+        node = root.host
       }
       return true
     },
@@ -115,7 +166,12 @@ async function isolate(page: Page, id: number, hideDescendants: boolean): Promis
  */
 async function restore(page: Page): Promise<void> {
   await page.evaluate((restoreAttribute) => {
-    for (const el of Array.from(document.querySelectorAll(`[${restoreAttribute}-bg]`))) {
+    // Through the shadow roots as well. `isolate` hides elements inside them,
+    // and a restore that cannot see those left them `visibility: hidden` for
+    // every capture afterwards, including the whole-slide fallbacks.
+    const roots = (window as any).__slidevExportRoots()
+    const all = (selector: string) => roots.flatMap((root: Document | ShadowRoot) => Array.from(root.querySelectorAll(selector)))
+    for (const el of all(`[${restoreAttribute}-bg]`)) {
       const previous = el.getAttribute(`${restoreAttribute}-bg`) ?? ''
       const style = (el as HTMLElement).style
       if (previous)
@@ -124,7 +180,7 @@ async function restore(page: Page): Promise<void> {
         style.removeProperty('background-color')
       el.removeAttribute(`${restoreAttribute}-bg`)
     }
-    for (const el of Array.from(document.querySelectorAll(`[${restoreAttribute}-color]`))) {
+    for (const el of all(`[${restoreAttribute}-color]`)) {
       const previous = el.getAttribute(`${restoreAttribute}-color`) ?? ''
       const style = (el as HTMLElement).style
       if (previous)
@@ -133,7 +189,7 @@ async function restore(page: Page): Promise<void> {
         style.removeProperty('color')
       el.removeAttribute(`${restoreAttribute}-color`)
     }
-    for (const el of Array.from(document.querySelectorAll(`[${restoreAttribute}]`))) {
+    for (const el of all(`[${restoreAttribute}]`)) {
       const previous = el.getAttribute(restoreAttribute) ?? ''
       const style = (el as HTMLElement).style
       if (previous)
@@ -334,6 +390,8 @@ export async function capture(
     isolationMissed: 0,
     fallbackSlides: [],
   }
+
+  await installRootFinder(page)
 
   const rasterBySource = new Map<number, IrRaster[]>()
   const imagesBySource = new Map<number, IrImage[]>()

--- a/packages/slidev/node/commands/pptx/capture.ts
+++ b/packages/slidev/node/commands/pptx/capture.ts
@@ -145,15 +145,21 @@ async function shoot(page: Page, selector: string): Promise<string | undefined> 
 /**
  * Screenshot a rectangle of the document.
  *
- * `clip` is in DOCUMENT coordinates, which is why `fullPage` is set: without
- * it Playwright reads the rectangle as viewport-relative and trims it to the
- * viewport, and the print route is far taller than the viewport as soon as
- * every click step has its own container.
+ * `clip` is in DOCUMENT coordinates, while Playwright reads it as
+ * viewport-relative. The two agree only at scroll origin, and element
+ * screenshots scroll their target into view, so the page is returned to the
+ * origin first.
+ *
+ * `fullPage` would remove the need for that and is wrong here: the print route
+ * sizes its viewport to the whole deck, so a full-page capture of a forty
+ * slide deck asks Chromium for a bitmap of some twenty-two thousand pixels
+ * squared at `deviceScaleFactor: 2`, and the page dies with "Target page,
+ * context or browser has been closed".
  */
 async function shootClip(page: Page, clip: Rect): Promise<string | undefined> {
   try {
+    await page.evaluate(() => window.scrollTo(0, 0))
     const buffer = await page.screenshot({
-      fullPage: true,
       clip: { x: clip.x, y: clip.y, width: clip.w, height: clip.h },
       omitBackground: true,
       timeout: 10_000,

--- a/packages/slidev/node/commands/pptx/capture.ts
+++ b/packages/slidev/node/commands/pptx/capture.ts
@@ -397,10 +397,22 @@ export async function capture(
         else {
           // Could not be fetched, or is an SVG that pptxgenjs would embed with
           // a broken fallback. Either way, a picture of the element is honest.
-          const shot = await shoot(page, `[${ID_ATTRIBUTE}="${sourceId}"]`)
-          if (shot) {
-            node.data = shot
-            report.rastersCaptured++
+          //
+          // Isolated like any other capture. An `<img>` is mostly transparent
+          // whenever it points at an SVG, so without this the picture carried
+          // whatever the slide painted behind the icon and drew it a second
+          // time on top of the shapes that already say it.
+          try {
+            if (!(await isolate(page, sourceId, false)))
+              report.isolationMissed++
+            const shot = await shoot(page, `[${ID_ATTRIBUTE}="${sourceId}"]`)
+            if (shot) {
+              node.data = shot
+              report.rastersCaptured++
+            }
+          }
+          finally {
+            await restore(page)
           }
         }
       }

--- a/packages/slidev/node/commands/pptx/capture.ts
+++ b/packages/slidev/node/commands/pptx/capture.ts
@@ -4,20 +4,11 @@ import type { RasterRequest } from './normalize'
 import { Buffer } from 'node:buffer'
 
 /**
- * The only Playwright glue in the exporter.
- *
- * Measurement happens in one `page.evaluate`, but rasterization cannot: an
- * element screenshot has to be driven from Node, and isolating an element for
- * one means mutating the DOM of a live Vue app. So this is deliberately a
- * second phase, run strictly after every measurement is already in hand.
- *
- * What this module does to the page is confined to two kinds of change, and
- * neither one moves anything: inline `visibility` and `background-color`,
- * which do not reflow, and the viewport HEIGHT, which the print route's
- * fixed-size slide containers do not depend on. Its width is never touched,
- * and width is what `PrintContainer` scales from. So the coordinates the
- * walker measured stay valid here. A slide sizing itself in `vh` would break
- * that, and would break the image exporter's own clip arithmetic first.
+ * The only Playwright glue in the exporter. Rasterization runs as a second phase,
+ * after every measurement is in hand, because isolating an element for a screenshot
+ * means mutating the DOM of the live app. Only inline `visibility`/`background-color`
+ * (no reflow) and the viewport height are touched; width is what `PrintContainer`
+ * scales from, so the coordinates the walker measured stay valid here.
  */
 
 export const ID_ATTRIBUTE = 'data-slidev-export-id'
@@ -26,17 +17,9 @@ export const ID_ATTRIBUTE = 'data-slidev-export-id'
 const RESTORE_ATTRIBUTE = 'data-slidev-export-restore'
 
 /**
- * Install a cached list of every root that can hold a captured element.
- *
- * The document plus every open shadow root, found by one tree walk and kept on
- * `window` for the rest of the export. `isolate` and `restore` both need it,
- * and both used to be written against `document` alone: the first found its
- * target through a fresh recursive scan per capture, and the second could not
- * see inside a shadow root at all, so anything hidden in one stayed hidden.
- *
- * Recomputed if a diagram renders late: the count of hosts is cheap to check
- * against the cache only by rescanning, so instead the cache is simply built
- * on first use, after every slide has already rendered.
+ * Cache the document plus every open shadow root on `window`. `isolate` and `restore`
+ * both need to see inside shadow roots (Mermaid renders into one), and rescanning the
+ * tree per capture is a full walk per picture. Built on first use, after every slide has rendered.
  */
 async function installRootFinder(page: Page): Promise<void> {
   await page.evaluate(() => {
@@ -64,28 +47,16 @@ async function installRootFinder(page: Page): Promise<void> {
 }
 
 /**
- * Hide everything except the target and its ancestors.
- *
- * `locator.screenshot()` CLIPS THE PAGE to the element's box; it does not
- * isolate the element. Without this, a backdrop's picture contains whatever is
- * painted on top of it, and that content is then drawn again as shapes, so
- * every word on the slide appears twice.
- *
- * `visibility` rather than `display`, because `display: none` removes the box
- * and reflows the siblings, which would move the very element being captured.
+ * Hide everything except the target and its ancestors. `locator.screenshot()` clips
+ * the page to the element's box rather than isolating it, so overlapping content would
+ * be captured and then drawn again as shapes. `visibility` rather than `display`:
+ * `display: none` reflows and moves the target.
  */
 async function isolate(page: Page, id: number, hideDescendants: boolean): Promise<boolean> {
   return await page.evaluate(
     ({ id, idAttribute, restoreAttribute, hideDescendants }) => {
-      // `document.querySelector` does not pierce shadow DOM, and Mermaid
-      // renders into one. `page.locator` DOES pierce, so the screenshot
-      // succeeded while isolation silently did nothing, which is the doubling
-      // this whole mechanism exists to prevent.
-      //
-      // The light DOM is tried first because that is where all but a handful
-      // of elements live, and the shadow roots are found once and cached on
-      // `window` rather than rescanning every element in the document for each
-      // capture, which is a full tree walk per picture on a deck that has none.
+      // `document.querySelector` does not pierce shadow DOM while `page.locator` does,
+      // so the screenshot succeeds even when isolation silently misses a shadow-DOM target.
       const roots = (window as any).__slidevExportRoots() as (Document | ShadowRoot)[]
       let target: Element | null = null
       for (const root of roots) {
@@ -104,37 +75,27 @@ async function isolate(page: Page, id: number, hideDescendants: boolean): Promis
         html.style.visibility = 'hidden'
       }
 
-      // `omitBackground` only drops the browser's DEFAULT backdrop. A slide
-      // container paints its own white, and an ancestor's background is not a
-      // sibling, so hiding siblings alone still captured it. A mostly
-      // transparent element, an `<svg>` arrow spanning half the slide say,
-      // then became an opaque white rectangle that covered everything under it
-      // once PowerPoint painted it in front.
+      // `omitBackground` only drops the browser's default backdrop; clear ancestor
+      // backgrounds too, or a mostly transparent element captures an opaque one.
       const clear = (el: Element) => {
         const html = el as HTMLElement
         html.setAttribute(`${restoreAttribute}-bg`, html.style.backgroundColor || '')
         html.style.backgroundColor = 'transparent'
       }
 
-      // The target's own descendants, but ONLY when they are redrawn as
-      // shapes afterwards. That holds for a backdrop, whose children are
-      // walked, and not for a leaf such as an `<svg>`, whose children ARE its
-      // artwork: hiding those emptied the decorative chrome out of the slide.
+      // Only correct when the descendants are redrawn as shapes afterwards;
+      // a leaf's children are its artwork.
       if (hideDescendants) {
         for (const child of Array.from(target.children))
           hide(child)
-        // A direct text child has no element to hide, so it would still be
-        // baked into the picture and then drawn again as a shape. Its own
-        // colour is what makes it visible.
+        // A direct text child has no element to hide; make it transparent.
         const html = target as HTMLElement
         html.setAttribute(`${restoreAttribute}-color`, html.style.color || '')
         html.style.color = 'transparent'
       }
 
-      // Climbs THROUGH a shadow boundary. `parentElement` is null at the top
-      // of a shadow tree, so a loop conditioned on it hid nothing at all for a
-      // target inside one, and still reported success: a Mermaid diagram with
-      // a title over it kept the title in its picture and drew it again.
+      // Climbs through shadow boundaries: `parentElement` is null at the top
+      // of a shadow tree, so a loop conditioned on it hides nothing there.
       let node: Element = target
       for (;;) {
         const parent: HTMLElement | null = node.parentElement
@@ -143,8 +104,7 @@ async function isolate(page: Page, id: number, hideDescendants: boolean): Promis
             if (sibling !== node)
               hide(sibling)
           }
-          // The target keeps its own background: for a backdrop that IS the
-          // thing being captured.
+          // The target keeps its own background: a backdrop is the thing captured.
           clear(parent)
           node = parent
           continue
@@ -165,17 +125,13 @@ async function isolate(page: Page, id: number, hideDescendants: boolean): Promis
 }
 
 /**
- * Put back everything `isolate` hid.
- *
- * Driven off an attribute rather than a remembered list, so it is correct even
- * if a previous restore was interrupted. It runs in a `finally`: leaving the
- * deck half-hidden would corrupt every capture after it.
+ * Put back everything `isolate` hid. Driven off an attribute rather than a remembered
+ * list, so it is correct even if a previous restore was interrupted. Runs in a
+ * `finally`: a half-hidden deck corrupts every capture after it.
  */
 async function restore(page: Page): Promise<void> {
   await page.evaluate((restoreAttribute) => {
-    // Through the shadow roots as well. `isolate` hides elements inside them,
-    // and a restore that cannot see those left them `visibility: hidden` for
-    // every capture afterwards, including the whole-slide fallbacks.
+    // Shadow roots too, or elements hidden inside them stay hidden.
     const roots = (window as any).__slidevExportRoots()
     const all = (selector: string) => roots.flatMap((root: Document | ShadowRoot) => Array.from(root.querySelectorAll(selector)))
     for (const el of all(`[${restoreAttribute}-bg]`)) {
@@ -209,19 +165,10 @@ async function restore(page: Page): Promise<void> {
 }
 
 /**
- * Screenshot an element, or return undefined.
- *
- * Never throws. A detached, zero-sized or slow element makes the underlying
- * screenshot reject, and two of the three call sites are the FALLBACK paths,
- * so an unhandled rejection there crashed the whole export at the exact
- * moment it was trying to degrade gracefully.
- *
- * `locator.screenshot()` would be the obvious call and is WRONG here. On a
- * print page far taller than its viewport, and every deck with click steps is
- * one, it returns a region from somewhere else on the page entirely: Slidev's
- * own starter deck came back with a picture of slide one pasted into slide
- * four. Reading the element's live box and clipping the page at it returns the
- * right pixels, and is the same primitive a pseudo-element already uses.
+ * Screenshot an element, or return undefined; never throws, since two of the three
+ * call sites are fallback paths. `locator.screenshot()` is not used: on a print page
+ * far taller than its viewport it returns a region from elsewhere on the page
+ * entirely, so the element's live box is read and the page clipped at it instead.
  */
 async function shoot(page: Page, selector: string): Promise<string | undefined> {
   try {
@@ -231,8 +178,7 @@ async function shoot(page: Page, selector: string): Promise<string | undefined> 
     const box = await locator.boundingBox()
     if (!box || box.width <= 0 || box.height <= 0)
       return undefined
-    // `boundingBox()` is viewport-relative, and `shootClip` wants document
-    // coordinates, so whatever the page is scrolled to has to be added back.
+    // `boundingBox()` is viewport-relative; `shootClip` wants document coordinates.
     const scrollY = await page.evaluate(() => window.scrollY)
     return await shootClip(page, { x: box.x, y: box.y + scrollY, w: box.width, h: box.height })
   }
@@ -242,29 +188,15 @@ async function shoot(page: Page, selector: string): Promise<string | undefined> 
 }
 
 /**
- * The tallest viewport a clip screenshot is taken through.
- *
- * The print route sizes its viewport to the WHOLE deck, and Chromium can only
- * rasterize a surface so large: past roughly twenty thousand CSS pixels the
- * capture is silently truncated and every clip below that point answers
- * "Clipped area is either empty or outside the resulting image". On a fifty
- * slide deck that is the last third of the presentation, and because the
- * caller swallows the failure those pictures simply went missing.
- *
- * So clips are taken through a short viewport that is scrolled instead. Small
- * enough to be far under the limit, tall enough to hold any single element
- * worth capturing whole.
+ * Chromium silently truncates captures past roughly twenty thousand CSS pixels, and
+ * the print route sizes its viewport to the whole deck, so on a long deck every clip
+ * below that point fails. Clips are taken through a short, scrolled viewport instead.
  */
 const CLIP_VIEWPORT_MIN_HEIGHT = 2000
 
 /**
- * A viewport tall enough to hold the tallest thing being captured.
- *
- * A fixed two thousand pixels is shorter than a single slide once the deck
- * sets `canvasWidth: 3840`, where 16:9 makes the slide 2160 tall. Every
- * full-bleed picture and every whole-slide fallback then asks for a clip
- * taller than the viewport and fails, silently, which is the exact class of
- * failure the short viewport was introduced to fix.
+ * A viewport tall enough to hold the tallest thing being captured: with `canvasWidth: 3840`
+ * a single 16:9 slide is 2160 tall, so a fixed height would fail every whole-slide clip.
  */
 function clipViewportHeight(slides: SlideIr[], requests: RasterRequest[]): number {
   const tallest = Math.max(
@@ -276,23 +208,13 @@ function clipViewportHeight(slides: SlideIr[], requests: RasterRequest[]): numbe
 }
 
 /**
- * Screenshot a rectangle of the document.
- *
- * `clip` is in DOCUMENT coordinates while Playwright reads it as
- * viewport-relative, so the region is scrolled to first and the clip is
- * rebased onto the scroll position the browser actually reached, which is not
- * the one asked for at the very bottom of the page.
- *
- * `fullPage` would avoid the arithmetic and is wrong here for the same reason
- * the short viewport exists: a full-page capture of a forty slide deck asks
- * Chromium for a bitmap of some twenty-two thousand pixels squared at
- * `deviceScaleFactor: 2`, and the page dies with "Target page, context or
- * browser has been closed".
+ * Screenshot a rectangle of the document. `clip` is in document coordinates while
+ * Playwright reads it as viewport-relative, so the region is scrolled to first and the
+ * clip rebased onto the scroll position actually reached. `fullPage` is not an option:
+ * on a long deck it asks Chromium for a bitmap large enough to kill the page.
  */
 export async function shootClip(page: Page, clip: Rect): Promise<string | undefined> {
-  // An element can start left of, or above, the page, and Chromium cannot
-  // capture a negative origin: it rejects the whole screenshot, so the picture
-  // went missing rather than being trimmed. Clamping keeps what there is.
+  // Chromium rejects a clip with a negative origin outright; clamp and keep what there is.
   const x = Math.max(0, clip.x)
   const y = Math.max(0, clip.y)
   const w = clip.w - (x - clip.x)
@@ -317,23 +239,17 @@ export async function shootClip(page: Page, clip: Rect): Promise<string | undefi
 }
 
 /**
- * Whether a data URI can be embedded as-is.
- *
- * pptxgenjs needs `image/<type>;base64,`. A URL-encoded data URI, which is how
- * an inline SVG icon is usually written, makes it print "Image `data` value
- * lacks a base64 header!" and emit nothing at all. SVG is rasterized on this
- * path regardless, so both cases fall through to a screenshot instead.
+ * Whether a data URI can be embedded as-is. pptxgenjs needs `image/<type>;base64,` and
+ * emits nothing for a URL-encoded data URI; SVG is rasterized on this path regardless.
+ * Both fall through to a screenshot.
  */
 export function isUsableDataUri(url: string): boolean {
   return /^data:image\/(?!svg\+xml)[\w.+-]+;base64,/.test(url)
 }
 
 /**
- * Fetch an image through Playwright rather than through the page.
- *
- * The in-page route is `canvas.toDataURL()`, which THROWS on a cross-origin
- * image because the canvas is tainted, and Slidev's own starter deck uses a
- * remote cover photo. `APIRequestContext` is not subject to CORS.
+ * Fetch an image through `APIRequestContext`, which is not subject to CORS;
+ * the in-page route, `canvas.toDataURL()`, throws on a cross-origin image.
  */
 async function fetchImage(page: Page, url: string): Promise<string | undefined> {
   if (url.startsWith('data:'))
@@ -343,9 +259,8 @@ async function fetchImage(page: Page, url: string): Promise<string | undefined> 
     if (!response.ok())
       return undefined
     const type = response.headers()['content-type']?.split(';')[0] ?? 'image/png'
-    // An SVG fetched here would be embedded as an SVG picture, and pptxgenjs
-    // writes a broken raster fallback for those from Node. Let the caller
-    // screenshot the element instead.
+    // pptxgenjs writes a broken raster fallback for SVG from Node; let the
+    // caller screenshot the element instead.
     if (type.includes('svg'))
       return undefined
     const body = await response.body()
@@ -362,23 +277,15 @@ export interface CaptureReport {
   imagesFetched: number
   /** Images that could be neither fetched nor screenshotted. */
   imagesDropped: number
-  /**
-   * Captures that asked for isolation and could not find their element.
-   *
-   * Counted rather than ignored: an isolation that silently does nothing
-   * produces a picture with the slide's own text baked into it, which is then
-   * drawn again as shapes.
-   */
+  /** Captures that asked for isolation and could not find their element. A silent miss bakes the slide's own text into the picture, which is then drawn again as shapes. */
   isolationMissed: number
   fallbackSlides: { no: number, reason: string }[]
 }
 
 /**
- * Run every capture through one short, scrollable viewport.
- *
- * Resizing reflows the page, so it happens once around all of them rather than
- * per capture. Boxes are read live inside this viewport, so they stay
- * consistent with it even on a deck the resize does move.
+ * Run every capture through one short, scrollable viewport. Resizing reflows the page,
+ * so it happens once around all of them rather than per capture; boxes are read live
+ * inside this viewport, so they stay consistent with it.
  */
 async function throughShortViewport(page: Page, needed: boolean, height: number, fn: () => Promise<void>): Promise<void> {
   if (!needed) {
@@ -398,13 +305,7 @@ async function throughShortViewport(page: Page, needed: boolean, height: number,
   }
 }
 
-/**
- * Fill in every picture the IR asked for, and shoot whole-slide fallbacks.
- *
- * Mutates `slides` in place, because the IR is a private intermediate and
- * copying a deck's worth of base64 to stay pure would be a real cost for no
- * real benefit.
- */
+/** Fill in every picture the IR asked for, and shoot whole-slide fallbacks. Mutates `slides` in place. */
 export async function capture(
   page: Page,
   slides: SlideIr[],
@@ -443,8 +344,8 @@ export async function capture(
     try {
       if (request.isolate && !(await isolate(page, request.isolateId ?? request.sourceId, request.hideDescendants)))
         report.isolationMissed++
-      // A pseudo-element has no element to point at, so the page is clipped to
-      // the box the walker computed for it instead.
+      // A pseudo-element has no element to point at; clip the page to the box
+      // the walker computed for it instead.
       data = request.clip
         ? await shootClip(page, request.clip)
         : await shoot(page, `[${ID_ATTRIBUTE}="${request.sourceId}"]`)
@@ -480,19 +381,12 @@ export async function capture(
         report.imagesFetched++
       }
       else {
-        // Could not be fetched, or is an SVG that pptxgenjs would embed with a
-        // broken fallback. Either way, a picture of the element is honest.
-        //
-        // Isolated like any other capture. An `<img>` is mostly transparent
-        // whenever it points at an SVG, so without this the picture carried
-        // whatever the slide painted behind the icon and drew it a second time
-        // on top of the shapes that already say it.
+        // Unfetchable, or an SVG: screenshot the element instead, isolated so
+        // the picture does not carry what the slide painted behind it.
         try {
           if (!(await isolate(page, sourceId, false)))
             report.isolationMissed++
-          // Once per ELEMENT, not once per node it produced. One `<img>`
-          // showing on several click steps was isolated and screenshotted
-          // again for each of them, for the same pixels every time.
+          // Once per element, not once per node it produced across click steps.
           data = await shoot(page, `[${ID_ATTRIBUTE}="${sourceId}"]`)
           if (data)
             report.imagesFetched++
@@ -508,10 +402,8 @@ export async function capture(
     }
   })
 
-  // Anything without real image data would reach pptxgenjs as a bare URL or an
-  // empty string. It answers with `Image 'data' value lacks a base64 header!`
-  // on stderr and writes nothing, so the picture is missing either way and the
-  // export looks like it crashed.
+  // Anything without real image data would reach pptxgenjs as a bare URL or
+  // an empty string, which it rejects on stderr while writing nothing.
   for (const slide of slides) {
     slide.nodes = slide.nodes.filter((node) => {
       if (node.kind === 'raster')
@@ -528,7 +420,7 @@ export async function capture(
     for (const slide of slides) {
       if (!slide.fallbackReason)
         continue
-      // The exact container id. A prefix match plus `.first()` handed every
+      // The exact container id: a prefix match plus `.first()` hands every
       // click step of a slide the picture of step one.
       const shot = await shoot(page, `[id="${slide.containerId}"]`)
       if (shot) {
@@ -536,11 +428,8 @@ export async function capture(
         report.fallbackSlides.push({ no: slide.no, reason: slide.fallbackReason })
       }
       else {
-        // No picture either. The slide falls back to whatever shapes it has,
-        // but `normalize` withheld its raster requests, so its pictures were
-        // already dropped. Clearing the reason here hid that: the slide came
-        // out gutted and the warning that would have explained it was
-        // suppressed.
+        // Screenshot failed too. The slide keeps its shapes, but `normalize`
+        // withheld its raster requests, so keep the warning and clear the reason.
         report.fallbackSlides.push({
           no: slide.no,
           reason: `${slide.fallbackReason}, and the replacement screenshot failed, so the slide is incomplete`,

--- a/packages/slidev/node/commands/pptx/capture.ts
+++ b/packages/slidev/node/commands/pptx/capture.ts
@@ -9,8 +9,15 @@ import { Buffer } from 'node:buffer'
  * Measurement happens in one `page.evaluate`, but rasterization cannot: an
  * element screenshot has to be driven from Node, and isolating an element for
  * one means mutating the DOM of a live Vue app. So this is deliberately a
- * second phase, run strictly after every measurement is already in hand. No
- * geometry is ever read from a page this module has touched.
+ * second phase, run strictly after every measurement is already in hand.
+ *
+ * What this module does to the page is confined to two kinds of change, and
+ * neither one moves anything: inline `visibility` and `background-color`,
+ * which do not reflow, and the viewport HEIGHT, which the print route's
+ * fixed-size slide containers do not depend on. Its width is never touched,
+ * and width is what `PrintContainer` scales from. So the coordinates the
+ * walker measured stay valid here. A slide sizing itself in `vh` would break
+ * that, and would break the image exporter's own clip arithmetic first.
  */
 
 export const ID_ATTRIBUTE = 'data-slidev-export-id'
@@ -248,7 +255,25 @@ async function shoot(page: Page, selector: string): Promise<string | undefined> 
  * enough to be far under the limit, tall enough to hold any single element
  * worth capturing whole.
  */
-const CLIP_VIEWPORT_HEIGHT = 2000
+const CLIP_VIEWPORT_MIN_HEIGHT = 2000
+
+/**
+ * A viewport tall enough to hold the tallest thing being captured.
+ *
+ * A fixed two thousand pixels is shorter than a single slide once the deck
+ * sets `canvasWidth: 3840`, where 16:9 makes the slide 2160 tall. Every
+ * full-bleed picture and every whole-slide fallback then asks for a clip
+ * taller than the viewport and fails, silently, which is the exact class of
+ * failure the short viewport was introduced to fix.
+ */
+function clipViewportHeight(slides: SlideIr[], requests: RasterRequest[]): number {
+  const tallest = Math.max(
+    0,
+    ...slides.map(slide => slide.size.h),
+    ...requests.map(request => request.clip?.h ?? 0),
+  )
+  return Math.max(CLIP_VIEWPORT_MIN_HEIGHT, Math.ceil(tallest) + 200)
+}
 
 /**
  * Screenshot a rectangle of the document.
@@ -265,19 +290,22 @@ const CLIP_VIEWPORT_HEIGHT = 2000
  * browser has been closed".
  */
 export async function shootClip(page: Page, clip: Rect): Promise<string | undefined> {
-  // An element can start left of the page, and Chromium cannot capture a
-  // negative origin. Clamping keeps the picture rather than losing it.
+  // An element can start left of, or above, the page, and Chromium cannot
+  // capture a negative origin: it rejects the whole screenshot, so the picture
+  // went missing rather than being trimmed. Clamping keeps what there is.
   const x = Math.max(0, clip.x)
+  const y = Math.max(0, clip.y)
   const w = clip.w - (x - clip.x)
-  if (w <= 0 || clip.h <= 0)
+  const h = clip.h - (y - clip.y)
+  if (w <= 0 || h <= 0)
     return undefined
   try {
-    const scrollY = await page.evaluate((y) => {
-      window.scrollTo(0, y)
+    const scrollY = await page.evaluate((top) => {
+      window.scrollTo(0, top)
       return window.scrollY
-    }, Math.max(0, clip.y - 1))
+    }, Math.max(0, y - 1))
     const buffer = await page.screenshot({
-      clip: { x, y: clip.y - scrollY, width: w, height: clip.h },
+      clip: { x, y: y - scrollY, width: w, height: h },
       omitBackground: true,
       timeout: 10_000,
     })
@@ -352,15 +380,15 @@ export interface CaptureReport {
  * per capture. Boxes are read live inside this viewport, so they stay
  * consistent with it even on a deck the resize does move.
  */
-async function throughShortViewport(page: Page, needed: boolean, fn: () => Promise<void>): Promise<void> {
+async function throughShortViewport(page: Page, needed: boolean, height: number, fn: () => Promise<void>): Promise<void> {
   if (!needed) {
     await fn()
     return
   }
   const viewport = page.viewportSize()
   try {
-    if (viewport && viewport.height > CLIP_VIEWPORT_HEIGHT)
-      await page.setViewportSize({ width: viewport.width, height: CLIP_VIEWPORT_HEIGHT })
+    if (viewport && viewport.height > height)
+      await page.setViewportSize({ width: viewport.width, height })
     await fn()
   }
   finally {
@@ -440,40 +468,43 @@ export async function capture(
     }
   }
 
-  await throughShortViewport(page, !!requests.length || !!imagesBySource.size, async () => {
+  const viewportHeight = clipViewportHeight(slides, requests)
+
+  await throughShortViewport(page, !!requests.length || !!imagesBySource.size, viewportHeight, async () => {
     for (const request of requests)
       await fulfil(request)
 
     for (const [sourceId, nodes] of imagesBySource) {
-      const url = nodes[0].data
-      const data = await fetchImage(page, url)
-      for (const node of nodes) {
-        if (data) {
-          node.data = data
-          report.imagesFetched++
+      let data = await fetchImage(page, nodes[0].data)
+      if (data) {
+        report.imagesFetched++
+      }
+      else {
+        // Could not be fetched, or is an SVG that pptxgenjs would embed with a
+        // broken fallback. Either way, a picture of the element is honest.
+        //
+        // Isolated like any other capture. An `<img>` is mostly transparent
+        // whenever it points at an SVG, so without this the picture carried
+        // whatever the slide painted behind the icon and drew it a second time
+        // on top of the shapes that already say it.
+        try {
+          if (!(await isolate(page, sourceId, false)))
+            report.isolationMissed++
+          // Once per ELEMENT, not once per node it produced. One `<img>`
+          // showing on several click steps was isolated and screenshotted
+          // again for each of them, for the same pixels every time.
+          data = await shoot(page, `[${ID_ATTRIBUTE}="${sourceId}"]`)
+          if (data)
+            report.imagesFetched++
         }
-        else {
-          // Could not be fetched, or is an SVG that pptxgenjs would embed with
-          // a broken fallback. Either way, a picture of the element is honest.
-          //
-          // Isolated like any other capture. An `<img>` is mostly transparent
-          // whenever it points at an SVG, so without this the picture carried
-          // whatever the slide painted behind the icon and drew it a second
-          // time on top of the shapes that already say it.
-          try {
-            if (!(await isolate(page, sourceId, false)))
-              report.isolationMissed++
-            const shot = await shoot(page, `[${ID_ATTRIBUTE}="${sourceId}"]`)
-            if (shot) {
-              node.data = shot
-              report.rastersCaptured++
-            }
-          }
-          finally {
-            await restore(page)
-          }
+        finally {
+          await restore(page)
         }
       }
+      if (!data)
+        continue
+      for (const node of nodes)
+        node.data = data
     }
   })
 
@@ -493,7 +524,7 @@ export async function capture(
     })
   }
 
-  await throughShortViewport(page, slides.some(slide => !!slide.fallbackReason), async () => {
+  await throughShortViewport(page, slides.some(slide => !!slide.fallbackReason), viewportHeight, async () => {
     for (const slide of slides) {
       if (!slide.fallbackReason)
         continue

--- a/packages/slidev/node/commands/pptx/color.ts
+++ b/packages/slidev/node/commands/pptx/color.ts
@@ -1,0 +1,151 @@
+import type { Rgba } from './ir'
+
+/**
+ * Somewhere to record a color string no parser understood. A parameter rather
+ * than module state, so calls made outside an export run cannot accumulate
+ * into the next one.
+ */
+export type UnparsedColors = Set<string> | undefined
+
+function numbers(body: string): number[] {
+  return body.split(/[\s,/]+/).filter(Boolean).map((token) => {
+    const n = Number.parseFloat(token)
+    return token.endsWith('%') ? n / 100 : n
+  })
+}
+
+function srgbChannel(v: number): number {
+  // The sRGB transfer function, for converting linear light back to 0-255.
+  const c = v <= 0.0031308 ? v * 12.92 : 1.055 * v ** (1 / 2.4) - 0.055
+  return Math.max(0, Math.min(255, Math.round(c * 255)))
+}
+
+/** Oklab to sRGB, per the CSS Color 4 conversion. */
+function oklabToRgb(L: number, a: number, b: number): [number, number, number] {
+  const l = (L + 0.3963377774 * a + 0.2158037573 * b) ** 3
+  const m = (L - 0.1055613458 * a - 0.0638541728 * b) ** 3
+  const s = (L - 0.0894841775 * a - 1.2914855480 * b) ** 3
+  return [
+    srgbChannel(4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s),
+    srgbChannel(-1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s),
+    srgbChannel(-0.0041960863 * l - 0.7034186147 * m + 1.7076147010 * s),
+  ]
+}
+
+function hueToRgb(h: number, s: number, l: number): [number, number, number] {
+  const c = (1 - Math.abs(2 * l - 1)) * s
+  const hp = (((h % 360) + 360) % 360) / 60
+  const x = c * (1 - Math.abs((hp % 2) - 1))
+  const [r, g, b]
+    = hp < 1
+      ? [c, x, 0]
+      : hp < 2
+        ? [x, c, 0]
+        : hp < 3
+          ? [0, c, x]
+          : hp < 4
+            ? [0, x, c]
+            : hp < 5
+              ? [x, 0, c]
+              : [c, 0, x]
+  const m = l - c / 2
+  const to255 = (v: number) => Math.max(0, Math.min(255, Math.round((v + m) * 255)))
+  return [to255(r), to255(g), to255(b)]
+}
+
+/**
+ * A computed CSS color, in any syntax Chromium actually serializes: a theme
+ * authored in modern syntax keeps `oklch()`, `color()` or `hsl()` in the
+ * computed value, and dropping those loses every fill on the slide.
+ */
+export function parseColor(value: string | undefined, unparsed?: UnparsedColors): Rgba | undefined {
+  if (!value)
+    return undefined
+  const text = value.trim()
+  if (text === 'transparent')
+    return { r: 0, g: 0, b: 0, a: 0 }
+
+  const fn = text.match(/^([a-z-]+)\(([^)]+)\)$/i)
+  if (!fn) {
+    unparsed?.add(text)
+    return undefined
+  }
+  const name = fn[1].toLowerCase()
+
+  if (name === 'color') {
+    // Before the numeric guard: the first token is a color space name, so
+    // parsing the whole body as numbers would reject every `color()` value.
+    const tokens = fn[2].trim().split(/[\s,/]+/).filter(Boolean)
+    const channels = numbers(tokens.slice(1).join(' '))
+    if (tokens[0] === 'srgb' && channels.length >= 3 && !channels.slice(0, 3).some(Number.isNaN)) {
+      return {
+        r: Math.round(channels[0] * 255),
+        g: Math.round(channels[1] * 255),
+        b: Math.round(channels[2] * 255),
+        a: channels.length > 3 && !Number.isNaN(channels[3]) ? channels[3] : 1,
+      }
+    }
+    unparsed?.add(text)
+    return undefined
+  }
+
+  const parts = numbers(fn[2])
+  if (parts.some(Number.isNaN)) {
+    unparsed?.add(text)
+    return undefined
+  }
+  const alpha = (index: number) => (parts.length > index ? parts[index] : 1)
+
+  if (name === 'rgb' || name === 'rgba') {
+    if (parts.length < 3)
+      return undefined
+    // Percentage channels were divided by 100 above, so scale them back.
+    const channel = (v: number, raw: string) => (raw.includes('%') ? v * 255 : v)
+    const raw = fn[2].split(/[\s,/]+/).filter(Boolean)
+    return {
+      r: channel(parts[0], raw[0] ?? ''),
+      g: channel(parts[1], raw[1] ?? ''),
+      b: channel(parts[2], raw[2] ?? ''),
+      a: alpha(3),
+    }
+  }
+
+  if (name === 'hsl' || name === 'hsla') {
+    if (parts.length < 3)
+      return undefined
+    const [r, g, b] = hueToRgb(parts[0], parts[1], parts[2])
+    return { r, g, b, a: alpha(3) }
+  }
+
+  if (name === 'oklch' || name === 'oklab') {
+    if (parts.length < 3)
+      return undefined
+    const L = parts[0]
+    const [a, b] = name === 'oklch'
+      ? [parts[1] * Math.cos((parts[2] * Math.PI) / 180), parts[1] * Math.sin((parts[2] * Math.PI) / 180)]
+      : [parts[1], parts[2]]
+    const [r, g, bb] = oklabToRgb(L, a, b)
+    return { r, g, b: bb, a: alpha(3) }
+  }
+
+  unparsed?.add(text)
+  return undefined
+}
+
+/** Whether a color contributes any ink at all. */
+export function isVisible(color: Rgba | undefined): boolean {
+  return !!color && color.a > 0
+}
+
+/**
+ * Fold an element's effective opacity into a color's own alpha: DrawingML has
+ * no element-level or group opacity, only per-fill alpha. The walker compounds
+ * the value down the tree, since CSS `opacity` does not inherit.
+ */
+export function withOpacity(color: Rgba | undefined, opacity: number | undefined): Rgba | undefined {
+  if (!color)
+    return undefined
+  if (opacity === undefined || !Number.isFinite(opacity) || opacity >= 1)
+    return color
+  return { ...color, a: color.a * Math.max(0, opacity) }
+}

--- a/packages/slidev/node/commands/pptx/index.ts
+++ b/packages/slidev/node/commands/pptx/index.ts
@@ -68,6 +68,16 @@ export async function exportPptxEditable(
 ): Promise<EditableExportResult> {
   await ctx.go('print')
 
+  // Measurement and capture are two separate passes over the page, so anything
+  // still moving between them is measured at one frame and photographed at
+  // another. A theme spinning a logo forever came out cropped and rotated
+  // against its own box. Pausing rather than cancelling keeps a reveal
+  // animation at the end state the deck settled on, which is what the audience
+  // saw; `animation: none` would rewind a fade-in to opacity zero instead.
+  await ctx.page.addStyleTag({
+    content: '*, *::before, *::after { animation-play-state: paused !important; transition: none !important; }',
+  })
+
   const snapshot = await ctx.page.evaluate(collectSnapshot, {
     containerSelector: '.print-slide-container',
     idAttribute: ID_ATTRIBUTE,

--- a/packages/slidev/node/commands/pptx/index.ts
+++ b/packages/slidev/node/commands/pptx/index.ts
@@ -43,6 +43,8 @@ export interface EditableExportResult {
   imagesDropped: number
   /** Colour strings no parser understood, so the user can report them. */
   unparsedColors: string[]
+  /** Decorative pseudo-elements whose box could not be resolved. */
+  unplaceablePseudos: string[]
   /** The path actually written, extension included. */
   output: string
 }
@@ -102,6 +104,7 @@ export async function exportPptxEditable(
     fallbackSlides: report.fallbackSlides,
     imagesDropped: report.imagesDropped,
     unparsedColors: takeUnparsedColors(),
+    unplaceablePseudos: [...new Set(snapshot.unplaceablePseudos ?? [])].sort(),
     // A pptx NAMES fonts, it does not carry them. Reporting which families the
     // file asks for is the only way an author learns what recipients need
     // installed before the deck reaches them looking wrong.

--- a/packages/slidev/node/commands/pptx/index.ts
+++ b/packages/slidev/node/commands/pptx/index.ts
@@ -1,21 +1,13 @@
 import type { SlideInfo } from '@slidev/types'
 import type { Page } from 'playwright-chromium'
 import fs from 'node:fs/promises'
+import { dim, yellow } from 'ansis'
 import { buildPptx } from './build'
 import { capture, ID_ATTRIBUTE } from './capture'
 import { normalize } from './normalize'
 import { collectSnapshot } from './walker'
 
-/**
- * Everything the editable exporter needs from `exportSlides`, as an explicit
- * object rather than as closure scope.
- *
- * The existing per-format generators are nested closures over `exportSlides`'s
- * locals. Following that pattern would have put this whole feature inside an
- * already 665-line function. Taking a context instead keeps `export.ts` to a
- * five-line change, and matches the shape `plans/023` wants when the per-format
- * extraction eventually happens.
- */
+/** Everything the editable exporter needs from `exportSlides`, as an explicit object rather than closure scope. */
 export interface PptxExportContext {
   page: Page
   slides: SlideInfo[]
@@ -23,14 +15,7 @@ export interface PptxExportContext {
   width: number
   /** Canvas height in pixels. */
   height: number
-  /**
-   * The 1-based slide numbers `--range` selected.
-   *
-   * Belt and braces. `go` puts the range in the query and `PrintContainer`
-   * renders only `printRange`, so the page should already hold nothing else;
-   * the image exporter carries the same defensive filter, as
-   * `if (!pages.includes(slideNo)) continue`.
-   */
+  /** The 1-based slide numbers `--range` selected; the same defensive filter the image exporter carries. */
   pages: number[]
   /** Navigate and wait for the deck to settle. `exportSlides` owns this. */
   go: (no: number | string, clicks?: string) => Promise<void>
@@ -46,7 +31,7 @@ export interface EditableExportResult {
   isolationMissed: number
   /** Elements whose screenshot failed, so they are missing from the file. */
   rastersFailed: number
-  /** Colour strings no parser understood, so the user can report them. */
+  /** Color strings no parser understood, so the user can report them. */
   unparsedColors: string[]
   /** Decorative pseudo-elements whose box could not be resolved. */
   unplaceablePseudos: string[]
@@ -55,13 +40,10 @@ export interface EditableExportResult {
 }
 
 /**
- * Export the deck as PowerPoint with native shapes and editable text.
- *
- * One navigation covers the whole deck: the print route renders every slide,
- * and every click step, into a single tall page, which is also how the image
- * exporter finds its slide indexes. So there is no per-slide loop here, and
- * `--with-clicks` needs no special handling: each step is already its own
- * `.print-slide-container`.
+ * Export the deck as PowerPoint with native shapes and editable text. One
+ * navigation covers everything: the print route renders every slide and click
+ * step into a single tall page, so there is no per-slide loop here and
+ * `--with-clicks` needs no special handling.
  */
 export async function exportPptxEditable(
   ctx: PptxExportContext,
@@ -69,12 +51,9 @@ export async function exportPptxEditable(
 ): Promise<EditableExportResult> {
   await ctx.go('print')
 
-  // Measurement and capture are two separate passes over the page, so anything
-  // still moving between them is measured at one frame and photographed at
-  // another. A theme spinning a logo forever came out cropped and rotated
-  // against its own box. Pausing rather than cancelling keeps a reveal
-  // animation at the end state the deck settled on, which is what the audience
-  // saw; `animation: none` would rewind a fade-in to opacity zero instead.
+  // Measurement and capture are separate passes, so anything still animating is
+  // measured at one frame and photographed at another. Pausing keeps the settled
+  // end state; `animation: none` would rewind a fade-in to opacity zero.
   await ctx.page.addStyleTag({
     content: '*, *::before, *::after { animation-play-state: paused !important; transition: none !important; }',
   })
@@ -84,8 +63,7 @@ export async function exportPptxEditable(
     idAttribute: ID_ATTRIBUTE,
   })
 
-  // Filtered before normalizing, so anything the print route did leave in the
-  // page costs no measurement work and no screenshots.
+  // Filter before normalizing, so leftover pages cost no measurement or screenshots.
   snapshot.slides = snapshot.slides.filter(slide => ctx.pages.includes(slide.no))
 
   const notes = new Map<number, string | undefined>()
@@ -95,9 +73,8 @@ export async function exportPptxEditable(
   const report = await capture(ctx.page, slides, rasterRequests)
 
   const title = ctx.slides[0]
-  // `?? module` because a bundler or a CJS interop layer can hand back the
-  // constructor itself rather than a namespace with `default` on it, and the
-  // failure is a `TypeError` at the last step of a slow export.
+  // A bundler or CJS interop layer can hand back the constructor itself rather
+  // than a namespace with `default` on it.
   const pptxgenjs = await import('pptxgenjs')
   const buffer = await buildPptx(
     pptxgenjs.default ?? (pptxgenjs as unknown as typeof pptxgenjs.default),
@@ -111,9 +88,7 @@ export async function exportPptxEditable(
     },
   )
 
-  // Returned rather than only used here: `exportSlides` prints the path it was
-  // given, so appending the extension locally told the user "exported to
-  // ./slides-export" for a file written as ./slides-export.pptx.
+  // Return the path actually written: `exportSlides` prints the path it was given.
   const written = output.endsWith('.pptx') ? output : `${output}.pptx`
   await fs.writeFile(written, buffer)
 
@@ -126,9 +101,31 @@ export async function exportPptxEditable(
     rastersFailed: report.rastersFailed,
     unparsedColors,
     unplaceablePseudos: [...new Set(snapshot.unplaceablePseudos ?? [])].sort(),
-    // A pptx NAMES fonts, it does not carry them. Reporting which families the
-    // file asks for is the only way an author learns what recipients need
-    // installed before the deck reaches them looking wrong.
+    // A pptx names fonts, it does not carry them; report what recipients need installed.
     fontsNamed: [...new Set(Object.values(snapshot.fontResolution).filter(Boolean))].sort(),
+  }
+}
+
+/** Print what the export could not do, after the progress bar has stopped. */
+export function reportEditableExport(result: EditableExportResult): void {
+  for (const slide of result.fallbackSlides)
+    console.warn(yellow(`  slide ${slide.no}: exported as an image (${slide.reason})`))
+  if (result.imagesDropped)
+    console.warn(yellow(`  ${result.imagesDropped} image(s) could not be read and were left out`))
+  if (result.rastersFailed)
+    console.warn(yellow(`  ${result.rastersFailed} element(s) could not be captured as a picture and were left out`))
+  if (result.unparsedColors.length) {
+    console.warn(yellow(`  ${result.unparsedColors.length} color value(s) could not be read, so those fills are missing:`))
+    console.warn(dim(`    ${result.unparsedColors.slice(0, 5).join(', ')}`))
+  }
+  if (result.isolationMissed)
+    console.warn(yellow(`  ${result.isolationMissed} picture(s) could not be isolated, so their slide may show doubled text`))
+  if (result.unplaceablePseudos.length) {
+    console.warn(yellow(`  ${result.unplaceablePseudos.length} CSS decoration(s) could not be placed and were left out:`))
+    console.warn(dim(`    ${result.unplaceablePseudos.slice(0, 5).join(', ')}`))
+  }
+  if (result.fontsNamed.length) {
+    console.warn(dim(`  fonts named in this file: ${result.fontsNamed.join(', ')}`))
+    console.warn(dim('  a .pptx names fonts rather than embedding them, so recipients need these installed'))
   }
 }

--- a/packages/slidev/node/commands/pptx/index.ts
+++ b/packages/slidev/node/commands/pptx/index.ts
@@ -3,7 +3,7 @@ import type { Page } from 'playwright-chromium'
 import fs from 'node:fs/promises'
 import { buildPptx } from './build'
 import { capture, ID_ATTRIBUTE } from './capture'
-import { normalize, takeUnparsedColors } from './normalize'
+import { normalize } from './normalize'
 import { collectSnapshot } from './walker'
 
 /**
@@ -41,6 +41,8 @@ export interface EditableExportResult {
   fontsNamed: string[]
   /** Images that could be neither fetched nor screenshotted. */
   imagesDropped: number
+  /** Captures that asked for isolation and could not find their element. */
+  isolationMissed: number
   /** Colour strings no parser understood, so the user can report them. */
   unparsedColors: string[]
   /** Decorative pseudo-elements whose box could not be resolved. */
@@ -76,7 +78,7 @@ export async function exportPptxEditable(
   const notes = new Map<number, string | undefined>()
   ctx.slides.forEach((slide, index) => notes.set(index + 1, slide.note))
 
-  const { slides, rasterRequests } = normalize(snapshot, { notes })
+  const { slides, rasterRequests, unparsedColors } = normalize(snapshot, { notes })
   const report = await capture(ctx.page, slides, rasterRequests)
 
   const title = ctx.slides[0]
@@ -103,7 +105,8 @@ export async function exportPptxEditable(
     slideCount: slides.length,
     fallbackSlides: report.fallbackSlides,
     imagesDropped: report.imagesDropped,
-    unparsedColors: takeUnparsedColors(),
+    isolationMissed: report.isolationMissed,
+    unparsedColors,
     unplaceablePseudos: [...new Set(snapshot.unplaceablePseudos ?? [])].sort(),
     // A pptx NAMES fonts, it does not carry them. Reporting which families the
     // file asks for is the only way an author learns what recipients need

--- a/packages/slidev/node/commands/pptx/index.ts
+++ b/packages/slidev/node/commands/pptx/index.ts
@@ -1,0 +1,110 @@
+import type { SlideInfo } from '@slidev/types'
+import type { Page } from 'playwright-chromium'
+import fs from 'node:fs/promises'
+import { buildPptx } from './build'
+import { capture, ID_ATTRIBUTE } from './capture'
+import { normalize, takeUnparsedColors } from './normalize'
+import { collectSnapshot } from './walker'
+
+/**
+ * Everything the editable exporter needs from `exportSlides`, as an explicit
+ * object rather than as closure scope.
+ *
+ * The existing per-format generators are nested closures over `exportSlides`'s
+ * locals. Following that pattern would have put this whole feature inside an
+ * already 665-line function. Taking a context instead keeps `export.ts` to a
+ * five-line change, and matches the shape `plans/023` wants when the per-format
+ * extraction eventually happens.
+ */
+export interface PptxExportContext {
+  page: Page
+  slides: SlideInfo[]
+  /** Canvas width in pixels. */
+  width: number
+  /** Canvas height in pixels. */
+  height: number
+  /**
+   * The 1-based slide numbers `--range` selected.
+   *
+   * The print route renders EVERY slide whatever the `range` query says, so
+   * this has to be applied here. The image exporter does the same thing with
+   * `if (!pages.includes(slideNo)) continue`.
+   */
+  pages: number[]
+  /** Navigate and wait for the deck to settle. `exportSlides` owns this. */
+  go: (no: number | string, clicks?: string) => Promise<void>
+}
+
+export interface EditableExportResult {
+  slideCount: number
+  fallbackSlides: { no: number, reason: string }[]
+  fontsNamed: string[]
+  /** Images that could be neither fetched nor screenshotted. */
+  imagesDropped: number
+  /** Colour strings no parser understood, so the user can report them. */
+  unparsedColors: string[]
+  /** The path actually written, extension included. */
+  output: string
+}
+
+/**
+ * Export the deck as PowerPoint with native shapes and editable text.
+ *
+ * One navigation covers the whole deck: the print route renders every slide,
+ * and every click step, into a single tall page, which is also how the image
+ * exporter finds its slide indexes. So there is no per-slide loop here, and
+ * `--with-clicks` needs no special handling: each step is already its own
+ * `.print-slide-container`.
+ */
+export async function exportPptxEditable(
+  ctx: PptxExportContext,
+  output: string,
+): Promise<EditableExportResult> {
+  await ctx.go('print')
+
+  const snapshot = await ctx.page.evaluate(collectSnapshot, {
+    containerSelector: '.print-slide-container',
+    idAttribute: ID_ATTRIBUTE,
+  })
+
+  // Filtered before normalizing, so out-of-range slides cost no measurement
+  // work and no screenshots.
+  snapshot.slides = snapshot.slides.filter(slide => ctx.pages.includes(slide.no))
+
+  const notes = new Map<number, string | undefined>()
+  ctx.slides.forEach((slide, index) => notes.set(index + 1, slide.note))
+
+  const { slides, rasterRequests } = normalize(snapshot, { notes })
+  const report = await capture(ctx.page, slides, rasterRequests)
+
+  const title = ctx.slides[0]
+  const buffer = await buildPptx(
+    (await import('pptxgenjs')).default,
+    slides,
+    {
+      width: ctx.width,
+      height: ctx.height,
+      title: title?.title,
+      author: title?.frontmatter?.author,
+      subject: title?.frontmatter?.info,
+    },
+  )
+
+  // Returned rather than only used here: `exportSlides` prints the path it was
+  // given, so appending the extension locally told the user "exported to
+  // ./slides-export" for a file written as ./slides-export.pptx.
+  const written = output.endsWith('.pptx') ? output : `${output}.pptx`
+  await fs.writeFile(written, buffer)
+
+  return {
+    output: written,
+    slideCount: slides.length,
+    fallbackSlides: report.fallbackSlides,
+    imagesDropped: report.imagesDropped,
+    unparsedColors: takeUnparsedColors(),
+    // A pptx NAMES fonts, it does not carry them. Reporting which families the
+    // file asks for is the only way an author learns what recipients need
+    // installed before the deck reaches them looking wrong.
+    fontsNamed: [...new Set(Object.values(snapshot.fontResolution).filter(Boolean))].sort(),
+  }
+}

--- a/packages/slidev/node/commands/pptx/index.ts
+++ b/packages/slidev/node/commands/pptx/index.ts
@@ -26,8 +26,9 @@ export interface PptxExportContext {
   /**
    * The 1-based slide numbers `--range` selected.
    *
-   * The print route renders EVERY slide whatever the `range` query says, so
-   * this has to be applied here. The image exporter does the same thing with
+   * Belt and braces. `go` puts the range in the query and `PrintContainer`
+   * renders only `printRange`, so the page should already hold nothing else;
+   * the image exporter carries the same defensive filter, as
    * `if (!pages.includes(slideNo)) continue`.
    */
   pages: number[]
@@ -83,8 +84,8 @@ export async function exportPptxEditable(
     idAttribute: ID_ATTRIBUTE,
   })
 
-  // Filtered before normalizing, so out-of-range slides cost no measurement
-  // work and no screenshots.
+  // Filtered before normalizing, so anything the print route did leave in the
+  // page costs no measurement work and no screenshots.
   snapshot.slides = snapshot.slides.filter(slide => ctx.pages.includes(slide.no))
 
   const notes = new Map<number, string | undefined>()
@@ -94,8 +95,12 @@ export async function exportPptxEditable(
   const report = await capture(ctx.page, slides, rasterRequests)
 
   const title = ctx.slides[0]
+  // `?? module` because a bundler or a CJS interop layer can hand back the
+  // constructor itself rather than a namespace with `default` on it, and the
+  // failure is a `TypeError` at the last step of a slow export.
+  const pptxgenjs = await import('pptxgenjs')
   const buffer = await buildPptx(
-    (await import('pptxgenjs')).default,
+    pptxgenjs.default ?? (pptxgenjs as unknown as typeof pptxgenjs.default),
     slides,
     {
       width: ctx.width,

--- a/packages/slidev/node/commands/pptx/index.ts
+++ b/packages/slidev/node/commands/pptx/index.ts
@@ -43,6 +43,8 @@ export interface EditableExportResult {
   imagesDropped: number
   /** Captures that asked for isolation and could not find their element. */
   isolationMissed: number
+  /** Elements whose screenshot failed, so they are missing from the file. */
+  rastersFailed: number
   /** Colour strings no parser understood, so the user can report them. */
   unparsedColors: string[]
   /** Decorative pseudo-elements whose box could not be resolved. */
@@ -106,6 +108,7 @@ export async function exportPptxEditable(
     fallbackSlides: report.fallbackSlides,
     imagesDropped: report.imagesDropped,
     isolationMissed: report.isolationMissed,
+    rastersFailed: report.rastersFailed,
     unparsedColors,
     unplaceablePseudos: [...new Set(snapshot.unplaceablePseudos ?? [])].sort(),
     // A pptx NAMES fonts, it does not carry them. Reporting which families the

--- a/packages/slidev/node/commands/pptx/ir.ts
+++ b/packages/slidev/node/commands/pptx/ir.ts
@@ -256,6 +256,13 @@ export interface IrText extends IrBase {
   /** Distinct line-box tops. One means the box must not be allowed to re-wrap. */
   lineCount: number
   align: 'left' | 'center' | 'right' | 'justify'
+  /**
+   * Vertical anchoring inside the box. Defaults to the top, because a box is
+   * normally measured from the glyphs themselves.
+   *
+   * A chip label is the exception: its box is the decoration, not the ink.
+   */
+  valign?: 'top' | 'middle'
   /** Pixels, with `normal` already resolved to a number. */
   lineHeight: number
   runs: IrRun[]

--- a/packages/slidev/node/commands/pptx/ir.ts
+++ b/packages/slidev/node/commands/pptx/ir.ts
@@ -188,6 +188,11 @@ export interface IrRun {
   bold?: boolean
   italic?: boolean
   underline?: boolean
+  /**
+   * How the underline is drawn. A `border-bottom` on inline text is an
+   * underline, and DrawingML can dash one, so it does not need a shape.
+   */
+  underlineStyle?: 'sng' | 'dash' | 'dotted'
   strike?: boolean
   color?: Rgba
   /** Pixels. */

--- a/packages/slidev/node/commands/pptx/ir.ts
+++ b/packages/slidev/node/commands/pptx/ir.ts
@@ -314,6 +314,18 @@ export interface IrImage extends IrBase {
   data: string
   alt?: string
   link?: string
+  /**
+   * The region of the image to show, when the slide edge cut it short.
+   *
+   * `rect` is the visible box, but the picture is drawn at its FULL size and
+   * then cropped to that box, exactly as the browser does. Without this the
+   * whole image was squeezed into the clipped box, so an image running off the
+   * bottom of the slide came out vertically compressed rather than cut off.
+   *
+   * All four values are CSS pixels: `w`/`h` the full undipped display size,
+   * `x`/`y` the offset from its top-left corner to `rect`.
+   */
+  crop?: { x: number, y: number, w: number, h: number }
 }
 
 export type RasterReason

--- a/packages/slidev/node/commands/pptx/ir.ts
+++ b/packages/slidev/node/commands/pptx/ir.ts
@@ -84,6 +84,8 @@ export interface RawStyle {
   letterSpacing: string
   lineHeight: string
   whiteSpace: string
+  paddingLeft: string
+  paddingRight: string
   borderTopWidth: string
   borderTopStyle: string
   borderTopColor: string
@@ -288,15 +290,22 @@ export interface IrRaster extends IrBase {
   data: string
   reason: RasterReason
   /**
-   * Capture this element with its siblings hidden and only its own ancestor
-   * chain revealed.
+   * Capture with everything else on the page hidden.
    *
-   * Needed because `locator.screenshot()` clips the page to the element's box
-   * rather than isolating the element: without hiding siblings, whatever is
-   * painted on top of a backdrop is baked into the backdrop's own picture and
-   * then drawn again as shapes.
+   * `locator.screenshot()` clips the page to the element's box rather than
+   * isolating the element, so anything overlapping that box lands in the
+   * picture. Whatever we also draw as a shape would then appear twice.
    */
   isolate: boolean
+  /**
+   * Also hide the element's own children while capturing.
+   *
+   * Only correct when those children are walked and redrawn as shapes, which
+   * is true for a backdrop and false for a leaf such as an `<svg>`. Hiding a
+   * leaf's children removes its artwork from the picture and nothing puts it
+   * back, which emptied the decorative chrome out of a themed deck.
+   */
+  hideDescendants: boolean
 }
 
 export type IrNode = IrBox | IrText | IrImage | IrRaster

--- a/packages/slidev/node/commands/pptx/ir.ts
+++ b/packages/slidev/node/commands/pptx/ir.ts
@@ -108,6 +108,12 @@ export interface RawStyle {
   writingMode: string
   webkitBackgroundClip: string
   overflow: string
+  top: string
+  right: string
+  bottom: string
+  left: string
+  width: string
+  height: string
 }
 
 export interface RawNode {
@@ -147,6 +153,13 @@ export interface RawNode {
   fromShadowRoot?: boolean
   /** A `::marker` list bullet, which is a pseudo-element and has no text node. */
   marker?: string
+  /**
+   * Page coordinates, for a node that cannot be pointed at with a selector.
+   *
+   * A `::before` or `::after` has no element of its own, so a screenshot has
+   * to clip the page rather than target a locator.
+   */
+  pageRect?: Rect
 }
 
 export interface RawSlide {
@@ -182,6 +195,14 @@ export interface RawSnapshot {
    * silently gets a substitution.
    */
   fontResolution: Record<string, string>
+  /**
+   * Pseudo-elements that paint something but whose box cannot be resolved from
+   * computed style, because they take part in inline or block flow.
+   *
+   * Reported rather than dropped in silence, so a missing decoration is a line
+   * in the log instead of a mystery.
+   */
+  unplaceablePseudos: string[]
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/slidev/node/commands/pptx/ir.ts
+++ b/packages/slidev/node/commands/pptx/ir.ts
@@ -151,6 +151,14 @@ export interface RawNode {
   hasForeignObject?: boolean
   /** Reached through `el.shadowRoot`. Mermaid diagrams live in one. */
   fromShadowRoot?: boolean
+  /**
+   * Opacity compounded from every ancestor, present only when below 1.
+   *
+   * CSS `opacity` does not inherit, but DrawingML has no group opacity, so the
+   * wrapper's transparency has to be folded into each descendant's own colours
+   * or a dimmed block exports at full strength.
+   */
+  opacity?: number
   /** A `::marker` list bullet, which is a pseudo-element and has no text node. */
   marker?: string
   /**

--- a/packages/slidev/node/commands/pptx/ir.ts
+++ b/packages/slidev/node/commands/pptx/ir.ts
@@ -138,6 +138,16 @@ export interface RawNode {
   glyphRects?: Rect[]
   /** Text nodes only: raw `textContent`, before `text-transform` is applied. */
   text?: string
+  /**
+   * One rect per line box, for an inline element whose box spans more than
+   * one line.
+   *
+   * A browser paints an inline element's background and borders once per line
+   * FRAGMENT, not once over the union of them. `getBoundingClientRect()`
+   * returns that union, so a wrapped inline `<code>` came out as one solid
+   * rectangle covering the blank space at the end of every line.
+   */
+  fragments?: Rect[]
   /** `IMG` only. */
   src?: string
   /** `IMG` only. */

--- a/packages/slidev/node/commands/pptx/ir.ts
+++ b/packages/slidev/node/commands/pptx/ir.ts
@@ -69,6 +69,7 @@ export interface Rect {
 export interface RawStyle {
   display: string
   position: string
+  zIndex: string
   visibility: string
   opacity: string
   color: string

--- a/packages/slidev/node/commands/pptx/ir.ts
+++ b/packages/slidev/node/commands/pptx/ir.ts
@@ -155,6 +155,15 @@ export interface RawNode {
   /** `A` only, resolved absolute. */
   href?: string
   /**
+   * The root of a rendered formula.
+   *
+   * KaTeX sets a formula as dozens of separately positioned spans in its own
+   * metric fonts, with the radicals, braces and fraction rules drawn as bare
+   * boxes. Walked as text it comes apart: glyphs land off their baselines and
+   * every rule disappears. It is a picture or it is nothing.
+   */
+  isMath?: boolean
+  /**
    * An `SVG` carrying `<foreignObject>`, which means its labels are HTML with
    * no `<text>` element. Mermaid renders this way and no PowerPoint renderer
    * draws it, so it has to be rasterized.
@@ -330,6 +339,7 @@ export interface IrImage extends IrBase {
 
 export type RasterReason
   = | 'svg'
+    | 'math'
     | 'foreign-object'
     | 'canvas'
     | 'media'

--- a/packages/slidev/node/commands/pptx/ir.ts
+++ b/packages/slidev/node/commands/pptx/ir.ts
@@ -1,52 +1,23 @@
 /**
- * The intermediate representation between the rendered DOM and a `.pptx`.
- *
- * Two levels, on purpose:
- *
- * - `RawSnapshot` is what the in-page walker returns. It stays deliberately
- *   close to the DOM and contains no judgement at all, because everything
- *   inside `page.evaluate` is unreachable from a unit test.
- * - `SlideIr` is what the normalizer produces. It stays deliberately close to
- *   what `pptxgenjs` wants, so the builder is a translation rather than a
- *   second round of decisions.
- *
- * Every judgement lives in `normalize.ts`, between the two, as pure functions
- * over plain JSON. That split is the whole reason this is testable without a
- * browser.
- *
- * This file has no imports and no runtime behaviour beyond three constants, so
- * it can be shared with the browser exporter later without moving anything.
+ * Intermediate representation between the rendered DOM and a `.pptx`.
+ * `RawSnapshot` is what the in-page walker returns and stays close to the DOM
+ * (code inside `page.evaluate` is unreachable from unit tests). `SlideIr` is
+ * what the normalizer produces and stays close to what `pptxgenjs` wants.
+ * Every decision lives in `normalize.ts` between the two, as pure functions
+ * over plain JSON, testable without a browser.
  */
 
 /**
- * All geometry is in CANVAS PIXELS: the deck's `canvasWidth` by
- * `round(canvasWidth / aspectRatio)` space, with the origin at the top-left of
- * the slide (NOT of the print page, which stacks every slide into one tall
- * viewport).
- *
- * `exportSlides` sizes the PowerPoint slide as `width / 96` by `height / 96`
- * INCHES, so one CSS pixel is exactly 1/96 inch whatever `canvasWidth` is.
- * That makes the EMU conversion an integer and there is no rounding drift.
- *
- * Do not assume 1px = 1pt. That holds only for a 960px canvas on a 13.333in
- * slide, which is one specific corporate template and not Slidev's default.
+ * All geometry is in canvas pixels: `canvasWidth` by `round(canvasWidth / aspectRatio)`,
+ * origin at the top-left of the slide (not of the print page). `exportSlides`
+ * sizes the PowerPoint slide as `width / 96` by `height / 96` inches, so one
+ * CSS pixel is exactly 1/96 inch. 1px = 1pt does not hold in general.
  */
 export const EMU_PER_PX = 9525 // 914400 EMU per inch / 96 px per inch
 export const INCHES_PER_PX = 1 / 96
 
-/**
- * Points per pixel, for font size, letter spacing and line height.
- *
- * PowerPoint measures type in points and the canvas measures it in pixels, at
- * 96 px per inch against 72 pt per inch. Forgetting this factor makes every
- * font a third too large, which reads as "the export is broken" rather than as
- * a unit bug.
- */
+/** Points per pixel (72 pt per inch against 96 px per inch), for font size, letter spacing and line height. */
 export const PT_PER_PX = 0.75 // 72 / 96
-
-// ---------------------------------------------------------------------------
-// Walker output
-// ---------------------------------------------------------------------------
 
 export interface Rect {
   x: number
@@ -56,15 +27,8 @@ export interface Rect {
 }
 
 /**
- * The computed-style subset the walker captures, as raw CSS strings.
- *
- * Kept as strings because parsing is judgement and judgement belongs on the
- * Node side. Kept to a fixed subset because `getComputedStyle` exposes several
- * hundred properties and serialising all of them for every node is what turns
- * a snapshot into megabytes.
- *
- * Records are INTERNED: `RawNode.style` is an index into `RawSnapshot.styles`.
- * A real slide has a few hundred nodes and a few dozen distinct styles.
+ * The computed-style subset the walker captures, as raw CSS strings; parsing
+ * happens on the Node side. Interned: `RawNode.style` indexes `RawSnapshot.styles`.
  */
 export interface RawStyle {
   display: string
@@ -128,25 +92,11 @@ export interface RawNode {
   style: number
   /** Relative to the slide container, not to the print page. */
   rect: Rect
-  /**
-   * Text nodes only: `Range.getClientRects()`, slide-relative.
-   *
-   * The raw list rather than a bounding box, because the normalizer counts
-   * distinct line-box tops from it. A text box positioned from the ELEMENT
-   * rect rather than from glyph bounds lands offset and re-wraps.
-   */
+  /** Text nodes only: `Range.getClientRects()`, slide-relative. Kept as the raw list so the normalizer can count line boxes; a text box positioned from the element rect lands offset and re-wraps. */
   glyphRects?: Rect[]
   /** Text nodes only: raw `textContent`, before `text-transform` is applied. */
   text?: string
-  /**
-   * One rect per line box, for an inline element whose box spans more than
-   * one line.
-   *
-   * A browser paints an inline element's background and borders once per line
-   * FRAGMENT, not once over the union of them. `getBoundingClientRect()`
-   * returns that union, so a wrapped inline `<code>` came out as one solid
-   * rectangle covering the blank space at the end of every line.
-   */
+  /** One rect per line box for a wrapped inline element. Backgrounds and borders paint per line fragment, not over the `getBoundingClientRect()` union. */
   fragments?: Rect[]
   /** `IMG` only. */
   src?: string
@@ -154,39 +104,17 @@ export interface RawNode {
   alt?: string
   /** `A` only, resolved absolute. */
   href?: string
-  /**
-   * The root of a rendered formula.
-   *
-   * KaTeX sets a formula as dozens of separately positioned spans in its own
-   * metric fonts, with the radicals, braces and fraction rules drawn as bare
-   * boxes. Walked as text it comes apart: glyphs land off their baselines and
-   * every rule disappears. It is a picture or it is nothing.
-   */
+  /** Root of a rendered formula. KaTeX sets it as dozens of positioned spans in its own metric fonts; walked as text the layout falls apart, so it is rasterized whole. */
   isMath?: boolean
-  /**
-   * An `SVG` carrying `<foreignObject>`, which means its labels are HTML with
-   * no `<text>` element. Mermaid renders this way and no PowerPoint renderer
-   * draws it, so it has to be rasterized.
-   */
+  /** An `SVG` carrying `<foreignObject>` (as Mermaid renders), so its labels are HTML. No PowerPoint renderer draws that; it has to be rasterized. */
   hasForeignObject?: boolean
   /** Reached through `el.shadowRoot`. Mermaid diagrams live in one. */
   fromShadowRoot?: boolean
-  /**
-   * Opacity compounded from every ancestor, present only when below 1.
-   *
-   * CSS `opacity` does not inherit, but DrawingML has no group opacity, so the
-   * wrapper's transparency has to be folded into each descendant's own colours
-   * or a dimmed block exports at full strength.
-   */
+  /** Opacity compounded from every ancestor, present only when below 1. DrawingML has no group opacity, so a wrapper's transparency is folded into each descendant's colors. */
   opacity?: number
   /** A `::marker` list bullet, which is a pseudo-element and has no text node. */
   marker?: string
-  /**
-   * Page coordinates, for a node that cannot be pointed at with a selector.
-   *
-   * A `::before` or `::after` has no element of its own, so a screenshot has
-   * to clip the page rather than target a locator.
-   */
+  /** Page coordinates. A `::before` or `::after` has no element of its own, so a screenshot clips the page instead of targeting a locator. */
   pageRect?: Rect
 }
 
@@ -195,16 +123,10 @@ export interface RawSlide {
   no: number
   /** 0-based click step within that slide. */
   clickIndex: number
-  /**
-   * The container's exact DOM id, e.g. `003-02`.
-   *
-   * Kept verbatim so a screenshot can target this step. Rebuilding a selector
-   * from `no` matches every click step of the slide, and taking the first hit
-   * gives every step a picture of step one.
-   */
+  /** The container's exact DOM id, e.g. `003-02`. A selector rebuilt from `no` matches every click step of the slide, so screenshots target this instead. */
   containerId: string
   size: { w: number, h: number }
-  /** The slide's own background colour, as a raw CSS string. */
+  /** The slide's own background color, as a raw CSS string. */
   background?: string
   nodes: RawNode[]
 }
@@ -213,29 +135,14 @@ export interface RawSnapshot {
   slides: RawSlide[]
   styles: RawStyle[]
   /**
-   * CSS font stack as written, mapped to the family the browser actually
-   * resolved it to.
-   *
-   * This has to be measured in the page, by comparing the rendered width of a
-   * probe string against generic bases. `document.fonts.check()` cannot be
-   * used: it returns true for families that do not exist, so a deck whose CSS
-   * leads with a licensed face names that face in the file and every recipient
-   * silently gets a substitution.
+   * CSS font stack as written, mapped to the family the browser actually resolved,
+   * measured by comparing rendered widths in the page. `document.fonts.check()`
+   * cannot be used: it returns true for families that do not exist.
    */
   fontResolution: Record<string, string>
-  /**
-   * Pseudo-elements that paint something but whose box cannot be resolved from
-   * computed style, because they take part in inline or block flow.
-   *
-   * Reported rather than dropped in silence, so a missing decoration is a line
-   * in the log instead of a mystery.
-   */
+  /** Pseudo-elements that paint something but take part in flow, so their box cannot be resolved from computed style. Reported so the loss is logged rather than silent. */
   unplaceablePseudos: string[]
 }
-
-// ---------------------------------------------------------------------------
-// Normalizer output
-// ---------------------------------------------------------------------------
 
 /** Straight (non-premultiplied) alpha, 0 to 1. */
 export interface Rgba {
@@ -261,12 +168,9 @@ export interface IrBox extends IrBase {
   kind: 'box'
   fill?: Rgba
   /**
-   * Top, right, bottom, left. A side is undefined when it has no visible
-   * border.
-   *
-   * Four sides rather than one border because `pptxgenjs` gives a shape a
-   * single uniform `line`; the four-sided form exists only on table cells. The
-   * builder emits each differing side as its own filled rectangle.
+   * Top, right, bottom, left; a side is undefined when it has no visible border.
+   * `pptxgenjs` gives a shape a single uniform `line`, so the builder emits
+   * each differing side as its own filled rectangle.
    */
   borders?: [Border?, Border?, Border?, Border?]
   /** Pixels. The builder converts; `rectRadius` is in inches despite its docs. */
@@ -296,21 +200,13 @@ export interface IrRun {
 }
 
 export interface IrText extends IrBase {
-  /**
-   * Glyph bounds, NOT the element box. See `RawNode.glyphRects`.
-   */
+  /** `rect` is glyph bounds, not the element box. See `RawNode.glyphRects`. */
   kind: 'text'
-  /** Kept for diagnostics and for future placeholder matching. */
   elementRect: Rect
   /** Distinct line-box tops. One means the box must not be allowed to re-wrap. */
   lineCount: number
   align: 'left' | 'center' | 'right' | 'justify'
-  /**
-   * Vertical anchoring inside the box. Defaults to the top, because a box is
-   * normally measured from the glyphs themselves.
-   *
-   * A chip label is the exception: its box is the decoration, not the ink.
-   */
+  /** Defaults to top, since the box is measured from the glyphs; middle is for chip labels, whose box is the decoration rather than the ink. */
   valign?: 'top' | 'middle'
   /** Pixels, with `normal` already resolved to a number. */
   lineHeight: number
@@ -324,15 +220,10 @@ export interface IrImage extends IrBase {
   alt?: string
   link?: string
   /**
-   * The region of the image to show, when the slide edge cut it short.
-   *
-   * `rect` is the visible box, but the picture is drawn at its FULL size and
-   * then cropped to that box, exactly as the browser does. Without this the
-   * whole image was squeezed into the clipped box, so an image running off the
-   * bottom of the slide came out vertically compressed rather than cut off.
-   *
-   * All four values are CSS pixels: `w`/`h` the full undipped display size,
-   * `x`/`y` the offset from its top-left corner to `rect`.
+   * The visible region when the slide edge cuts the image short: draw at full
+   * size, then crop to `rect`, as the browser does; squeezing into the clipped
+   * box would compress it. All values are CSS pixels: `w`/`h` the full display
+   * size, `x`/`y` the offset from its top-left corner to `rect`.
    */
   crop?: { x: number, y: number, w: number, h: number }
 }
@@ -358,22 +249,9 @@ export interface IrRaster extends IrBase {
   /** A PNG `data:` URI, filled in by the capture phase. */
   data: string
   reason: RasterReason
-  /**
-   * Capture with everything else on the page hidden.
-   *
-   * `locator.screenshot()` clips the page to the element's box rather than
-   * isolating the element, so anything overlapping that box lands in the
-   * picture. Whatever we also draw as a shape would then appear twice.
-   */
+  /** Capture with everything else on the page hidden. `locator.screenshot()` clips the page to the element's box rather than isolating the element, so overlapping content would land in the picture and be drawn twice. */
   isolate: boolean
-  /**
-   * Also hide the element's own children while capturing.
-   *
-   * Only correct when those children are walked and redrawn as shapes, which
-   * is true for a backdrop and false for a leaf such as an `<svg>`. Hiding a
-   * leaf's children removes its artwork from the picture and nothing puts it
-   * back, which emptied the decorative chrome out of a themed deck.
-   */
+  /** Also hide the element's own children while capturing. Correct only when they are walked and redrawn as shapes; hiding a leaf's children (e.g. an `<svg>`) removes its artwork from the picture. */
   hideDescendants: boolean
 }
 
@@ -387,23 +265,13 @@ export interface SlideIr {
   containerId: string
   size: { w: number, h: number }
   background?: Rgba
-  /**
-   * Paint order IS array order.
-   *
-   * An inline decoration, such as a `<span>` with a background colour behind
-   * white text, must be emitted before the text it sits behind, or the text
-   * disappears into the page.
-   */
+  /** Paint order is array order: an inline decoration must be emitted before the text it sits behind. */
   nodes: IrNode[]
   note?: string
   /**
-   * The safety valve. When set, `nodes` is ignored and the slide is written as
-   * a single background picture, exactly as `--format pptx` does today.
-   *
-   * Set when the walk failed, when the slide lost all of its text, or when so
-   * much of it rasterized that vectorizing bought nothing. A theme this
-   * heuristic cannot handle degrades to current behaviour rather than to a
-   * broken file.
+   * When set, `nodes` is ignored and the slide is written as a single background
+   * picture, exactly as `--format pptx` does. Set when the walk failed, the
+   * slide lost all of its text, or so much rasterized that vectorizing bought nothing.
    */
   fallbackPng?: string
   fallbackReason?: string

--- a/packages/slidev/node/commands/pptx/ir.ts
+++ b/packages/slidev/node/commands/pptx/ir.ts
@@ -1,0 +1,332 @@
+/**
+ * The intermediate representation between the rendered DOM and a `.pptx`.
+ *
+ * Two levels, on purpose:
+ *
+ * - `RawSnapshot` is what the in-page walker returns. It stays deliberately
+ *   close to the DOM and contains no judgement at all, because everything
+ *   inside `page.evaluate` is unreachable from a unit test.
+ * - `SlideIr` is what the normalizer produces. It stays deliberately close to
+ *   what `pptxgenjs` wants, so the builder is a translation rather than a
+ *   second round of decisions.
+ *
+ * Every judgement lives in `normalize.ts`, between the two, as pure functions
+ * over plain JSON. That split is the whole reason this is testable without a
+ * browser.
+ *
+ * This file has no imports and no runtime behaviour beyond three constants, so
+ * it can be shared with the browser exporter later without moving anything.
+ */
+
+/**
+ * All geometry is in CANVAS PIXELS: the deck's `canvasWidth` by
+ * `round(canvasWidth / aspectRatio)` space, with the origin at the top-left of
+ * the slide (NOT of the print page, which stacks every slide into one tall
+ * viewport).
+ *
+ * `exportSlides` sizes the PowerPoint slide as `width / 96` by `height / 96`
+ * INCHES, so one CSS pixel is exactly 1/96 inch whatever `canvasWidth` is.
+ * That makes the EMU conversion an integer and there is no rounding drift.
+ *
+ * Do not assume 1px = 1pt. That holds only for a 960px canvas on a 13.333in
+ * slide, which is one specific corporate template and not Slidev's default.
+ */
+export const EMU_PER_PX = 9525 // 914400 EMU per inch / 96 px per inch
+export const INCHES_PER_PX = 1 / 96
+
+/**
+ * Points per pixel, for font size, letter spacing and line height.
+ *
+ * PowerPoint measures type in points and the canvas measures it in pixels, at
+ * 96 px per inch against 72 pt per inch. Forgetting this factor makes every
+ * font a third too large, which reads as "the export is broken" rather than as
+ * a unit bug.
+ */
+export const PT_PER_PX = 0.75 // 72 / 96
+
+// ---------------------------------------------------------------------------
+// Walker output
+// ---------------------------------------------------------------------------
+
+export interface Rect {
+  x: number
+  y: number
+  w: number
+  h: number
+}
+
+/**
+ * The computed-style subset the walker captures, as raw CSS strings.
+ *
+ * Kept as strings because parsing is judgement and judgement belongs on the
+ * Node side. Kept to a fixed subset because `getComputedStyle` exposes several
+ * hundred properties and serialising all of them for every node is what turns
+ * a snapshot into megabytes.
+ *
+ * Records are INTERNED: `RawNode.style` is an index into `RawSnapshot.styles`.
+ * A real slide has a few hundred nodes and a few dozen distinct styles.
+ */
+export interface RawStyle {
+  display: string
+  position: string
+  visibility: string
+  opacity: string
+  color: string
+  backgroundColor: string
+  backgroundImage: string
+  fontFamily: string
+  fontSize: string
+  fontWeight: string
+  fontStyle: string
+  textAlign: string
+  textDecorationLine: string
+  textTransform: string
+  letterSpacing: string
+  lineHeight: string
+  whiteSpace: string
+  borderTopWidth: string
+  borderTopStyle: string
+  borderTopColor: string
+  borderRightWidth: string
+  borderRightStyle: string
+  borderRightColor: string
+  borderBottomWidth: string
+  borderBottomStyle: string
+  borderBottomColor: string
+  borderLeftWidth: string
+  borderLeftStyle: string
+  borderLeftColor: string
+  borderTopLeftRadius: string
+  boxShadow: string
+  filter: string
+  backdropFilter: string
+  mixBlendMode: string
+  clipPath: string
+  transform: string
+  writingMode: string
+  webkitBackgroundClip: string
+  overflow: string
+}
+
+export interface RawNode {
+  /** Index into `RawSnapshot.nodes`, and the value of `data-slidev-export-id`. */
+  id: number
+  /** Parent's `id`, or -1 for the slide container itself. */
+  parent: number
+  /** Upper-case tag name, or `#text` for a text node. */
+  tag: string
+  /** Index into `RawSnapshot.styles`; -1 for text nodes, which have no style. */
+  style: number
+  /** Relative to the slide container, not to the print page. */
+  rect: Rect
+  /**
+   * Text nodes only: `Range.getClientRects()`, slide-relative.
+   *
+   * The raw list rather than a bounding box, because the normalizer counts
+   * distinct line-box tops from it. A text box positioned from the ELEMENT
+   * rect rather than from glyph bounds lands offset and re-wraps.
+   */
+  glyphRects?: Rect[]
+  /** Text nodes only: raw `textContent`, before `text-transform` is applied. */
+  text?: string
+  /** `IMG` only. */
+  src?: string
+  /** `IMG` only. */
+  alt?: string
+  /** `A` only, resolved absolute. */
+  href?: string
+  /**
+   * An `SVG` carrying `<foreignObject>`, which means its labels are HTML with
+   * no `<text>` element. Mermaid renders this way and no PowerPoint renderer
+   * draws it, so it has to be rasterized.
+   */
+  hasForeignObject?: boolean
+  /** Reached through `el.shadowRoot`. Mermaid diagrams live in one. */
+  fromShadowRoot?: boolean
+  /** A `::marker` list bullet, which is a pseudo-element and has no text node. */
+  marker?: string
+}
+
+export interface RawSlide {
+  /** 1-based deck slide number, parsed from the container id `003-02`. */
+  no: number
+  /** 0-based click step within that slide. */
+  clickIndex: number
+  /**
+   * The container's exact DOM id, e.g. `003-02`.
+   *
+   * Kept verbatim so a screenshot can target this step. Rebuilding a selector
+   * from `no` matches every click step of the slide, and taking the first hit
+   * gives every step a picture of step one.
+   */
+  containerId: string
+  size: { w: number, h: number }
+  /** The slide's own background colour, as a raw CSS string. */
+  background?: string
+  nodes: RawNode[]
+}
+
+export interface RawSnapshot {
+  slides: RawSlide[]
+  styles: RawStyle[]
+  /**
+   * CSS font stack as written, mapped to the family the browser actually
+   * resolved it to.
+   *
+   * This has to be measured in the page, by comparing the rendered width of a
+   * probe string against generic bases. `document.fonts.check()` cannot be
+   * used: it returns true for families that do not exist, so a deck whose CSS
+   * leads with a licensed face names that face in the file and every recipient
+   * silently gets a substitution.
+   */
+  fontResolution: Record<string, string>
+}
+
+// ---------------------------------------------------------------------------
+// Normalizer output
+// ---------------------------------------------------------------------------
+
+/** Straight (non-premultiplied) alpha, 0 to 1. */
+export interface Rgba {
+  r: number
+  g: number
+  b: number
+  a: number
+}
+
+export interface Border {
+  width: number
+  color: Rgba
+  style: 'solid' | 'dashed' | 'dotted'
+}
+
+interface IrBase {
+  rect: Rect
+  /** The `RawNode.id` this came from. Only for diagnostics. */
+  sourceId: number
+}
+
+export interface IrBox extends IrBase {
+  kind: 'box'
+  fill?: Rgba
+  /**
+   * Top, right, bottom, left. A side is undefined when it has no visible
+   * border.
+   *
+   * Four sides rather than one border because `pptxgenjs` gives a shape a
+   * single uniform `line`; the four-sided form exists only on table cells. The
+   * builder emits each differing side as its own filled rectangle.
+   */
+  borders?: [Border?, Border?, Border?, Border?]
+  /** Pixels. The builder converts; `rectRadius` is in inches despite its docs. */
+  radius?: number
+  shadow?: { blur: number, offset: number, angle: number, color: Rgba }
+}
+
+export interface IrRun {
+  /** Already `text-transform`ed. */
+  text: string
+  /** Pixels. */
+  fontSize: number
+  /** Already resolved to a family that exists on this machine. */
+  fontFamily: string
+  bold?: boolean
+  italic?: boolean
+  underline?: boolean
+  strike?: boolean
+  color?: Rgba
+  /** Pixels. */
+  letterSpacing?: number
+  link?: string
+  /** Emit a line break before this run. From `<br>`. */
+  breakBefore?: boolean
+  /** This run ends a paragraph. */
+  endsParagraph?: boolean
+}
+
+export interface IrText extends IrBase {
+  /**
+   * Glyph bounds, NOT the element box. See `RawNode.glyphRects`.
+   */
+  kind: 'text'
+  /** Kept for diagnostics and for future placeholder matching. */
+  elementRect: Rect
+  /** Distinct line-box tops. One means the box must not be allowed to re-wrap. */
+  lineCount: number
+  align: 'left' | 'center' | 'right' | 'justify'
+  /** Pixels, with `normal` already resolved to a number. */
+  lineHeight: number
+  runs: IrRun[]
+}
+
+export interface IrImage extends IrBase {
+  kind: 'image'
+  /** A `data:` URI. Always raster; SVG is routed to `IrRaster` instead. */
+  data: string
+  alt?: string
+  link?: string
+}
+
+export type RasterReason
+  = | 'svg'
+    | 'foreign-object'
+    | 'canvas'
+    | 'media'
+    | 'iframe'
+    | 'background-image'
+    | 'background-clip-text'
+    | 'filter'
+    | 'backdrop-filter'
+    | 'mix-blend-mode'
+    | 'clip-path'
+    | 'transform'
+    | 'writing-mode'
+
+export interface IrRaster extends IrBase {
+  kind: 'raster'
+  /** A PNG `data:` URI, filled in by the capture phase. */
+  data: string
+  reason: RasterReason
+  /**
+   * Capture this element with its siblings hidden and only its own ancestor
+   * chain revealed.
+   *
+   * Needed because `locator.screenshot()` clips the page to the element's box
+   * rather than isolating the element: without hiding siblings, whatever is
+   * painted on top of a backdrop is baked into the backdrop's own picture and
+   * then drawn again as shapes.
+   */
+  isolate: boolean
+}
+
+export type IrNode = IrBox | IrText | IrImage | IrRaster
+
+export interface SlideIr {
+  /** 1-based deck slide number. */
+  no: number
+  clickIndex: number
+  /** The rendered container's exact DOM id, for targeting a screenshot. */
+  containerId: string
+  size: { w: number, h: number }
+  background?: Rgba
+  /**
+   * Paint order IS array order.
+   *
+   * An inline decoration, such as a `<span>` with a background colour behind
+   * white text, must be emitted before the text it sits behind, or the text
+   * disappears into the page.
+   */
+  nodes: IrNode[]
+  note?: string
+  /**
+   * The safety valve. When set, `nodes` is ignored and the slide is written as
+   * a single background picture, exactly as `--format pptx` does today.
+   *
+   * Set when the walk failed, when the slide lost all of its text, or when so
+   * much of it rasterized that vectorizing bought nothing. A theme this
+   * heuristic cannot handle degrades to current behaviour rather than to a
+   * broken file.
+   */
+  fallbackPng?: string
+  fallbackReason?: string
+}

--- a/packages/slidev/node/commands/pptx/normalize.test.ts
+++ b/packages/slidev/node/commands/pptx/normalize.test.ts
@@ -1,14 +1,13 @@
 import type { IrBox, IrText, RawNode, RawSlide, RawSnapshot, RawStyle } from './ir'
 import { describe, expect, it } from 'vitest'
-import { normalize, parseColor, parseLength, parseShadow, rasterReasonFor } from './normalize'
+import { parseColor } from './color'
+import { normalize, parseLength, parseShadow, rasterReasonFor } from './normalize'
 
 /**
- * One named case per trap.
+ * One named case per rule.
  *
- * Every one of these is a bug that already shipped in the Python
- * implementation this was ported from, or one found by reading Slidev's own
- * `demo/starter`. A rule without a case here is a rule nobody will remember
- * the reason for in six months.
+ * Every case here is a defect that reached a rendered deck. A rule without one
+ * is a rule nobody will remember the reason for.
  */
 
 const BASE_STYLE: RawStyle = {
@@ -110,9 +109,9 @@ describe('value parsing', () => {
     expect(parseColor(undefined)).toBeUndefined()
   })
 
-  it('reads the modern colour syntaxes Chromium leaves in computed values', () => {
+  it('reads the modern color syntaxes Chromium leaves in computed values', () => {
     // A theme authored in modern syntax keeps these in the computed value.
-    // Returning undefined for them dropped every fill and text colour on the
+    // Returning undefined for them dropped every fill and text color on the
     // slide with nothing in the log to explain it.
     const red = parseColor('oklch(0.628 0.2577 29.23)')!
     expect(red.r).toBeGreaterThan(248)
@@ -123,7 +122,7 @@ describe('value parsing', () => {
     expect(parseColor('color(srgb 1 0 0)')).toEqual({ r: 255, g: 0, b: 0, a: 1 })
   })
 
-  it('reports a colour it cannot read instead of failing silently', () => {
+  it('reports a color it cannot read instead of failing silently', () => {
     const bad = style({ backgroundColor: 'lab(50% 40 59.5)' })
     const { unparsedColors } = run([el(0, -1, 'DIV', 1)], [BASE_STYLE, bad])
     expect(unparsedColors).toContain('lab(50% 40 59.5)')
@@ -152,7 +151,7 @@ describe('value parsing', () => {
   })
 })
 
-describe('finding 2: <br> becomes a real line break', () => {
+describe('a <br> becomes a real line break', () => {
   it('breaks between the runs either side of it', () => {
     const nodes = [
       el(0, -1, 'DIV', 0),
@@ -218,7 +217,7 @@ describe('code blocks keep their line structure', () => {
   })
 })
 
-describe('finding 4: an inline image survives', () => {
+describe('an inline image survives the text walk', () => {
   it('draws an <img> that sits inside a line of text', () => {
     const inline = style({ display: 'inline' })
     const nodes = [
@@ -235,7 +234,7 @@ describe('finding 4: an inline image survives', () => {
   })
 })
 
-describe('finding 11: the space between inline elements', () => {
+describe('the space between inline elements', () => {
   it('keeps a whitespace-only node between two spans', () => {
     const inline = style({ display: 'inline' })
     const nodes = [
@@ -253,7 +252,7 @@ describe('finding 11: the space between inline elements', () => {
   })
 })
 
-describe('finding 7: inline-level layout containers still lay out', () => {
+describe('inline-level layout containers still lay out as boxes', () => {
   it('does not merge the cells of an inline-flex badge', () => {
     const badge = style({ display: 'inline-flex' })
     const cell = style({ display: 'inline' })
@@ -274,7 +273,7 @@ describe('finding 7: inline-level layout containers still lay out', () => {
   })
 })
 
-describe('finding 8: a list item flows its children as text', () => {
+describe('a list item flows its children as text', () => {
   it('keeps a bold lead-in joined inside an <li>', () => {
     const item = style({ display: 'list-item' })
     const inline = style({ display: 'inline' })
@@ -294,8 +293,8 @@ describe('finding 8: a list item flows its children as text', () => {
   })
 })
 
-describe('finding 15: element opacity reaches the fill', () => {
-  it('folds opacity into the colour alpha', () => {
+describe('element opacity reaches the fill', () => {
+  it('folds opacity into the color alpha', () => {
     const faded = style({ backgroundColor: 'rgb(0, 0, 0)' })
     // Carried on the NODE, compounded down the tree by the walker, because CSS
     // opacity does not inherit and DrawingML has no group opacity to stand in
@@ -345,7 +344,7 @@ describe('paint order follows CSS, not the document', () => {
 describe('opacity reaches text, not only shapes', () => {
   it('greys a paragraph that its ancestor dimmed', () => {
     // Slidev's own stylesheet greys this kind of paragraph with `opacity: 0.5`
-    // rather than a colour. Opacity is compounded down the tree onto elements,
+    // rather than a color. Opacity is compounded down the tree onto elements,
     // but a text node has no style of its own, so every run lost it and the
     // paragraph exported solid black.
     const nodes = [
@@ -356,14 +355,14 @@ describe('opacity reaches text, not only shapes', () => {
     expect(texts(slides[0].nodes)[0].runs[0].color).toEqual({ r: 0, g: 0, b: 0, a: 0.5 })
   })
 
-  it('centres a list marker on its line rather than above it', () => {
+  it('centers a list marker on its line rather than above it', () => {
     const item = style({ display: 'list-item' })
     const { slides } = run([el(0, -1, 'LI', 1, { marker: '\u25AA ' })], [BASE_STYLE, item])
     expect(texts(slides[0].nodes)[0].valign).toBe('middle')
   })
 })
 
-describe('finding 6: the slide keeps its own background', () => {
+describe('the slide keeps its own background', () => {
   it('carries the container background into the IR', () => {
     const raw = snapshot([el(0, -1, 'DIV', 0)], [BASE_STYLE])
     raw.slides[0].background = 'rgb(18, 18, 18)'
@@ -375,16 +374,16 @@ describe('finding 6: the slide keeps its own background', () => {
 })
 
 describe('a shrink-wrapped container leaves no room to wrap', () => {
-  it('widens a centred block whose container is exactly its ink', () => {
-    const centred = style({ textAlign: 'center' })
-    // The container fits the text exactly, which is what a centred statement
+  it('widens a centered block whose container is exactly its ink', () => {
+    const centered = style({ textAlign: 'center' })
+    // The container fits the text exactly, which is what a centered statement
     // block does. PowerPoint sets the same string slightly wider than
     // Chromium, so with no headroom the longest line wraps and the block
     // gains a line.
     const box = { x: 155, y: 192, w: 487, h: 90 }
     const nodes = [
       el(0, -1, 'DIV', 1, { rect: box }),
-      text(1, 0, 'a long centred statement', {
+      text(1, 0, 'a long centered statement', {
         rect: box,
         glyphRects: [
           { x: 155, y: 192, w: 400, h: 30 },
@@ -393,10 +392,10 @@ describe('a shrink-wrapped container leaves no room to wrap', () => {
         ],
       }),
     ]
-    const { slides } = run(nodes, [BASE_STYLE, centred])
+    const { slides } = run(nodes, [BASE_STYLE, centered])
     const out = texts(slides[0].nodes)[0]
     expect(out.rect.w).toBeGreaterThan(487)
-    // Grown about the centre, so the text does not slide sideways.
+    // Grown about the center, so the text does not slide sideways.
     expect(out.rect.x + out.rect.w / 2).toBeCloseTo(155 + 487 / 2, 5)
   })
 
@@ -418,7 +417,7 @@ describe('a shrink-wrapped container leaves no room to wrap', () => {
   })
 })
 
-describe('trap 16: --range is applied by the caller, not the page', () => {
+describe('--range is applied by the caller, not the page', () => {
   it('exposes the slide number so out-of-range slides can be filtered', () => {
     // The print route renders EVERY slide whatever the `range` query says, so
     // out-of-range containers are fully laid out rather than hidden, and an
@@ -434,7 +433,7 @@ describe('trap 16: --range is applied by the caller, not the page', () => {
   })
 })
 
-describe('cSS pseudo-element decorations', () => {
+describe('pseudo-element decorations are drawn', () => {
   it('draws an ::after that paints a background image', () => {
     const mark = style({
       position: 'absolute',
@@ -469,7 +468,7 @@ describe('cSS pseudo-element decorations', () => {
   })
 })
 
-describe('finding 20: line counting tolerates sub-pixel layout', () => {
+describe('line counting tolerates sub-pixel layout', () => {
   it('treats fragments a fraction of a pixel apart as one line', () => {
     const nodes = [
       el(0, -1, 'DIV', 0),
@@ -487,7 +486,7 @@ describe('finding 20: line counting tolerates sub-pixel layout', () => {
   })
 })
 
-describe('trap 3: layout containers are not text blocks', () => {
+describe('layout containers are not text blocks', () => {
   it('keeps grid cells apart instead of concatenating them', () => {
     const grid = style({ display: 'grid' })
     // The cells are INLINE on purpose. CSS blockifies the children of a grid
@@ -512,7 +511,7 @@ describe('trap 3: layout containers are not text blocks', () => {
   })
 })
 
-describe('trap 7: consecutive inline nodes are one anonymous block', () => {
+describe('consecutive inline nodes form one anonymous block', () => {
   it('joins a bold lead-in with the rest of its sentence', () => {
     const inline = style({ display: 'inline' })
     const bold = style({ display: 'inline', fontWeight: '700' })
@@ -537,7 +536,7 @@ describe('trap 7: consecutive inline nodes are one anonymous block', () => {
   })
 })
 
-describe('trap 8: inline decorations paint before their text', () => {
+describe('inline decorations paint before their text', () => {
   it('emits a chip background ahead of the white label on it', () => {
     const chip = style({ display: 'inline', backgroundColor: 'rgb(0, 128, 0)', color: 'rgb(255, 255, 255)' })
     const nodes = [
@@ -569,7 +568,7 @@ describe('trap 8: inline decorations paint before their text', () => {
     // accumulate across the earlier runs and slide the label off its chip.
     expect(out).toHaveLength(1)
     expect(out[0].runs[0].text).toBe('NEW')
-    // Pinned to the chip and centred in it, not to its own ink. However much
+    // Pinned to the chip and centered in it, not to its own ink. However much
     // wider PowerPoint sets the string than the browser did, the label stays
     // evenly inset instead of ending up hard against one edge.
     expect(out[0].rect).toEqual(label)
@@ -589,7 +588,7 @@ describe('trap 8: inline decorations paint before their text', () => {
     ]
     const { slides } = run(nodes, [BASE_STYLE, inline, code])
     // Slidev gives inline code a background, so an unconditional chip split
-    // cut ordinary sentences into three boxes and centred the code span; when
+    // cut ordinary sentences into three boxes and centered the code span; when
     // such a sentence wrapped, the halves overlapped. A chip is a label on its
     // own, not a word in the middle of a line.
     const out = texts(slides[0].nodes)
@@ -598,7 +597,7 @@ describe('trap 8: inline decorations paint before their text', () => {
   })
 })
 
-describe('trap 2: text-transform and letter-spacing are applied', () => {
+describe('text-transform and letter-spacing are applied', () => {
   it('uppercases the run rather than trusting PowerPoint to do it', () => {
     const label = style({ textTransform: 'uppercase', letterSpacing: '2px' })
     const nodes = [el(0, -1, 'DIV', 1), text(1, 0, 'section one')]
@@ -611,7 +610,7 @@ describe('trap 2: text-transform and letter-spacing are applied', () => {
   })
 })
 
-describe('trap 6: text is positioned from glyph bounds', () => {
+describe('text is positioned from glyph bounds', () => {
   it('uses the glyph rects for a single line, not the element box', () => {
     const nodes = [
       el(0, -1, 'DIV', 0, { rect: { x: 0, y: 0, w: 500, h: 100 } }),
@@ -652,7 +651,7 @@ describe('trap 6: text is positioned from glyph bounds', () => {
   })
 })
 
-describe('trap 11: list bullets are pseudo-elements', () => {
+describe('list bullets survive as text', () => {
   it('recovers a ::marker glyph that has no text node', () => {
     const item = style({ display: 'list-item' })
     const nodes = [
@@ -668,7 +667,7 @@ describe('trap 11: list bullets are pseudo-elements', () => {
   })
 })
 
-describe('traps 4, 5, 12, 13: what has to become a picture', () => {
+describe('what has to become a picture', () => {
   it('rasterizes a mermaid svg whose labels are foreignObject', () => {
     expect(rasterReasonFor(el(0, -1, 'SVG', 0, { hasForeignObject: true }), BASE_STYLE))
       .toBe('foreign-object')
@@ -738,7 +737,7 @@ describe('a picture with content over it is captured in isolation', () => {
   })
 })
 
-describe('trap 10: only backdrops need isolation', () => {
+describe('only backdrops need their descendants hidden', () => {
   it('isolates a backdrop but not a leaf picture', () => {
     const backdrop = run(
       [el(0, -1, 'DIV', 1), el(1, 0, 'DIV', 0), text(2, 1, 'on top')],
@@ -758,7 +757,7 @@ describe('trap 10: only backdrops need isolation', () => {
   })
 })
 
-describe('tier 4: the safety valve', () => {
+describe('a slide that cannot be rebuilt falls back to an image', () => {
   it('falls back when a slide with text yields none', () => {
     // Every text node sits under an <svg>, so all of it rasterizes.
     const nodes = [el(0, -1, 'SVG', 0), text(1, 0, 'invisible to the walk')]
@@ -811,7 +810,7 @@ describe('tier 4: the safety valve', () => {
   })
 })
 
-describe('trap 16: content outside the slide', () => {
+describe('content outside the slide is clipped', () => {
   it('clips a shape that overflows the slide', () => {
     const wide = style({ backgroundColor: 'rgb(1, 2, 3)' })
     const nodes = [el(0, -1, 'DIV', 1, { rect: { x: 900, y: 0, w: 500, h: 100 } })]

--- a/packages/slidev/node/commands/pptx/normalize.test.ts
+++ b/packages/slidev/node/commands/pptx/normalize.test.ts
@@ -1048,3 +1048,40 @@ describe('a rendered formula is a picture', () => {
     expect(slides[0].nodes.map(node => node.kind)).toEqual(['text'])
   })
 })
+
+describe('gradient text is the picture, not a backdrop for it', () => {
+  it('reports background-clip before background-image', () => {
+    // Gradient text is both at once: a linear-gradient clipped to the glyphs,
+    // with `color` left as a flat fallback for browsers without the clip.
+    // Called a background image it counts as a backdrop, so its own text is
+    // drawn again on top and the fallback color hides the gradient.
+    const gradient = style({
+      backgroundImage: 'linear-gradient(45deg, rgb(78, 197, 212) 10%, rgb(20, 107, 140) 20%)',
+      webkitBackgroundClip: 'text',
+      color: 'rgb(93, 131, 146)',
+    })
+    expect(rasterReasonFor(el(0, -1, 'H1', 1), gradient)).toBe('background-clip-text')
+  })
+
+  it('leaves the text of a real backdrop editable', () => {
+    const backdrop = style({ backgroundImage: 'url(cover.png)' })
+    expect(rasterReasonFor(el(0, -1, 'DIV', 1), backdrop)).toBe('background-image')
+  })
+
+  it('does not draw the heading twice', () => {
+    const gradient = style({
+      backgroundImage: 'linear-gradient(45deg, rgb(78, 197, 212) 10%, rgb(20, 107, 140) 20%)',
+      webkitBackgroundClip: 'text',
+    })
+    const nodes = [
+      el(0, -1, 'H1', 1, { rect: { x: 54, y: 40, w: 870, h: 40 } }),
+      text(1, 0, 'What is Slidev?', { glyphRects: [{ x: 54, y: 36, w: 256, h: 47 }] }),
+      el(2, -1, 'P', 0, { rect: { x: 54, y: 88, w: 700, h: 23 } }),
+      text(3, 2, 'Body copy', { glyphRects: [{ x: 54, y: 88, w: 200, h: 23 }] }),
+    ]
+    const { slides } = run(nodes, [BASE_STYLE, gradient])
+    expect(slides[0].nodes.filter(n => n.kind === 'raster')).toHaveLength(1)
+    // The body copy survives; only the heading became a picture.
+    expect(texts(slides[0].nodes).map(t => t.runs.map(r => r.text).join(''))).toEqual(['Body copy'])
+  })
+})

--- a/packages/slidev/node/commands/pptx/normalize.test.ts
+++ b/packages/slidev/node/commands/pptx/normalize.test.ts
@@ -772,6 +772,25 @@ describe('trap 16: content outside the slide', () => {
     expect(boxes(slides[0].nodes)).toHaveLength(0)
   })
 
+  it('captures a runaway element as a clipped region, not as itself', () => {
+    // Slidev's own starter deck carries an element measuring tens of millions
+    // of pixels. Screenshotting it whole asks Chromium for a bitmap it cannot
+    // allocate, and the renderer dies mid-export; the failure then surfaces
+    // from an unrelated call as "Target page, context or browser has been
+    // closed", which is a miserable thing to debug.
+    // Only the left edge of it is on the slide, so this does not also trip the
+    // whole-slide fallback, which withholds captures by design.
+    const huge = { x: 900, y: 0, w: 24_000_000, h: 300 }
+    const page = { x: 1000, y: 200, w: 24_000_000, h: 300 }
+    const nodes = [el(0, -1, 'CANVAS', 0, { rect: huge, pageRect: page })]
+    const { slides, rasterRequests } = run(nodes, [BASE_STYLE])
+    const raster = slides[0].nodes[0] as any
+    // Placed at the clipped rectangle, and captured at the same one, so the
+    // picture is neither squashed nor enormous.
+    expect(raster.rect).toEqual({ x: 900, y: 0, w: 80, h: 300 })
+    expect(rasterRequests[0].clip).toEqual({ x: 1000, y: 200, w: 80, h: 300 })
+  })
+
   it('does not let a runaway rect blow up the fallback maths', () => {
     // Slidev's own starter deck has an element measuring tens of millions of
     // pixels, which reported "104064986954% of the slide had to be rasterized".

--- a/packages/slidev/node/commands/pptx/normalize.test.ts
+++ b/packages/slidev/node/commands/pptx/normalize.test.ts
@@ -1133,3 +1133,62 @@ describe('an inline rule is an underline, not a shape', () => {
     expect(boxes(slides[0].nodes).length).toBeGreaterThan(0)
   })
 })
+
+describe('a table cell flows its children, it does not lay them out', () => {
+  it('places each key of a shortcut row on its own', () => {
+    // A chip is padded and spaced by its own box, which flowed text cannot
+    // reproduce: the labels run together while the keys keep their gaps.
+    const cell = style({ display: 'table-cell' })
+    const chip = style({ display: 'inline-block', backgroundColor: 'rgb(240, 240, 240)' })
+    const nodes = [
+      el(0, -1, 'TD', 1),
+      el(1, 0, 'KBD', 2, { rect: { x: 69, y: 226, w: 48, h: 27 } }),
+      text(2, 1, 'left', { rect: { x: 73, y: 233, w: 40, h: 20 }, glyphRects: [{ x: 73, y: 233, w: 40, h: 20 }] }),
+      text(3, 0, ' / ', { rect: { x: 117, y: 233, w: 13, h: 20 }, glyphRects: [{ x: 117, y: 233, w: 13, h: 20 }] }),
+      el(4, 0, 'KBD', 2, { rect: { x: 130, y: 226, w: 48, h: 27 } }),
+      text(5, 4, 'shift', { rect: { x: 134, y: 233, w: 40, h: 20 }, glyphRects: [{ x: 134, y: 233, w: 40, h: 20 }] }),
+      el(6, 0, 'KBD', 2, { rect: { x: 186, y: 226, w: 48, h: 27 } }),
+      text(7, 6, 'space', { rect: { x: 190, y: 233, w: 40, h: 20 }, glyphRects: [{ x: 190, y: 233, w: 40, h: 20 }] }),
+    ]
+    const lines = texts(run(nodes, [BASE_STYLE, cell, chip]).slides[0].nodes)
+    expect(lines.map(l => l.runs.map(r => r.text).join(''))).toEqual(['left', ' / ', 'shift', 'space'])
+    // The separator keeps the spaces its glyph bounds were measured across:
+    // trimmed, it drew where the leading space had been, on the key beside it.
+    expect(lines[1].runs[0].text).toBe(' / ')
+  })
+
+  it('keeps a cell of inline content in one text box', () => {
+    // A table lays out its rows and a row its cells, but the contents of a
+    // cell flow like any block. Treated as a layout container,
+    // `<kbd>right</kbd> / <kbd>space</kbd>` became three boxes, and the
+    // separator was positioned from glyph bounds that included the spaces
+    // around it while its own text had them trimmed, so it sat on the key.
+    const cell = style({ display: 'table-cell' })
+    const chip = style({ display: 'inline-block', backgroundColor: 'rgb(240, 240, 240)' })
+    const nodes = [
+      el(0, -1, 'TD', 1),
+      el(1, 0, 'SPAN', 3, { rect: { x: 69, y: 233, w: 48, h: 20 } }),
+      text(2, 1, 'right', { rect: { x: 73, y: 233, w: 40, h: 20 }, glyphRects: [{ x: 73, y: 233, w: 40, h: 20 }] }),
+      text(3, 0, ' / ', { rect: { x: 117, y: 233, w: 13, h: 20 }, glyphRects: [{ x: 117, y: 233, w: 13, h: 20 }] }),
+      el(4, 0, 'SPAN', 3, { rect: { x: 130, y: 233, w: 48, h: 20 } }),
+      text(5, 4, 'space', { rect: { x: 134, y: 233, w: 40, h: 20 }, glyphRects: [{ x: 134, y: 233, w: 40, h: 20 }] }),
+    ]
+    const plain = style({ display: 'inline' })
+    const lines = texts(run(nodes, [BASE_STYLE, cell, chip, plain]).slides[0].nodes)
+    expect(lines).toHaveLength(1)
+    expect(lines[0].runs.map(r => r.text)).toEqual(['right', ' / ', 'space'])
+  })
+
+  it('still lays out the rows of a table', () => {
+    const table = style({ display: 'table' })
+    const nodes = [
+      el(0, -1, 'TABLE', 1),
+      el(1, 0, 'TR', 0, { rect: { x: 0, y: 0, w: 200, h: 20 } }),
+      text(2, 1, 'one', { glyphRects: [{ x: 0, y: 0, w: 60, h: 20 }] }),
+      el(3, 0, 'TR', 0, { rect: { x: 0, y: 30, w: 200, h: 20 } }),
+      text(4, 3, 'two', { glyphRects: [{ x: 0, y: 30, w: 60, h: 20 }] }),
+    ]
+    const lines = texts(run(nodes, [BASE_STYLE, table]).slides[0].nodes)
+    expect(lines.map(l => l.runs.map(r => r.text).join(''))).toEqual(['one', 'two'])
+  })
+})

--- a/packages/slidev/node/commands/pptx/normalize.test.ts
+++ b/packages/slidev/node/commands/pptx/normalize.test.ts
@@ -468,15 +468,34 @@ describe('tier 4: the safety valve', () => {
     expect(slides[0].fallbackReason).toMatch(/no text could be recovered/)
   })
 
-  it('falls back when most of the slide had to be rasterized', () => {
+  it('falls back when most of the slide is a picture with nothing over it', () => {
     const big = { x: 0, y: 0, w: 900, h: 500 }
+    const away = { x: 905, y: 505, w: 60, h: 20 }
     const nodes = [
       el(0, -1, 'SVG', 0, { rect: big }),
-      el(1, -1, 'DIV', 0),
-      text(2, 1, 'a little text'),
+      el(1, -1, 'DIV', 0, { rect: away }),
+      text(2, 1, 'a caption in the corner', { rect: away, glyphRects: [away] }),
     ]
     const { slides } = run(nodes, [BASE_STYLE])
+    // The caption sits beside the picture rather than on it, so vectorizing
+    // really did recover almost nothing.
     expect(slides[0].fallbackReason).toMatch(/rasterized/)
+  })
+
+  it('keeps a slide whose text sits ON TOP of a full-bleed picture', () => {
+    const full = { x: 0, y: 0, w: 980, h: 552 }
+    const title = { x: 80, y: 200, w: 400, h: 60 }
+    const nodes = [
+      el(0, -1, 'SVG', 0, { rect: full }),
+      el(1, -1, 'H1', 0, { rect: title }),
+      text(2, 1, 'A cover title', { rect: title, glyphRects: [title] }),
+    ]
+    const { slides } = run(nodes, [BASE_STYLE])
+    // A cover photo or decorative graphic covers the slide by definition. The
+    // title over it vectorizes perfectly, so counting the picture against the
+    // budget threw away the text on every cover slide in the deck.
+    expect(slides[0].fallbackReason).toBeUndefined()
+    expect(texts(slides[0].nodes)[0].runs[0].text).toBe('A cover title')
   })
 
   it('does not request captures for a slide that is falling back anyway', () => {
@@ -514,9 +533,9 @@ describe('trap 16: content outside the slide', () => {
   it('does not let a runaway rect blow up the fallback maths', () => {
     // Slidev's own starter deck has an element measuring tens of millions of
     // pixels, which reported "104064986954% of the slide had to be rasterized".
+    // No text here, so the area rule is the one under test.
     const huge = { x: 0, y: 0, w: 24_000_000, h: 24_000_000 }
-    const nodes = [el(0, -1, 'CANVAS', 0, { rect: huge }), el(1, -1, 'DIV', 0), text(2, 1, 'hi')]
-    const { slides } = run(nodes, [BASE_STYLE])
+    const { slides } = run([el(0, -1, 'CANVAS', 0, { rect: huge })], [BASE_STYLE])
     expect(slides[0].fallbackReason).toMatch(/^100% of the slide/)
   })
 })

--- a/packages/slidev/node/commands/pptx/normalize.test.ts
+++ b/packages/slidev/node/commands/pptx/normalize.test.ts
@@ -1000,3 +1000,22 @@ describe('a raster that cannot be placed must not swallow its subtree', () => {
     expect(rasterRequests.map(request => request.sourceId)).toEqual([1])
   })
 })
+
+describe('an image cut off by the slide edge is cropped, not squashed', () => {
+  it('keeps the full display size and takes a window out of it', () => {
+    // The slide container has `overflow: hidden`, so a browser shows the top
+    // of an oversized image and cuts the rest off. Clipping the BOX alone
+    // scaled the whole image into it instead, which came out vertically
+    // compressed and showed content the audience never saw.
+    const nodes = [el(0, -1, 'IMG', 0, { rect: { x: 56, y: 40, w: 434, h: 772 }, src: 'a.png' })]
+    const [image] = run(nodes, [BASE_STYLE]).slides[0].nodes as any[]
+    expect(image.rect).toEqual({ x: 56, y: 40, w: 434, h: 512 })
+    expect(image.crop).toEqual({ x: 0, y: 0, w: 434, h: 772 })
+  })
+
+  it('leaves an image that fits uncropped', () => {
+    const nodes = [el(0, -1, 'IMG', 0, { rect: { x: 10, y: 10, w: 100, h: 50 }, src: 'a.png' })]
+    const [image] = run(nodes, [BASE_STYLE]).slides[0].nodes as any[]
+    expect(image.crop).toBeUndefined()
+  })
+})

--- a/packages/slidev/node/commands/pptx/normalize.test.ts
+++ b/packages/slidev/node/commands/pptx/normalize.test.ts
@@ -1019,3 +1019,33 @@ describe('an image cut off by the slide edge is cropped, not squashed', () => {
     expect(image.crop).toBeUndefined()
   })
 })
+
+describe('a rendered formula is a picture', () => {
+  it('rasterizes a KaTeX root instead of walking its spans', () => {
+    // KaTeX sets a formula as dozens of separately positioned spans in its own
+    // metric fonts, with radicals, braces and fraction rules drawn as bare
+    // boxes. Walked as text it comes apart: glyphs land off their baselines
+    // and every rule disappears.
+    const nodes = [
+      el(0, -1, 'DIV', 0),
+      el(1, 0, 'SPAN', 0, { isMath: true, rect: { x: 10, y: 10, w: 200, h: 40 } }),
+      el(2, 1, 'SPAN', 0, { rect: { x: 10, y: 10, w: 20, h: 40 } }),
+      text(3, 2, '3x'),
+      el(4, 0, 'P', 0, { rect: { x: 10, y: 80, w: 200, h: 20 } }),
+      text(5, 4, 'Block', { glyphRects: [{ x: 10, y: 80, w: 60, h: 20 }] }),
+    ]
+    const { slides, rasterRequests } = run(nodes, [BASE_STYLE])
+    const math = slides[0].nodes.filter(node => node.kind === 'raster')
+    expect(math).toHaveLength(1)
+    expect((math[0] as any).reason).toBe('math')
+    // Its own spans are not ALSO drawn as text.
+    expect(texts(slides[0].nodes).map(t => t.runs.map(r => r.text).join(''))).toEqual(['Block'])
+    expect(rasterRequests.map(request => request.sourceId)).toEqual([1])
+  })
+
+  it('leaves an ordinary span alone', () => {
+    const nodes = [el(0, -1, 'SPAN', 0), text(1, 0, 'plain')]
+    const { slides } = run(nodes, [BASE_STYLE])
+    expect(slides[0].nodes.map(node => node.kind)).toEqual(['text'])
+  })
+})

--- a/packages/slidev/node/commands/pptx/normalize.test.ts
+++ b/packages/slidev/node/commands/pptx/normalize.test.ts
@@ -378,7 +378,12 @@ describe('trap 8: inline decorations paint before their text', () => {
     // accumulate across the earlier runs and slide the label off its chip.
     expect(out).toHaveLength(2)
     expect(out[1].runs[0].text).toBe('NEW')
-    expect(out[1].rect.x).toBe(122)
+    // Pinned to the chip and centred in it, not to its own ink. However much
+    // wider PowerPoint sets the string than the browser did, the label stays
+    // evenly inset instead of ending up hard against one edge.
+    expect(out[1].rect).toEqual(label)
+    expect(out[1].align).toBe('center')
+    expect(out[1].valign).toBe('middle')
   })
 })
 

--- a/packages/slidev/node/commands/pptx/normalize.test.ts
+++ b/packages/slidev/node/commands/pptx/normalize.test.ts
@@ -29,6 +29,8 @@ const BASE_STYLE: RawStyle = {
   letterSpacing: 'normal',
   lineHeight: 'normal',
   whiteSpace: 'normal',
+  paddingLeft: '0px',
+  paddingRight: '0px',
   borderTopWidth: '0px',
   borderTopStyle: 'none',
   borderTopColor: 'rgb(0, 0, 0)',
@@ -356,6 +358,28 @@ describe('trap 8: inline decorations paint before their text', () => {
     expect(kinds.indexOf('box')).toBeLessThan(kinds.indexOf('text'))
     expect(boxes(slides[0].nodes)[0].fill).toEqual({ r: 0, g: 128, b: 0, a: 1 })
   })
+
+  it('anchors a chip label in its own box so it cannot drift off the chip', () => {
+    const inline = style({ display: 'inline' })
+    const chip = style({ display: 'inline', backgroundColor: 'rgb(0, 128, 0)' })
+    const before = { x: 0, y: 0, w: 120, h: 20 }
+    const label = { x: 122, y: 0, w: 30, h: 20 }
+    const nodes = [
+      el(0, -1, 'DIV', 0),
+      el(1, 0, 'SPAN', 1, { rect: before }),
+      text(2, 1, 'C2C.PI.A2A.', { rect: before, glyphRects: [before] }),
+      el(3, 0, 'SPAN', 2, { rect: label }),
+      text(4, 3, 'NEW', { rect: label, glyphRects: [label] }),
+    ]
+    const { slides } = run(nodes, [BASE_STYLE, inline, chip])
+    const out = texts(slides[0].nodes)
+    // The chip's background is an absolutely positioned shape while the text
+    // around it flows, so sharing one box lets PowerPoint's metrics
+    // accumulate across the earlier runs and slide the label off its chip.
+    expect(out).toHaveLength(2)
+    expect(out[1].runs[0].text).toBe('NEW')
+    expect(out[1].rect.x).toBe(122)
+  })
 })
 
 describe('trap 2: text-transform and letter-spacing are applied', () => {
@@ -372,22 +396,42 @@ describe('trap 2: text-transform and letter-spacing are applied', () => {
 })
 
 describe('trap 6: text is positioned from glyph bounds', () => {
-  it('uses the glyph rects, not the element box, and counts line boxes', () => {
+  it('uses the glyph rects for a single line, not the element box', () => {
     const nodes = [
-      el(0, -1, 'DIV', 0),
-      text(1, 0, 'two lines here', {
+      el(0, -1, 'DIV', 0, { rect: { x: 0, y: 0, w: 500, h: 100 } }),
+      text(1, 0, 'one line', {
         rect: { x: 0, y: 0, w: 500, h: 100 },
-        glyphRects: [
-          { x: 40, y: 10, w: 120, h: 20 },
-          { x: 40, y: 34, w: 90, h: 20 },
-        ],
+        glyphRects: [{ x: 40, y: 10, w: 120, h: 20 }],
       }),
     ]
     const { slides } = run(nodes, [BASE_STYLE])
     const out = texts(slides[0].nodes)[0]
-    expect(out.rect).toEqual({ x: 40, y: 10, w: 120, h: 44 })
-    // Line count drives `wrap` in the builder: a single-line box must not be
-    // allowed to re-wrap under PowerPoint's wider metrics.
+    // Positioning from the element rect offsets the text by the container's
+    // padding, and its width bears no relation to the ink.
+    expect(out.rect).toEqual({ x: 40, y: 10, w: 120, h: 20 })
+    expect(out.lineCount).toBe(1)
+  })
+
+  it('wraps multi-line text against the container content box', () => {
+    const padded = style({ paddingLeft: '8px', paddingRight: '8px' })
+    const nodes = [
+      el(0, -1, 'DIV', 1, { rect: { x: 0, y: 0, w: 200, h: 100 } }),
+      text(1, 0, 'two lines here', {
+        rect: { x: 0, y: 0, w: 200, h: 100 },
+        glyphRects: [
+          { x: 8, y: 10, w: 120, h: 20 },
+          { x: 8, y: 34, w: 90, h: 20 },
+        ],
+      }),
+    ]
+    const { slides } = run(nodes, [BASE_STYLE, padded])
+    const out = texts(slides[0].nodes)[0]
+    // Glyph bounds for wrapped text are the width of the LONGEST LINE, so
+    // handing PowerPoint 120px guarantees a second, tighter wrap: "a short caption" came back over three lines and overflowed its box. The browser
+    // wrapped against the content box, which is 200 less 8px either side.
+    expect(out.rect).toEqual({ x: 8, y: 10, w: 184, h: 44 })
+    // Vertical position still comes from the glyphs, not the element.
+    expect(out.rect.y).toBe(10)
     expect(out.lineCount).toBe(2)
   })
 })
@@ -442,6 +486,42 @@ describe('traps 4, 5, 12, 13: what has to become a picture', () => {
   })
 })
 
+describe('a picture with content over it is captured in isolation', () => {
+  it('isolates a leaf picture that a title is drawn on top of', () => {
+    const full = { x: 0, y: 0, w: 980, h: 552 }
+    const title = { x: 80, y: 200, w: 400, h: 60 }
+    const nodes = [
+      el(0, -1, 'SVG', 0, { rect: full }),
+      el(1, -1, 'H1', 0, { rect: title }),
+      text(2, 1, 'A cover title', { rect: title, glyphRects: [title] }),
+    ]
+    const { slides, rasterRequests } = run(nodes, [BASE_STYLE])
+    // `locator.screenshot()` clips the page rather than isolating the element,
+    // so without this the title is baked into the picture AND drawn again as
+    // a shape, printing every line of the slide twice.
+    const raster = slides[0].nodes.find(n => n.kind === 'raster') as any
+    expect(raster.isolate).toBe(true)
+    expect(rasterRequests[0].isolate).toBe(true)
+    // But NOT its own children: an <svg>'s children are its artwork, and
+    // nothing redraws them, so hiding those emptied the decorative chrome out
+    // of a themed deck entirely.
+    expect(rasterRequests[0].hideDescendants).toBe(false)
+  })
+
+  it('leaves a picture alone when nothing is drawn over it', () => {
+    const corner = { x: 0, y: 0, w: 100, h: 100 }
+    const away = { x: 500, y: 400, w: 200, h: 20 }
+    const nodes = [
+      el(0, -1, 'SVG', 0, { rect: corner }),
+      el(1, -1, 'DIV', 0, { rect: away }),
+      text(2, 1, 'caption', { rect: away, glyphRects: [away] }),
+    ]
+    const { rasterRequests } = run(nodes, [BASE_STYLE])
+    // Isolation costs two DOM mutations per capture, so it is not free.
+    expect(rasterRequests[0].isolate).toBe(false)
+  })
+})
+
 describe('trap 10: only backdrops need isolation', () => {
   it('isolates a backdrop but not a leaf picture', () => {
     const backdrop = run(
@@ -452,6 +532,8 @@ describe('trap 10: only backdrops need isolation', () => {
     // Without hiding siblings, the text bakes into the backdrop picture and is
     // then drawn again as a shape, doubling every word.
     expect(raster.isolate).toBe(true)
+    // A backdrop's children ARE walked and redrawn, so hiding them is correct.
+    expect(raster.hideDescendants).toBe(true)
     // Its children are still walked, so the text survives as editable text.
     expect(texts(backdrop.slides[0].nodes)).toHaveLength(1)
 

--- a/packages/slidev/node/commands/pptx/normalize.test.ts
+++ b/packages/slidev/node/commands/pptx/normalize.test.ts
@@ -1085,3 +1085,51 @@ describe('gradient text is the picture, not a backdrop for it', () => {
     expect(texts(slides[0].nodes).map(t => t.runs.map(r => r.text).join(''))).toEqual(['Body copy'])
   })
 })
+
+describe('an inline rule is an underline, not a shape', () => {
+  const linkStyle = style({
+    display: 'inline',
+    borderBottomWidth: '1px',
+    borderBottomStyle: 'dashed',
+    borderBottomColor: 'rgb(0, 0, 0)',
+  })
+
+  it('draws a dashed border-bottom as a dashed underline', () => {
+    // Slidev rules its links this way. As a separate line it has to be placed
+    // against text PowerPoint may re-lay, cannot follow an edit, and is a
+    // second thing that can draw a line under a link PowerPoint may underline
+    // itself. DrawingML dashes an underline, so none of that is needed.
+    const nodes = [
+      el(0, -1, 'P', 0),
+      el(1, 0, 'A', 1, { href: 'https://sli.dev' }),
+      text(2, 1, 'Why Slidev?'),
+    ]
+    const { slides } = run(nodes, [BASE_STYLE, linkStyle])
+    expect(boxes(slides[0].nodes)).toHaveLength(0)
+    const [line] = texts(slides[0].nodes)
+    expect(line.runs[0].underline).toBe(true)
+    expect(line.runs[0].underlineStyle).toBe('dash')
+  })
+
+  it('leaves a bordered box a box', () => {
+    // A bottom border on a BLOCK is a rule under a section, not an underline.
+    const blockRule = style({ borderBottomWidth: '1px', borderBottomStyle: 'solid', borderBottomColor: 'rgb(0, 0, 0)' })
+    const nodes = [el(0, -1, 'DIV', 1), text(1, 0, 'Section')]
+    const { slides } = run(nodes, [BASE_STYLE, blockRule])
+    expect(boxes(slides[0].nodes)).toHaveLength(1)
+    expect(texts(slides[0].nodes)[0].runs[0].underline).toBeUndefined()
+  })
+
+  it('leaves a chip alone, because it is more than a rule', () => {
+    const chip = style({
+      display: 'inline',
+      backgroundColor: 'rgb(200, 200, 200)',
+      borderBottomWidth: '1px',
+      borderBottomStyle: 'dashed',
+      borderBottomColor: 'rgb(0, 0, 0)',
+    })
+    const nodes = [el(0, -1, 'P', 0), el(1, 0, 'CODE', 1), text(2, 1, 'npm i')]
+    const { slides } = run(nodes, [BASE_STYLE, chip])
+    expect(boxes(slides[0].nodes).length).toBeGreaterThan(0)
+  })
+})

--- a/packages/slidev/node/commands/pptx/normalize.test.ts
+++ b/packages/slidev/node/commands/pptx/normalize.test.ts
@@ -954,3 +954,31 @@ describe('lines are grouped by overlap, not by matching tops', () => {
     expect(line.lineCount).toBe(2)
   })
 })
+
+describe('a wrapped inline box is painted once per line', () => {
+  it('emits one shape per line fragment', () => {
+    // CSS paints an inline element's background once per line FRAGMENT, while
+    // `getBoundingClientRect` reports the union of them. Drawn as that union,
+    // an inline `<code>` running across three lines filled the ragged space at
+    // the end of every line with its own dark background.
+    const inline = style({ display: 'inline', backgroundColor: 'rgb(0, 0, 0)' })
+    const fragments = [
+      { x: 100, y: 0, w: 200, h: 20 },
+      { x: 0, y: 20, w: 300, h: 20 },
+      { x: 0, y: 40, w: 80, h: 20 },
+    ]
+    const nodes = [
+      el(0, -1, 'CODE', 1, { rect: { x: 0, y: 0, w: 300, h: 60 }, fragments }),
+    ]
+    const painted = boxes(run(nodes, [BASE_STYLE, inline]).slides[0].nodes)
+    expect(painted.map(box => box.rect)).toEqual(fragments)
+  })
+
+  it('leaves an unwrapped element as one shape', () => {
+    const filled = style({ backgroundColor: 'rgb(0, 0, 0)' })
+    const nodes = [el(0, -1, 'DIV', 1, { rect: { x: 0, y: 0, w: 300, h: 60 } })]
+    const painted = boxes(run(nodes, [BASE_STYLE, filled]).slides[0].nodes)
+    expect(painted).toHaveLength(1)
+    expect(painted[0].rect).toEqual({ x: 0, y: 0, w: 300, h: 60 })
+  })
+})

--- a/packages/slidev/node/commands/pptx/normalize.test.ts
+++ b/packages/slidev/node/commands/pptx/normalize.test.ts
@@ -307,6 +307,27 @@ describe('finding 15: element opacity reaches the fill', () => {
   })
 })
 
+describe('opacity reaches text, not only shapes', () => {
+  it('greys a paragraph that its ancestor dimmed', () => {
+    // Slidev's own stylesheet greys this kind of paragraph with `opacity: 0.5`
+    // rather than a colour. Opacity is compounded down the tree onto elements,
+    // but a text node has no style of its own, so every run lost it and the
+    // paragraph exported solid black.
+    const nodes = [
+      el(0, -1, 'P', 0, { opacity: 0.5 }),
+      text(1, 0, 'a dimmed paragraph', { opacity: 0.5 }),
+    ]
+    const { slides } = run(nodes, [BASE_STYLE])
+    expect(texts(slides[0].nodes)[0].runs[0].color).toEqual({ r: 0, g: 0, b: 0, a: 0.5 })
+  })
+
+  it('centres a list marker on its line rather than above it', () => {
+    const item = style({ display: 'list-item' })
+    const { slides } = run([el(0, -1, 'LI', 1, { marker: '\u25AA ' })], [BASE_STYLE, item])
+    expect(texts(slides[0].nodes)[0].valign).toBe('middle')
+  })
+})
+
 describe('finding 6: the slide keeps its own background', () => {
   it('carries the container background into the IR', () => {
     const raw = snapshot([el(0, -1, 'DIV', 0)], [BASE_STYLE])

--- a/packages/slidev/node/commands/pptx/normalize.test.ts
+++ b/packages/slidev/node/commands/pptx/normalize.test.ts
@@ -14,6 +14,7 @@ import { normalize, parseColor, parseLength, parseShadow, rasterReasonFor } from
 const BASE_STYLE: RawStyle = {
   display: 'block',
   position: 'static',
+  zIndex: 'auto',
   visibility: 'visible',
   opacity: '1',
   color: 'rgb(0, 0, 0)',
@@ -304,6 +305,40 @@ describe('finding 15: element opacity reaches the fill', () => {
     // DrawingML has no element opacity, only per-fill alpha, so a half
     // transparent overlay exported fully opaque and hid what was behind it.
     expect(boxes(slides[0].nodes)[0].fill).toEqual({ r: 0, g: 0, b: 0, a: 0.5 })
+  })
+})
+
+describe('paint order follows CSS, not the document', () => {
+  it('draws a positioned element above in-flow content that comes later', () => {
+    const positioned = style({ position: 'absolute' })
+    const backdrop = style({ backgroundImage: 'url(/img/scenery.png)' })
+    const corner = { x: 900, y: 10, w: 60, h: 20 }
+    const nodes = [
+      // A slide's page counter is the FIRST child of its container, and it is
+      // a positioned <footer> wrapping a plain <div>, so the layer has to come
+      // from the nearest POSITIONED ancestor rather than the nearest styled one.
+      el(0, -1, 'FOOTER', 1, { rect: corner }),
+      el(1, 0, 'DIV', 0, { rect: corner }),
+      text(2, 1, '3 / 35', { rect: corner, glyphRects: [corner] }),
+      // The full-bleed background comes after it in the tree, so array order
+      // painted it straight over the counter and the counter vanished.
+      el(3, -1, 'DIV', 2, { rect: { x: 0, y: 0, w: 980, h: 552 } }),
+    ]
+    const { slides } = run(nodes, [BASE_STYLE, positioned, backdrop])
+    const kinds = slides[0].nodes.map(n => n.kind)
+    expect(kinds.indexOf('raster')).toBeLessThan(kinds.indexOf('text'))
+  })
+
+  it('keeps document order within one layer', () => {
+    const nodes = [
+      el(0, -1, 'DIV', 1),
+      text(1, 0, 'first'),
+      el(2, -1, 'DIV', 1),
+      text(3, 2, 'second'),
+    ]
+    const { slides } = run(nodes, [BASE_STYLE, style({ backgroundColor: 'rgb(1, 2, 3)' })])
+    const out = texts(slides[0].nodes)
+    expect(out.map(t => t.runs[0].text)).toEqual(['first', 'second'])
   })
 })
 

--- a/packages/slidev/node/commands/pptx/normalize.test.ts
+++ b/packages/slidev/node/commands/pptx/normalize.test.ts
@@ -318,6 +318,50 @@ describe('finding 6: the slide keeps its own background', () => {
   })
 })
 
+describe('a shrink-wrapped container leaves no room to wrap', () => {
+  it('widens a centred block whose container is exactly its ink', () => {
+    const centred = style({ textAlign: 'center' })
+    // The container fits the text exactly, which is what a centred statement
+    // block does. PowerPoint sets the same string slightly wider than
+    // Chromium, so with no headroom the longest line wraps and the block
+    // gains a line.
+    const box = { x: 155, y: 192, w: 487, h: 90 }
+    const nodes = [
+      el(0, -1, 'DIV', 1, { rect: box }),
+      text(1, 0, 'a long centred statement', {
+        rect: box,
+        glyphRects: [
+          { x: 155, y: 192, w: 400, h: 30 },
+          { x: 155, y: 222, w: 487, h: 30 },
+          { x: 155, y: 252, w: 380, h: 30 },
+        ],
+      }),
+    ]
+    const { slides } = run(nodes, [BASE_STYLE, centred])
+    const out = texts(slides[0].nodes)[0]
+    expect(out.rect.w).toBeGreaterThan(487)
+    // Grown about the centre, so the text does not slide sideways.
+    expect(out.rect.x + out.rect.w / 2).toBeCloseTo(155 + 487 / 2, 5)
+  })
+
+  it('leaves a column-constrained paragraph at its container width', () => {
+    const nodes = [
+      el(0, -1, 'DIV', 0, { rect: { x: 0, y: 0, w: 400, h: 60 } }),
+      text(1, 0, 'wrapped body copy', {
+        rect: { x: 0, y: 0, w: 400, h: 60 },
+        glyphRects: [
+          { x: 0, y: 0, w: 380, h: 20 },
+          { x: 0, y: 24, w: 200, h: 20 },
+        ],
+      }),
+    ]
+    const { slides } = run(nodes, [BASE_STYLE])
+    // 20px of headroom is already more than the 2% this needs, so widening it
+    // would push the text into whatever sits beside it.
+    expect(texts(slides[0].nodes)[0].rect.w).toBe(400)
+  })
+})
+
 describe('trap 16: --range is applied by the caller, not the page', () => {
   it('exposes the slide number so out-of-range slides can be filtered', () => {
     // The print route renders EVERY slide whatever the `range` query says, so

--- a/packages/slidev/node/commands/pptx/normalize.test.ts
+++ b/packages/slidev/node/commands/pptx/normalize.test.ts
@@ -1,6 +1,6 @@
 import type { IrBox, IrText, RawNode, RawSlide, RawSnapshot, RawStyle } from './ir'
 import { describe, expect, it } from 'vitest'
-import { normalize, parseColor, parseLength, parseShadow, rasterReasonFor, takeUnparsedColors } from './normalize'
+import { normalize, parseColor, parseLength, parseShadow, rasterReasonFor } from './normalize'
 
 /**
  * One named case per trap.
@@ -122,12 +122,13 @@ describe('value parsing', () => {
     expect(parseColor('color(srgb 1 0 0)')).toEqual({ r: 255, g: 0, b: 0, a: 1 })
   })
 
-  it('records a colour it cannot read instead of failing silently', () => {
-    takeUnparsedColors()
-    expect(parseColor('lab(50% 40 59.5)')).toBeUndefined()
-    expect(takeUnparsedColors()).toContain('lab(50% 40 59.5)')
-    // Draining is what makes the report per-export rather than cumulative.
-    expect(takeUnparsedColors()).toHaveLength(0)
+  it('reports a colour it cannot read instead of failing silently', () => {
+    const bad = style({ backgroundColor: 'lab(50% 40 59.5)' })
+    const { unparsedColors } = run([el(0, -1, 'DIV', 1)], [BASE_STYLE, bad])
+    expect(unparsedColors).toContain('lab(50% 40 59.5)')
+    // Per run, not module state: a drained global leaks into the next export
+    // whenever this one throws before the caller collects it.
+    expect(run([el(0, -1, 'DIV', 0)], [BASE_STYLE]).unparsedColors).toHaveLength(0)
   })
 
   it('reads a pixel length, and a percentage against its basis', () => {
@@ -164,6 +165,55 @@ describe('finding 2: <br> becomes a real line break', () => {
     expect(out.runs.map(r => r.text)).toEqual(['line one', 'line two'])
     expect(out.runs[1].breakBefore).toBe(true)
     expect(out.runs[0].breakBefore).toBeUndefined()
+  })
+})
+
+describe('code blocks keep their line structure', () => {
+  it('turns a pre newline into a real line break', () => {
+    const pre = style({ whiteSpace: 'pre' })
+    const inline = style({ display: 'inline', whiteSpace: 'pre' })
+    const nodes = [
+      el(0, -1, 'PRE', 1),
+      el(1, 0, 'SPAN', 2),
+      text(2, 1, 'const a = 1'),
+      // Shiki separates its line spans with a bare newline text node, which
+      // has no client rects of its own.
+      text(3, 0, '\n', { glyphRects: [] }),
+      el(4, 0, 'SPAN', 2),
+      text(5, 4, 'const b = 2'),
+    ]
+    const { slides } = run(nodes, [BASE_STYLE, pre, inline])
+    const out = texts(slides[0].nodes)[0]
+    // Folded to a space, every multi-line code block exported as one
+    // re-wrapped paragraph, which is core content for a developer slide tool.
+    expect(out.runs.map(r => r.text)).toEqual(['const a = 1', 'const b = 2'])
+    expect(out.runs[1].breakBefore).toBe(true)
+  })
+
+  it('keeps a blank line between two consecutive breaks', () => {
+    const inline = style({ display: 'inline' })
+    const nodes = [
+      el(0, -1, 'DIV', 0),
+      text(1, 0, 'first'),
+      el(2, 0, 'BR', 1),
+      el(3, 0, 'BR', 1),
+      text(4, 0, 'second'),
+    ]
+    const { slides } = run(nodes, [BASE_STYLE, inline])
+    const out = texts(slides[0].nodes)[0]
+    // `softBreakBefore` is one break per run, so two in a row need an empty
+    // run between them or the blank line silently disappears.
+    expect(out.runs).toHaveLength(3)
+    expect(out.runs[1].text).toBe('')
+    expect(out.runs[1].breakBefore).toBe(true)
+    expect(out.runs[2].breakBefore).toBe(true)
+  })
+
+  it('does not open a box with a leading break', () => {
+    const inline = style({ display: 'inline' })
+    const nodes = [el(0, -1, 'DIV', 0), el(1, 0, 'BR', 1), text(2, 0, 'text')]
+    const { slides } = run(nodes, [BASE_STYLE, inline])
+    expect(texts(slides[0].nodes)[0].runs[0].breakBefore).toBeUndefined()
   })
 })
 
@@ -245,8 +295,11 @@ describe('finding 8: a list item flows its children as text', () => {
 
 describe('finding 15: element opacity reaches the fill', () => {
   it('folds opacity into the colour alpha', () => {
-    const faded = style({ backgroundColor: 'rgb(0, 0, 0)', opacity: '0.5' })
-    const nodes = [el(0, -1, 'DIV', 1)]
+    const faded = style({ backgroundColor: 'rgb(0, 0, 0)' })
+    // Carried on the NODE, compounded down the tree by the walker, because CSS
+    // opacity does not inherit and DrawingML has no group opacity to stand in
+    // for a half-transparent wrapper.
+    const nodes = [el(0, -1, 'DIV', 1, { opacity: 0.5 })]
     const { slides } = run(nodes, [BASE_STYLE, faded])
     // DrawingML has no element opacity, only per-fill alpha, so a half
     // transparent overlay exported fully opaque and hid what was behind it.
@@ -403,28 +456,45 @@ describe('trap 8: inline decorations paint before their text', () => {
   it('anchors a chip label in its own box so it cannot drift off the chip', () => {
     const inline = style({ display: 'inline' })
     const chip = style({ display: 'inline', backgroundColor: 'rgb(0, 128, 0)' })
-    const before = { x: 0, y: 0, w: 120, h: 20 }
     const label = { x: 122, y: 0, w: 30, h: 20 }
     const nodes = [
       el(0, -1, 'DIV', 0),
-      el(1, 0, 'SPAN', 1, { rect: before }),
-      text(2, 1, 'C2C.PI.A2A.', { rect: before, glyphRects: [before] }),
-      el(3, 0, 'SPAN', 2, { rect: label }),
-      text(4, 3, 'NEW', { rect: label, glyphRects: [label] }),
+      el(1, 0, 'SPAN', 2, { rect: label }),
+      text(2, 1, 'NEW', { rect: label, glyphRects: [label] }),
     ]
     const { slides } = run(nodes, [BASE_STYLE, inline, chip])
     const out = texts(slides[0].nodes)
     // The chip's background is an absolutely positioned shape while the text
     // around it flows, so sharing one box lets PowerPoint's metrics
     // accumulate across the earlier runs and slide the label off its chip.
-    expect(out).toHaveLength(2)
-    expect(out[1].runs[0].text).toBe('NEW')
+    expect(out).toHaveLength(1)
+    expect(out[0].runs[0].text).toBe('NEW')
     // Pinned to the chip and centred in it, not to its own ink. However much
     // wider PowerPoint sets the string than the browser did, the label stays
     // evenly inset instead of ending up hard against one edge.
-    expect(out[1].rect).toEqual(label)
-    expect(out[1].align).toBe('center')
-    expect(out[1].valign).toBe('middle')
+    expect(out[0].rect).toEqual(label)
+    expect(out[0].align).toBe('center')
+    expect(out[0].valign).toBe('middle')
+  })
+
+  it('leaves inline code in the middle of a sentence alone', () => {
+    const inline = style({ display: 'inline' })
+    const code = style({ display: 'inline', backgroundColor: 'rgb(240, 240, 240)' })
+    const nodes = [
+      el(0, -1, 'P', 0),
+      text(1, 0, 'Use '),
+      el(2, 0, 'CODE', 2),
+      text(3, 2, 'npm i'),
+      text(4, 0, ' to begin.'),
+    ]
+    const { slides } = run(nodes, [BASE_STYLE, inline, code])
+    // Slidev gives inline code a background, so an unconditional chip split
+    // cut ordinary sentences into three boxes and centred the code span; when
+    // such a sentence wrapped, the halves overlapped. A chip is a label on its
+    // own, not a word in the middle of a line.
+    const out = texts(slides[0].nodes)
+    expect(out).toHaveLength(1)
+    expect(out[0].runs.map(r => r.text)).toEqual(['Use ', 'npm i', ' to begin.'])
   })
 })
 

--- a/packages/slidev/node/commands/pptx/normalize.test.ts
+++ b/packages/slidev/node/commands/pptx/normalize.test.ts
@@ -1,0 +1,574 @@
+import type { IrBox, IrText, RawNode, RawSlide, RawSnapshot, RawStyle } from './ir'
+import { describe, expect, it } from 'vitest'
+import { normalize, parseColor, parseLength, parseShadow, rasterReasonFor, takeUnparsedColors } from './normalize'
+
+/**
+ * One named case per trap.
+ *
+ * Every one of these is a bug that already shipped in the Python
+ * implementation this was ported from, or one found by reading Slidev's own
+ * `demo/starter`. A rule without a case here is a rule nobody will remember
+ * the reason for in six months.
+ */
+
+const BASE_STYLE: RawStyle = {
+  display: 'block',
+  position: 'static',
+  visibility: 'visible',
+  opacity: '1',
+  color: 'rgb(0, 0, 0)',
+  backgroundColor: 'rgba(0, 0, 0, 0)',
+  backgroundImage: 'none',
+  fontFamily: 'Inter, sans-serif',
+  fontSize: '16px',
+  fontWeight: '400',
+  fontStyle: 'normal',
+  textAlign: 'start',
+  textDecorationLine: 'none',
+  textTransform: 'none',
+  letterSpacing: 'normal',
+  lineHeight: 'normal',
+  whiteSpace: 'normal',
+  borderTopWidth: '0px',
+  borderTopStyle: 'none',
+  borderTopColor: 'rgb(0, 0, 0)',
+  borderRightWidth: '0px',
+  borderRightStyle: 'none',
+  borderRightColor: 'rgb(0, 0, 0)',
+  borderBottomWidth: '0px',
+  borderBottomStyle: 'none',
+  borderBottomColor: 'rgb(0, 0, 0)',
+  borderLeftWidth: '0px',
+  borderLeftStyle: 'none',
+  borderLeftColor: 'rgb(0, 0, 0)',
+  borderTopLeftRadius: '0px',
+  boxShadow: 'none',
+  filter: 'none',
+  backdropFilter: 'none',
+  mixBlendMode: 'normal',
+  clipPath: 'none',
+  transform: 'none',
+  writingMode: 'horizontal-tb',
+  webkitBackgroundClip: 'border-box',
+  overflow: 'visible',
+}
+
+function style(overrides: Partial<RawStyle> = {}): RawStyle {
+  return { ...BASE_STYLE, ...overrides }
+}
+
+const RECT = { x: 0, y: 0, w: 100, h: 20 }
+
+function el(id: number, parent: number, tag: string, styleIndex: number, extra: Partial<RawNode> = {}): RawNode {
+  return { id, parent, tag, style: styleIndex, rect: RECT, ...extra }
+}
+
+function text(id: number, parent: number, value: string, extra: Partial<RawNode> = {}): RawNode {
+  return {
+    id,
+    parent,
+    tag: '#text',
+    style: -1,
+    rect: RECT,
+    text: value,
+    glyphRects: [RECT],
+    ...extra,
+  }
+}
+
+function snapshot(nodes: RawNode[], styles: RawStyle[]): RawSnapshot {
+  const slide: RawSlide = { no: 1, clickIndex: 0, containerId: '001-01', size: { w: 980, h: 552 }, nodes }
+  return { slides: [slide], styles, fontResolution: { 'Inter, sans-serif': 'Inter' } }
+}
+
+function run(nodes: RawNode[], styles: RawStyle[]) {
+  return normalize(snapshot(nodes, styles), { notes: new Map() })
+}
+
+function texts(nodes: any[]): IrText[] {
+  return nodes.filter(n => n.kind === 'text')
+}
+
+function boxes(nodes: any[]): IrBox[] {
+  return nodes.filter(n => n.kind === 'box')
+}
+
+describe('value parsing', () => {
+  it('reads rgb and rgba', () => {
+    expect(parseColor('rgb(255, 0, 0)')).toEqual({ r: 255, g: 0, b: 0, a: 1 })
+    expect(parseColor('rgba(0, 0, 0, 0.5)')).toEqual({ r: 0, g: 0, b: 0, a: 0.5 })
+    expect(parseColor('transparent')).toEqual({ r: 0, g: 0, b: 0, a: 0 })
+    expect(parseColor(undefined)).toBeUndefined()
+  })
+
+  it('reads the modern colour syntaxes Chromium leaves in computed values', () => {
+    // A theme authored in modern syntax keeps these in the computed value.
+    // Returning undefined for them dropped every fill and text colour on the
+    // slide with nothing in the log to explain it.
+    const red = parseColor('oklch(0.628 0.2577 29.23)')!
+    expect(red.r).toBeGreaterThan(248)
+    expect(red.g).toBeLessThan(8)
+    expect(red.b).toBeLessThan(8)
+
+    expect(parseColor('hsl(120, 100%, 50%)')).toEqual({ r: 0, g: 255, b: 0, a: 1 })
+    expect(parseColor('color(srgb 1 0 0)')).toEqual({ r: 255, g: 0, b: 0, a: 1 })
+  })
+
+  it('records a colour it cannot read instead of failing silently', () => {
+    takeUnparsedColors()
+    expect(parseColor('lab(50% 40 59.5)')).toBeUndefined()
+    expect(takeUnparsedColors()).toContain('lab(50% 40 59.5)')
+    // Draining is what makes the report per-export rather than cumulative.
+    expect(takeUnparsedColors()).toHaveLength(0)
+  })
+
+  it('reads a pixel length, and a percentage against its basis', () => {
+    expect(parseLength('12.5px')).toBe(12.5)
+    expect(parseLength('normal')).toBe(0)
+    // Chromium keeps border-radius as a percentage rather than resolving it, so
+    // `parseFloat` alone turned `50%` on a 200px box into 50px.
+    expect(parseLength('50%', 200)).toBe(100)
+  })
+
+  it('reads a box-shadow into PowerPoint polar form', () => {
+    const shadow = parseShadow('rgba(0, 0, 0, 0.5) 0px 4px 8px 0px')!
+    expect(shadow.blur).toBe(8)
+    expect(shadow.offset).toBe(4)
+    expect(shadow.angle).toBe(90)
+    expect(shadow.color.a).toBe(0.5)
+    // No DrawingML equivalent for either of these.
+    expect(parseShadow('none')).toBeUndefined()
+    expect(parseShadow('rgb(0, 0, 0) 0px 2px 4px inset')).toBeUndefined()
+  })
+})
+
+describe('finding 2: <br> becomes a real line break', () => {
+  it('breaks between the runs either side of it', () => {
+    const nodes = [
+      el(0, -1, 'DIV', 0),
+      text(1, 0, 'line one'),
+      el(2, 0, 'BR', 1),
+      text(3, 0, 'line two'),
+    ]
+    const { slides } = run(nodes, [BASE_STYLE, style({ display: 'inline' })])
+    const out = texts(slides[0].nodes)[0]
+    // Without this the two runs are concatenated and export as "line oneline two".
+    expect(out.runs.map(r => r.text)).toEqual(['line one', 'line two'])
+    expect(out.runs[1].breakBefore).toBe(true)
+    expect(out.runs[0].breakBefore).toBeUndefined()
+  })
+})
+
+describe('finding 4: an inline image survives', () => {
+  it('draws an <img> that sits inside a line of text', () => {
+    const inline = style({ display: 'inline' })
+    const nodes = [
+      el(0, -1, 'P', 0),
+      text(1, 0, 'before'),
+      el(2, 0, 'IMG', 1, { src: 'data:image/png;base64,AAAA', alt: 'logo' }),
+    ]
+    const { slides } = run(nodes, [BASE_STYLE, inline])
+    // Inline children go to the text grouper, which finds no text under an
+    // IMG, so the image used to vanish from the slide entirely.
+    const images = slides[0].nodes.filter(n => n.kind === 'image')
+    expect(images).toHaveLength(1)
+    expect((images[0] as any).alt).toBe('logo')
+  })
+})
+
+describe('finding 11: the space between inline elements', () => {
+  it('keeps a whitespace-only node between two spans', () => {
+    const inline = style({ display: 'inline' })
+    const nodes = [
+      el(0, -1, 'DIV', 0),
+      el(1, 0, 'SPAN', 1),
+      text(2, 1, 'Hello'),
+      text(3, 0, ' '),
+      el(4, 0, 'SPAN', 1),
+      text(5, 4, 'World'),
+    ]
+    const { slides } = run(nodes, [BASE_STYLE, inline])
+    const out = texts(slides[0].nodes)[0]
+    // Dropping it exported "HelloWorld".
+    expect(out.runs.map(r => r.text).join('')).toBe('Hello World')
+  })
+})
+
+describe('finding 7: inline-level layout containers still lay out', () => {
+  it('does not merge the cells of an inline-flex badge', () => {
+    const badge = style({ display: 'inline-flex' })
+    const cell = style({ display: 'inline' })
+    const nodes = [
+      el(0, -1, 'DIV', 0),
+      el(1, 0, 'SPAN', 1),
+      el(2, 1, 'SPAN', 2),
+      text(3, 2, 'Left cell'),
+      el(4, 1, 'SPAN', 2),
+      text(5, 4, 'Right cell'),
+    ]
+    const { slides } = run(nodes, [BASE_STYLE, badge, cell])
+    // `^inline` matched inline-flex, so the walk descended and concatenated
+    // the cells: the trap-3 bug one display value over.
+    const out = texts(slides[0].nodes)
+    expect(out).toHaveLength(2)
+    expect(out.map(t => t.runs[0].text)).toEqual(['Left cell', 'Right cell'])
+  })
+})
+
+describe('finding 8: a list item flows its children as text', () => {
+  it('keeps a bold lead-in joined inside an <li>', () => {
+    const item = style({ display: 'list-item' })
+    const inline = style({ display: 'inline' })
+    const nodes = [
+      el(0, -1, 'LI', 1, { marker: '\u2022 ' }),
+      text(1, 0, 'plain '),
+      el(2, 0, 'B', 2),
+      text(3, 2, 'bold'),
+      text(4, 0, ' tail'),
+    ]
+    const { slides } = run(nodes, [BASE_STYLE, item, inline])
+    const out = texts(slides[0].nodes)
+    // One marker box plus ONE grouped paragraph. Treating `list-item` as a
+    // layout container fragmented this into four boxes.
+    expect(out).toHaveLength(2)
+    expect(out[1].runs.map(r => r.text)).toEqual(['plain ', 'bold', ' tail'])
+  })
+})
+
+describe('finding 15: element opacity reaches the fill', () => {
+  it('folds opacity into the colour alpha', () => {
+    const faded = style({ backgroundColor: 'rgb(0, 0, 0)', opacity: '0.5' })
+    const nodes = [el(0, -1, 'DIV', 1)]
+    const { slides } = run(nodes, [BASE_STYLE, faded])
+    // DrawingML has no element opacity, only per-fill alpha, so a half
+    // transparent overlay exported fully opaque and hid what was behind it.
+    expect(boxes(slides[0].nodes)[0].fill).toEqual({ r: 0, g: 0, b: 0, a: 0.5 })
+  })
+})
+
+describe('finding 6: the slide keeps its own background', () => {
+  it('carries the container background into the IR', () => {
+    const raw = snapshot([el(0, -1, 'DIV', 0)], [BASE_STYLE])
+    raw.slides[0].background = 'rgb(18, 18, 18)'
+    const { slides } = normalize(raw, { notes: new Map() })
+    // The walk starts at the container's children, so without this every slide
+    // exported onto PowerPoint's white and a dark theme became unreadable.
+    expect(slides[0].background).toEqual({ r: 18, g: 18, b: 18, a: 1 })
+  })
+})
+
+describe('trap 16: --range is applied by the caller, not the page', () => {
+  it('exposes the slide number so out-of-range slides can be filtered', () => {
+    // The print route renders EVERY slide whatever the `range` query says, so
+    // out-of-range containers are fully laid out rather than hidden, and an
+    // exporter that trusts the page exports the whole deck. `no` and
+    // `containerId` are what let the caller drop them, the same way the image
+    // exporter does with `pages.includes(slideNo)`.
+    const raw = snapshot([el(0, -1, 'DIV', 0), text(1, 0, 'content')], [BASE_STYLE])
+    raw.slides[0].no = 7
+    raw.slides[0].containerId = '007-03'
+    const { slides } = normalize(raw, { notes: new Map() })
+    expect(slides[0].no).toBe(7)
+    expect(slides[0].containerId).toBe('007-03')
+  })
+})
+
+describe('finding 20: line counting tolerates sub-pixel layout', () => {
+  it('treats fragments a fraction of a pixel apart as one line', () => {
+    const nodes = [
+      el(0, -1, 'DIV', 0),
+      text(1, 0, 'one visual line', {
+        glyphRects: [
+          { x: 0, y: 10.4, w: 50, h: 20 },
+          { x: 50, y: 10.6, w: 50, h: 20 },
+        ],
+      }),
+    ]
+    const { slides } = run(nodes, [BASE_STYLE])
+    // Rounding put these on 10 and 11 and reported two lines, which flips
+    // `wrap` in the builder, the one decision this number exists to make.
+    expect(texts(slides[0].nodes)[0].lineCount).toBe(1)
+  })
+})
+
+describe('trap 3: layout containers are not text blocks', () => {
+  it('keeps grid cells apart instead of concatenating them', () => {
+    const grid = style({ display: 'grid' })
+    // The cells are INLINE on purpose. CSS blockifies the children of a grid
+    // container into grid items whatever their specified display says, so they
+    // are separate boxes. An earlier fixture used block children, which fall
+    // into separate text groups anyway, so it passed even with the rule
+    // disabled and tested nothing.
+    const cell = style({ display: 'inline' })
+    const nodes = [
+      el(0, -1, 'DIV', 1),
+      el(1, 0, 'SPAN', 2),
+      text(2, 1, 'Left cell'),
+      el(3, 0, 'SPAN', 2),
+      text(4, 3, 'Right cell'),
+    ]
+    const { slides } = run(nodes, [BASE_STYLE, grid, cell])
+    const out = texts(slides[0].nodes)
+    // The original bug produced one run reading "Left cellRight cell".
+    expect(out).toHaveLength(2)
+    expect(out[0].runs[0].text).toBe('Left cell')
+    expect(out[1].runs[0].text).toBe('Right cell')
+  })
+})
+
+describe('trap 7: consecutive inline nodes are one anonymous block', () => {
+  it('joins a bold lead-in with the rest of its sentence', () => {
+    const inline = style({ display: 'inline' })
+    const bold = style({ display: 'inline', fontWeight: '700' })
+    const nodes = [
+      el(0, -1, 'DIV', 0),
+      el(1, 0, 'B', 2),
+      text(2, 1, 'A bold lead-in'),
+      text(3, 0, ', and the rest of the sentence'),
+      el(4, 0, 'DIV', 0),
+      text(5, 4, 'A following block.'),
+    ]
+    const { slides } = run(nodes, [BASE_STYLE, inline, bold])
+    const out = texts(slides[0].nodes)
+    // Two boxes: the anonymous block, then the nested block. Emitting three
+    // separate shapes made the bold lead-in and the tail lay out from the same
+    // origin and print on top of each other.
+    expect(out).toHaveLength(2)
+    expect(out[0].runs.map(r => r.text)).toEqual(['A bold lead-in', ', and the rest of the sentence'])
+    expect(out[0].runs[0].bold).toBe(true)
+    expect(out[0].runs[1].bold).toBeUndefined()
+    expect(out[1].runs[0].text).toBe('A following block.')
+  })
+})
+
+describe('trap 8: inline decorations paint before their text', () => {
+  it('emits a chip background ahead of the white label on it', () => {
+    const chip = style({ display: 'inline', backgroundColor: 'rgb(0, 128, 0)', color: 'rgb(255, 255, 255)' })
+    const nodes = [
+      el(0, -1, 'DIV', 0),
+      el(1, 0, 'SPAN', 1),
+      text(2, 1, 'NEW'),
+    ]
+    const { slides } = run(nodes, [BASE_STYLE, chip])
+    const kinds = slides[0].nodes.map(n => n.kind)
+    // Paint order is array order. Emitted after the text, the chip covers its
+    // own label and white-on-green becomes white-on-white.
+    expect(kinds.indexOf('box')).toBeLessThan(kinds.indexOf('text'))
+    expect(boxes(slides[0].nodes)[0].fill).toEqual({ r: 0, g: 128, b: 0, a: 1 })
+  })
+})
+
+describe('trap 2: text-transform and letter-spacing are applied', () => {
+  it('uppercases the run rather than trusting PowerPoint to do it', () => {
+    const label = style({ textTransform: 'uppercase', letterSpacing: '2px' })
+    const nodes = [el(0, -1, 'DIV', 1), text(1, 0, 'section one')]
+    const { slides } = run(nodes, [BASE_STYLE, label])
+    const out = texts(slides[0].nodes)[0]
+    // PowerPoint has no text-transform, so an untransformed run exports the
+    // lower-case source text and the slide silently changes.
+    expect(out.runs[0].text).toBe('SECTION ONE')
+    expect(out.runs[0].letterSpacing).toBe(2)
+  })
+})
+
+describe('trap 6: text is positioned from glyph bounds', () => {
+  it('uses the glyph rects, not the element box, and counts line boxes', () => {
+    const nodes = [
+      el(0, -1, 'DIV', 0),
+      text(1, 0, 'two lines here', {
+        rect: { x: 0, y: 0, w: 500, h: 100 },
+        glyphRects: [
+          { x: 40, y: 10, w: 120, h: 20 },
+          { x: 40, y: 34, w: 90, h: 20 },
+        ],
+      }),
+    ]
+    const { slides } = run(nodes, [BASE_STYLE])
+    const out = texts(slides[0].nodes)[0]
+    expect(out.rect).toEqual({ x: 40, y: 10, w: 120, h: 44 })
+    // Line count drives `wrap` in the builder: a single-line box must not be
+    // allowed to re-wrap under PowerPoint's wider metrics.
+    expect(out.lineCount).toBe(2)
+  })
+})
+
+describe('trap 11: list bullets are pseudo-elements', () => {
+  it('recovers a ::marker glyph that has no text node', () => {
+    const item = style({ display: 'list-item' })
+    const nodes = [
+      el(0, -1, 'LI', 1, { marker: '• ' }),
+      text(1, 0, 'first point'),
+    ]
+    const { slides } = run(nodes, [BASE_STYLE, item])
+    const out = texts(slides[0].nodes)
+    // A plain DOM walk drops every bullet in the deck, because ::marker is not
+    // in the tree.
+    expect(out.some(t => t.runs[0].text.includes('•'))).toBe(true)
+    expect(out.some(t => t.runs[0].text === 'first point')).toBe(true)
+  })
+})
+
+describe('traps 4, 5, 12, 13: what has to become a picture', () => {
+  it('rasterizes a mermaid svg whose labels are foreignObject', () => {
+    expect(rasterReasonFor(el(0, -1, 'SVG', 0, { hasForeignObject: true }), BASE_STYLE))
+      .toBe('foreign-object')
+  })
+
+  it('rasterizes svg, canvas and cross-origin iframes', () => {
+    expect(rasterReasonFor(el(0, -1, 'SVG', 0), BASE_STYLE)).toBe('svg')
+    expect(rasterReasonFor(el(0, -1, 'CANVAS', 0), BASE_STYLE)).toBe('canvas')
+    // demo/starter embeds <Tweet>, which is a cross-origin frame the walker
+    // cannot descend into at all.
+    expect(rasterReasonFor(el(0, -1, 'IFRAME', 0), BASE_STYLE)).toBe('iframe')
+  })
+
+  it('rasterizes a css background image and a gradient-filled heading', () => {
+    expect(rasterReasonFor(el(0, -1, 'DIV', 0), style({ backgroundImage: 'url(cover.jpg)' })))
+      .toBe('background-image')
+    expect(rasterReasonFor(el(0, -1, 'H1', 0), style({ webkitBackgroundClip: 'text' })))
+      .toBe('background-clip-text')
+  })
+
+  it('keeps a shadow-root diagram rather than skipping it', () => {
+    const nodes = [
+      el(0, -1, 'DIV', 0),
+      el(1, 0, 'SVG', 0, { fromShadowRoot: true, hasForeignObject: true }),
+    ]
+    const { slides, rasterRequests } = run(nodes, [BASE_STYLE])
+    // Mermaid renders into a shadow root, so a document-level query finds
+    // nothing and the diagram vanishes from the export entirely.
+    expect(slides[0].nodes.some(n => n.kind === 'raster')).toBe(true)
+    expect(rasterRequests).toHaveLength(1)
+  })
+})
+
+describe('trap 10: only backdrops need isolation', () => {
+  it('isolates a backdrop but not a leaf picture', () => {
+    const backdrop = run(
+      [el(0, -1, 'DIV', 1), el(1, 0, 'DIV', 0), text(2, 1, 'on top')],
+      [BASE_STYLE, style({ backgroundImage: 'linear-gradient(red, blue)' })],
+    )
+    const raster = backdrop.slides[0].nodes.find(n => n.kind === 'raster') as any
+    // Without hiding siblings, the text bakes into the backdrop picture and is
+    // then drawn again as a shape, doubling every word.
+    expect(raster.isolate).toBe(true)
+    // Its children are still walked, so the text survives as editable text.
+    expect(texts(backdrop.slides[0].nodes)).toHaveLength(1)
+
+    const leaf = run([el(0, -1, 'SVG', 0)], [BASE_STYLE])
+    expect((leaf.slides[0].nodes[0] as any).isolate).toBe(false)
+  })
+})
+
+describe('tier 4: the safety valve', () => {
+  it('falls back when a slide with text yields none', () => {
+    // Every text node sits under an <svg>, so all of it rasterizes.
+    const nodes = [el(0, -1, 'SVG', 0), text(1, 0, 'invisible to the walk')]
+    const { slides } = run(nodes, [BASE_STYLE])
+    expect(slides[0].fallbackReason).toMatch(/no text could be recovered/)
+  })
+
+  it('falls back when most of the slide had to be rasterized', () => {
+    const big = { x: 0, y: 0, w: 900, h: 500 }
+    const nodes = [
+      el(0, -1, 'SVG', 0, { rect: big }),
+      el(1, -1, 'DIV', 0),
+      text(2, 1, 'a little text'),
+    ]
+    const { slides } = run(nodes, [BASE_STYLE])
+    expect(slides[0].fallbackReason).toMatch(/rasterized/)
+  })
+
+  it('does not request captures for a slide that is falling back anyway', () => {
+    const nodes = [el(0, -1, 'SVG', 0), text(1, 0, 'invisible to the walk')]
+    const { rasterRequests } = run(nodes, [BASE_STYLE])
+    // The whole slide becomes one picture, so per-element captures would be
+    // paid for and thrown away.
+    expect(rasterRequests).toHaveLength(0)
+  })
+
+  it('leaves an ordinary slide alone', () => {
+    const nodes = [el(0, -1, 'DIV', 0), text(1, 0, 'ordinary content')]
+    const { slides } = run(nodes, [BASE_STYLE])
+    expect(slides[0].fallbackReason).toBeUndefined()
+  })
+})
+
+describe('trap 16: content outside the slide', () => {
+  it('clips a shape that overflows the slide', () => {
+    const wide = style({ backgroundColor: 'rgb(1, 2, 3)' })
+    const nodes = [el(0, -1, 'DIV', 1, { rect: { x: 900, y: 0, w: 500, h: 100 } })]
+    const { slides } = run(nodes, [BASE_STYLE, wide])
+    // A slide container is overflow:hidden, but PowerPoint has no clipping, so
+    // an unclamped shape sits off the canvas where it cannot even be selected.
+    expect(boxes(slides[0].nodes)[0].rect).toEqual({ x: 900, y: 0, w: 80, h: 100 })
+  })
+
+  it('drops a shape that is entirely off the slide', () => {
+    const off = style({ backgroundColor: 'rgb(1, 2, 3)' })
+    const nodes = [el(0, -1, 'DIV', 1, { rect: { x: 2000, y: 0, w: 100, h: 100 } })]
+    const { slides } = run(nodes, [BASE_STYLE, off])
+    expect(boxes(slides[0].nodes)).toHaveLength(0)
+  })
+
+  it('does not let a runaway rect blow up the fallback maths', () => {
+    // Slidev's own starter deck has an element measuring tens of millions of
+    // pixels, which reported "104064986954% of the slide had to be rasterized".
+    const huge = { x: 0, y: 0, w: 24_000_000, h: 24_000_000 }
+    const nodes = [el(0, -1, 'CANVAS', 0, { rect: huge }), el(1, -1, 'DIV', 0), text(2, 1, 'hi')]
+    const { slides } = run(nodes, [BASE_STYLE])
+    expect(slides[0].fallbackReason).toMatch(/^100% of the slide/)
+  })
+})
+
+describe('a full-bleed backdrop does not trigger the fallback', () => {
+  it('keeps the text on a cover slide editable', () => {
+    const cover = style({ backgroundImage: 'url(https://cover.sli.dev)' })
+    const nodes = [
+      el(0, -1, 'DIV', 1, { rect: { x: 0, y: 0, w: 980, h: 552 } }),
+      el(1, 0, 'H1', 0),
+      text(2, 1, 'Welcome to Slidev'),
+    ]
+    const { slides } = run(nodes, [BASE_STYLE, cover])
+    // A cover photo covers 100% of the slide by definition, but the title on
+    // top of it is still perfectly vectorizable. Counting isolated backdrops
+    // toward the raster budget sent every deck with a cover straight to the
+    // whole-slide fallback.
+    expect(slides[0].fallbackReason).toBeUndefined()
+    expect(texts(slides[0].nodes)[0].runs[0].text).toBe('Welcome to Slidev')
+  })
+})
+
+describe('fonts', () => {
+  it('names the family the browser actually resolved', () => {
+    const nodes = [el(0, -1, 'DIV', 0), text(1, 0, 'hello')]
+    const { slides } = run(nodes, [BASE_STYLE])
+    expect(texts(slides[0].nodes)[0].runs[0].fontFamily).toBe('Inter')
+  })
+
+  it('strips the @fontsource Variable suffix when nothing resolved', () => {
+    const nodes = [el(0, -1, 'DIV', 1), text(1, 0, 'hello')]
+    const styles = [BASE_STYLE, style({ fontFamily: '"Inter Variable", sans-serif' })]
+    const { slides } = run(nodes, styles)
+    // Nobody has a font installed under the name "Inter Variable"; that is a
+    // packaging artifact of @fontsource-variable.
+    expect(texts(slides[0].nodes)[0].runs[0].fontFamily).toBe('Inter')
+  })
+})
+
+describe('boxes', () => {
+  it('ignores a fully transparent background', () => {
+    const nodes = [el(0, -1, 'DIV', 0)]
+    const { slides } = run(nodes, [BASE_STYLE])
+    expect(boxes(slides[0].nodes)).toHaveLength(0)
+  })
+
+  it('keeps one side of a border', () => {
+    const accent = style({ borderLeftWidth: '4px', borderLeftStyle: 'solid', borderLeftColor: 'rgb(0, 128, 0)' })
+    const nodes = [el(0, -1, 'DIV', 1)]
+    const { slides } = run(nodes, [BASE_STYLE, accent])
+    const box = boxes(slides[0].nodes)[0]
+    expect(box.borders?.[3]).toEqual({ width: 4, color: { r: 0, g: 128, b: 0, a: 1 }, style: 'solid' })
+    expect(box.borders?.[0]).toBeUndefined()
+  })
+})

--- a/packages/slidev/node/commands/pptx/normalize.test.ts
+++ b/packages/slidev/node/commands/pptx/normalize.test.ts
@@ -53,6 +53,12 @@ const BASE_STYLE: RawStyle = {
   writingMode: 'horizontal-tb',
   webkitBackgroundClip: 'border-box',
   overflow: 'visible',
+  top: 'auto',
+  right: 'auto',
+  bottom: 'auto',
+  left: 'auto',
+  width: 'auto',
+  height: 'auto',
 }
 
 function style(overrides: Partial<RawStyle> = {}): RawStyle {
@@ -80,7 +86,7 @@ function text(id: number, parent: number, value: string, extra: Partial<RawNode>
 
 function snapshot(nodes: RawNode[], styles: RawStyle[]): RawSnapshot {
   const slide: RawSlide = { no: 1, clickIndex: 0, containerId: '001-01', size: { w: 980, h: 552 }, nodes }
-  return { slides: [slide], styles, fontResolution: { 'Inter, sans-serif': 'Inter' } }
+  return { slides: [slide], styles, fontResolution: { 'Inter, sans-serif': 'Inter' }, unplaceablePseudos: [] }
 }
 
 function run(nodes: RawNode[], styles: RawStyle[]) {
@@ -272,6 +278,41 @@ describe('trap 16: --range is applied by the caller, not the page', () => {
     const { slides } = normalize(raw, { notes: new Map() })
     expect(slides[0].no).toBe(7)
     expect(slides[0].containerId).toBe('007-03')
+  })
+})
+
+describe('cSS pseudo-element decorations', () => {
+  it('draws an ::after that paints a background image', () => {
+    const mark = style({
+      position: 'absolute',
+      backgroundImage: 'url(/img/logo.png)',
+      width: '84px',
+      height: '33px',
+    })
+    const rect = { x: 858, y: 493, w: 84, h: 33 }
+    const nodes = [
+      el(0, -1, 'DIV', 0),
+      el(1, 0, '::AFTER', 1, { rect, pageRect: rect }),
+    ]
+    const { slides, rasterRequests } = run(nodes, [BASE_STYLE, mark])
+    // A pseudo-element has no DOM node, so a walk over the tree cannot see it.
+    // A corporate logo drawn this way was silently absent from every slide.
+    const raster = slides[0].nodes.find(n => n.kind === 'raster') as any
+    expect(raster).toBeDefined()
+    expect(raster.rect).toEqual(rect)
+    // And no locator can point at it, so the capture clips the page instead.
+    expect(rasterRequests[0].clip).toEqual(rect)
+  })
+
+  it('draws an ::before that paints a string', () => {
+    const quote = style({ position: 'absolute', width: '20px', height: '20px' })
+    const rect = { x: 10, y: 10, w: 20, h: 20 }
+    const nodes = [
+      el(0, -1, 'DIV', 0),
+      el(1, 0, '::BEFORE', 1, { rect, pageRect: rect, text: '\u201C' }),
+    ]
+    const { slides } = run(nodes, [BASE_STYLE, quote])
+    expect(texts(slides[0].nodes)[0].runs[0].text).toBe('\u201C')
   })
 })
 

--- a/packages/slidev/node/commands/pptx/normalize.test.ts
+++ b/packages/slidev/node/commands/pptx/normalize.test.ts
@@ -1192,3 +1192,30 @@ describe('a table cell flows its children, it does not lay them out', () => {
     expect(lines.map(l => l.runs.map(r => r.text).join(''))).toEqual(['one', 'two'])
   })
 })
+
+describe('a block box inside an inline run is not folded into the paragraph', () => {
+  // Shiki's `<code>` is `display: inline`, and TwoSlash renders a diagnostic as
+  // a `<div>` inside it. Collecting text through the inline subtree without
+  // testing display ran the message onto the end of the code line it belongs
+  // to: "doubled.value = 2Cannot assign to 'value' because it is a read-only
+  // property." on `demo/starter`.
+  const styles = [
+    style({ display: 'block', whiteSpace: 'pre' }), // 0: <pre>
+    style({ display: 'inline', whiteSpace: 'pre' }), // 1: <code>
+    style({ display: 'block', whiteSpace: 'pre' }), // 2: the diagnostic
+  ]
+  const nodes = [
+    el(1, -1, 'PRE', 0),
+    el(2, 1, 'CODE', 1),
+    text(3, 2, 'doubled.value = 2'),
+    el(4, 2, 'DIV', 2, { rect: { x: 0, y: 30, w: 200, h: 20 } }),
+    text(5, 4, 'Cannot assign to \'value\'.', { rect: { x: 0, y: 30, w: 200, h: 20 }, glyphRects: [{ x: 0, y: 30, w: 200, h: 20 }] }),
+  ]
+
+  it('gives the diagnostic its own text box', () => {
+    const found = texts(run(nodes, styles).slides[0].nodes)
+    const joined = found.map(t => t.runs.map(r => r.text).join('')).join('|')
+    expect(joined).not.toContain('2Cannot assign')
+    expect(found).toHaveLength(2)
+  })
+})

--- a/packages/slidev/node/commands/pptx/normalize.test.ts
+++ b/packages/slidev/node/commands/pptx/normalize.test.ts
@@ -908,3 +908,49 @@ describe('boxes', () => {
     expect(box.borders?.[0]).toBeUndefined()
   })
 })
+
+describe('lines are grouped by overlap, not by matching tops', () => {
+  it('counts one line when a heading mixes run sizes', () => {
+    // A browser aligns runs of different sizes on a shared BASELINE, so their
+    // rect tops differ while they sit on the same line. Grouping by top
+    // counted `Needed a **Pros-Cons comparison** in now?` as four lines where
+    // it has two, and the spacing that came out of that count set the two real
+    // lines on top of each other.
+    const small = { x: 0, y: 130, w: 120, h: 40 }
+    const large = { x: 120, y: 100, w: 400, h: 100 }
+    const nodes = [
+      el(0, -1, 'H1', 0, { rect: { x: 0, y: 100, w: 520, h: 220 } }),
+      text(1, 0, 'Needed a ', { glyphRects: [small] }),
+      text(2, 0, 'Pros-Cons', { glyphRects: [large] }),
+      text(3, 0, 'comparison', { glyphRects: [{ ...large, y: 220 }] }),
+      text(4, 0, ' in now?', { glyphRects: [{ ...small, y: 250 }] }),
+    ]
+    const [line] = texts(run(nodes, [BASE_STYLE]).slides[0].nodes)
+    expect(line.lineCount).toBe(2)
+  })
+
+  it('takes the line spacing from the measured line boxes', () => {
+    // The computed `line-height` belongs to the element while a line box is as
+    // tall as its largest run, so a heading mixing sizes reported far too
+    // little leading and PowerPoint overlapped the lines.
+    const nodes = [
+      el(0, -1, 'H1', 0, { rect: { x: 0, y: 0, w: 400, h: 240 } }),
+      text(1, 0, 'first', { glyphRects: [{ x: 0, y: 0, w: 300, h: 100 }] }),
+      text(2, 0, 'second', { glyphRects: [{ x: 0, y: 120, w: 300, h: 100 }] }),
+    ]
+    const [line] = texts(run(nodes, [BASE_STYLE]).slides[0].nodes)
+    // 120, the distance between the line tops. `line-height: normal` on a
+    // 16px font would have said 19.2.
+    expect(line.lineHeight).toBe(120)
+  })
+
+  it('still separates lines whose ink very nearly touches', () => {
+    const nodes = [
+      el(0, -1, 'P', 0, { rect: { x: 0, y: 0, w: 400, h: 40 } }),
+      text(1, 0, 'one', { glyphRects: [{ x: 0, y: 0, w: 300, h: 20 }] }),
+      text(2, 0, 'two', { glyphRects: [{ x: 0, y: 19, w: 300, h: 20 }] }),
+    ]
+    const [line] = texts(run(nodes, [BASE_STYLE]).slides[0].nodes)
+    expect(line.lineCount).toBe(2)
+  })
+})

--- a/packages/slidev/node/commands/pptx/normalize.test.ts
+++ b/packages/slidev/node/commands/pptx/normalize.test.ts
@@ -982,3 +982,21 @@ describe('a wrapped inline box is painted once per line', () => {
     expect(painted[0].rect).toEqual({ x: 0, y: 0, w: 300, h: 60 })
   })
 })
+
+describe('a raster that cannot be placed must not swallow its subtree', () => {
+  it('walks into a rotated wrapper that has no box of its own', () => {
+    // A theme rotating a corner decoration puts the transform on a wrapper
+    // with no size, while the artwork inside is absolutely positioned and does
+    // have one. Treating the wrapper as rasterized dropped the whole
+    // decoration: the picture had no area, so nothing was emitted for it
+    // either, and the entire corner vanished from every slide.
+    const rotated = style({ transform: 'matrix(0, 1, -1, 0, 0, 0)', position: 'absolute' })
+    const nodes = [
+      el(0, -1, 'DIV', 1, { rect: { x: 0, y: 0, w: 0, h: 0 } }),
+      el(1, 0, 'SVG', 0, { rect: { x: 10, y: 20, w: 279, h: 322 } }),
+    ]
+    const { slides, rasterRequests } = run(nodes, [BASE_STYLE, rotated])
+    expect(slides[0].nodes.map(node => node.sourceId)).toEqual([1])
+    expect(rasterRequests.map(request => request.sourceId)).toEqual([1])
+  })
+})

--- a/packages/slidev/node/commands/pptx/normalize.ts
+++ b/packages/slidev/node/commands/pptx/normalize.ts
@@ -847,20 +847,27 @@ class SlideWalker {
     const radius = parseLength(style.borderTopLeftRadius, Math.min(node.rect.w, node.rect.h))
     if (!isVisible(fill) && !hasBorder)
       return
-    const rect = clipToSlide(node.rect, this.size)
-    if (!rect)
-      return
-    const box: IrBox = { kind: 'box', sourceId: node.id, rect }
-    if (isVisible(fill))
-      box.fill = fill
-    if (hasBorder)
-      box.borders = borders
-    if (radius > 0)
-      box.radius = radius
     const shadow = parseShadow(style.boxShadow)
-    if (shadow)
-      box.shadow = shadow
-    this.push(box, node)
+    // One shape per line fragment for a wrapped inline element, because that
+    // is what a browser paints. Drawn as one rect over the union instead, an
+    // inline `<code>` running across several lines filled the ragged space at
+    // the end of every line with its own background.
+    const boxes = node.fragments?.length ? node.fragments : [node.rect]
+    for (const source of boxes) {
+      const rect = clipToSlide(source, this.size)
+      if (!rect)
+        continue
+      const box: IrBox = { kind: 'box', sourceId: node.id, rect }
+      if (isVisible(fill))
+        box.fill = fill
+      if (hasBorder)
+        box.borders = borders
+      if (radius > 0)
+        box.radius = radius
+      if (shadow)
+        box.shadow = shadow
+      this.push(box, node)
+    }
   }
 
   private visit(node: RawNode): void {

--- a/packages/slidev/node/commands/pptx/normalize.ts
+++ b/packages/slidev/node/commands/pptx/normalize.ts
@@ -69,7 +69,10 @@ const RASTER_TAGS: Record<string, RasterReason> = {
 export interface RasterRequest {
   /** The `data-slidev-export-id` of the element to capture. */
   sourceId: number
+  /** Hide everything outside this element's own subtree. */
   isolate: boolean
+  /** Also hide its children, which is only safe when they are redrawn. */
+  hideDescendants: boolean
 }
 
 export interface NormalizeOptions {
@@ -542,6 +545,16 @@ class SlideWalker {
     return undefined
   }
 
+  /** Whether an inline element paints something of its own behind its text. */
+  private hasDecoration(node: RawNode): boolean {
+    const style = this.styleOf(node)
+    if (!style)
+      return false
+    if (isVisible(withOpacity(parseColor(style.backgroundColor), style.opacity)))
+      return true
+    return (['Top', 'Right', 'Bottom', 'Left'] as const).some(side => borderOf(style, side))
+  }
+
   private isInline(node: RawNode): boolean {
     if (node.tag === '#text')
       return true
@@ -554,23 +567,45 @@ class SlideWalker {
       this.visit(root)
 
     const texts = this.nodes.filter(n => n.kind === 'text')
+    // Pictures are drawn from their own screenshots, so a picture overlapping
+    // another picture is not the doubling problem below.
+    const drawnOver = this.nodes.filter(n => n.kind === 'text' || n.kind === 'image')
 
-    /**
-     * Raster area that bought us nothing.
-     *
-     * A picture with editable text drawn ON TOP of it is not wasted work: a
-     * full-bleed cover photo or a decorative background graphic covers the
-     * whole slide by definition, while the title over it vectorizes perfectly.
-     * Counting those sent every cover slide straight to the whole-slide
-     * fallback and threw away its text.
-     *
-     * So only a raster that nothing was recovered over counts against the
-     * budget. This generalises the rule that used to apply to isolated
-     * backdrops alone, which missed leaf pictures such as a full-bleed `<svg>`.
-     */
     for (const node of this.nodes) {
       if (node.kind !== 'raster')
         continue
+
+      /**
+       * Anything we ALSO draw as a shape inside this picture's box.
+       *
+       * `locator.screenshot()` clips the page to the element's box rather than
+       * isolating the element, so every overlapping thing lands in the
+       * picture. Drawing it again as a shape then prints it twice, which is
+       * exactly what a cover title over a full-bleed graphic looked like.
+       *
+       * Isolation used to be decided from the CSS reason - backdrops and the
+       * filter family - but that was only ever a proxy for "something is
+       * painted on top of this". Overlap tests the real thing, so a leaf
+       * picture such as a full-bleed `<svg>` is covered too.
+       */
+      const covered = drawnOver.some(other => overlaps(other.rect, node.rect))
+      if (covered)
+        node.isolate = true
+
+      this.requests.push({
+        sourceId: node.sourceId,
+        isolate: node.isolate,
+        hideDescendants: node.hideDescendants,
+      })
+
+      /**
+       * Raster area that bought us nothing.
+       *
+       * A picture with editable text over it is not wasted work: a cover photo
+       * covers the whole slide by definition while the title over it
+       * vectorizes perfectly. Counting those sent every cover slide to the
+       * whole-slide fallback and threw its text away.
+       */
       if (texts.some(text => overlaps(text.rect, node.rect)))
         continue
       const visible = clipToSlide(node.rect, this.size)
@@ -589,6 +624,9 @@ class SlideWalker {
     this.nodes.push({
       kind: 'raster',
       sourceId: node.id,
+      // Its children are walked and redrawn only when it is a backdrop, so
+      // only then is it safe to hide them for the capture.
+      hideDescendants: isolate,
       // The element's FULL rect, not the clipped one. The screenshot is of the
       // whole element, so drawing it into a smaller box squashes the picture
       // and shows content that should have been cropped away. PowerPoint has
@@ -599,7 +637,6 @@ class SlideWalker {
       reason,
       isolate,
     })
-    this.requests.push({ sourceId: node.id, isolate })
   }
 
   private emitImage(node: RawNode): void {
@@ -730,6 +767,19 @@ class SlideWalker {
     }
     for (const child of children) {
       if (this.isInline(child)) {
+        // An inline element carrying its own background or border is a chip,
+        // and its decoration is an absolutely positioned shape while the text
+        // around it is a flowed text box. Left in the same box, any difference
+        // between PowerPoint's metrics and the browser's accumulates across
+        // the earlier runs and slides the label off its own chip.
+        //
+        // Given its own box at its own glyph bounds, the label is anchored to
+        // where the browser actually put it, so the two cannot drift apart.
+        if (this.hasDecoration(child)) {
+          flush()
+          this.emitTextGroup([child])
+          continue
+        }
         group.push(child)
       }
       else {
@@ -846,14 +896,37 @@ class SlideWalker {
     const containerStyle = container ? this.styleOf(container) : undefined
     const anchorStyle = containerStyle ?? this.inheritedStyle(textNodes[0])!
 
+    const glyphs = boundsOf(rects)
+    const lineCount = countLines(rects)
+
+    /**
+     * The box PowerPoint will wrap inside.
+     *
+     * Glyph bounds are the ink, not the wrap width, and for text that already
+     * wrapped they are the width of the LONGEST LINE. Handing PowerPoint that
+     * guarantees a second, tighter wrap: a caption reading "a short caption"
+     * over two lines came back over three and overflowed its box.
+     *
+     * The browser wrapped against the container's content box, so that is the
+     * width to reproduce. Single-line text keeps its glyph bounds, which are
+     * exact and carry no wrapping risk.
+     */
+    let rect = glyphs
+    if (lineCount > 1 && container && containerStyle) {
+      const left = parseLength(containerStyle.paddingLeft)
+      const right = parseLength(containerStyle.paddingRight)
+      const width = container.rect.w - left - right
+      if (width > 0) {
+        rect = { x: container.rect.x + left, y: glyphs.y, w: width, h: glyphs.h }
+      }
+    }
+
     this.nodes.push({
       kind: 'text',
       sourceId: group[0].id,
-      // Glyph bounds, not the element box. Positioning from the element rect
-      // offsets the text by the container's padding and makes it re-wrap.
-      rect: boundsOf(rects),
-      elementRect: container?.rect ?? boundsOf(rects),
-      lineCount: countLines(rects),
+      rect,
+      elementRect: container?.rect ?? glyphs,
+      lineCount,
       align: alignOf(anchorStyle),
       lineHeight: resolveLineHeight(anchorStyle),
       runs,

--- a/packages/slidev/node/commands/pptx/normalize.ts
+++ b/packages/slidev/node/commands/pptx/normalize.ts
@@ -79,6 +79,14 @@ export interface RasterRequest {
   isolate: boolean
   /** Also hide its children, which is only safe when they are redrawn. */
   hideDescendants: boolean
+  /**
+   * The element to isolate against, when it is not the captured node itself.
+   *
+   * A pseudo-element has no DOM node and so no id attribute to find, but its
+   * originating element does, and hiding that element's siblings is what keeps
+   * the surrounding slide out of the clip.
+   */
+  isolateId?: number
 }
 
 export interface NormalizeOptions {
@@ -89,20 +97,22 @@ export interface NormalizeOptions {
 export interface NormalizeResult {
   slides: SlideIr[]
   rasterRequests: RasterRequest[]
+  /** Colour strings no parser understood, so the caller can report them. */
+  unparsedColors: string[]
 }
 
 // ---------------------------------------------------------------------------
 // Value parsing
 // ---------------------------------------------------------------------------
 
-/** Colour strings we could not read, so the caller can say so once. */
-const unparsedColors = new Set<string>()
-
-export function takeUnparsedColors(): string[] {
-  const seen = [...unparsedColors]
-  unparsedColors.clear()
-  return seen
-}
+/**
+ * Colour strings no parser understood, for the current `normalize()` call.
+ *
+ * Reset at the start of every run rather than drained by the caller: drained
+ * state leaks into the next export whenever the current one throws before the
+ * caller gets to it, and this module claims to be pure.
+ */
+let unparsedColors = new Set<string>()
 
 function numbers(body: string): number[] {
   return body.split(/[\s,/]+/).filter(Boolean).map((token) => {
@@ -283,20 +293,20 @@ function isVisible(color: Rgba | undefined): boolean {
 }
 
 /**
- * Fold an element's `opacity` into a colour's own alpha.
+ * Fold an element's effective opacity into a colour's own alpha.
  *
- * DrawingML has no element-level opacity, only per-fill alpha, so an
- * `opacity: 0.5` overlay exported fully opaque and hid whatever sat behind it.
- * Inherited opacity is not compounded: the walker records each element's own
- * computed value, and CSS opacity on an ancestor already applies to the group.
+ * DrawingML has no element-level opacity and no group opacity, only per-fill
+ * alpha, so an `opacity: 0.5` overlay exported fully opaque and hid whatever
+ * sat behind it. The value is compounded down the tree by the walker, because
+ * CSS `opacity` does not inherit: a child of a half-transparent wrapper
+ * computes 1 and would otherwise export at full strength.
  */
-function withOpacity(color: Rgba | undefined, opacity: string | undefined): Rgba | undefined {
+function withOpacity(color: Rgba | undefined, opacity: number | undefined): Rgba | undefined {
   if (!color)
     return undefined
-  const factor = opacity === undefined || opacity === '' ? 1 : Number(opacity)
-  if (!Number.isFinite(factor) || factor >= 1)
+  if (opacity === undefined || !Number.isFinite(opacity) || opacity >= 1)
     return color
-  return { ...color, a: color.a * Math.max(0, factor) }
+  return { ...color, a: color.a * Math.max(0, opacity) }
 }
 
 function borderOf(style: RawStyle, side: 'Top' | 'Right' | 'Bottom' | 'Left'): Border | undefined {
@@ -406,12 +416,47 @@ function alignOf(style: RawStyle | undefined): IrText['align'] {
   }
 }
 
-function runFrom(text: string, style: RawStyle, fontResolution: Record<string, string>, link?: string): IrRun {
+/**
+ * CSS keywords rather than typefaces. Naming one asks PowerPoint for a font
+ * that exists nowhere, so it substitutes its own default silently.
+ *
+ * The walker already skips these when probing, but when NOTHING in a stack
+ * resolves it reports an empty string, and falling back to the head of the
+ * stack put `system-ui` straight back into the file.
+ */
+const GENERIC_FAMILIES = new Set([
+  'system-ui',
+  'ui-sans-serif',
+  'ui-serif',
+  'ui-monospace',
+  'ui-rounded',
+  'sans-serif',
+  'serif',
+  'monospace',
+  'cursive',
+  'fantasy',
+  'math',
+  'emoji',
+  'fangsong',
+  'inherit',
+  'initial',
+  'unset',
+])
+
+export function fallbackFamily(stack: string): string {
+  for (const raw of stack.split(',')) {
+    const family = raw.trim().replace(/^["']|["']$/g, '').replace(/\s+Variable$/, '')
+    if (!family || family.startsWith('-') || GENERIC_FAMILIES.has(family.toLowerCase()))
+      continue
+    return family
+  }
+  return 'Arial'
+}
+
+function runFrom(text: string, style: RawStyle, fontResolution: Record<string, string>, link?: string, opacity?: number): IrRun {
   const weight = Number(style.fontWeight)
   const decoration = style.textDecorationLine || ''
-  const family = fontResolution[style.fontFamily]
-    || style.fontFamily.split(',')[0].trim().replace(/^["']|["']$/g, '').replace(/\s+Variable$/, '')
-    || 'Arial'
+  const family = fontResolution[style.fontFamily] || fallbackFamily(style.fontFamily)
   const run: IrRun = {
     text: applyTransform(text, style.textTransform),
     fontSize: parseLength(style.fontSize),
@@ -425,7 +470,7 @@ function runFrom(text: string, style: RawStyle, fontResolution: Record<string, s
     run.underline = true
   if (decoration.includes('line-through'))
     run.strike = true
-  const color = withOpacity(parseColor(style.color), style.opacity)
+  const color = withOpacity(parseColor(style.color), opacity)
   if (isVisible(color))
     run.color = color
   const spacing = parseLength(style.letterSpacing)
@@ -506,6 +551,9 @@ class SlideWalker {
   private requests: RasterRequest[] = []
   private rasterArea = 0
   private pageRects = new Map<number, Rect | undefined>()
+  private boxed = new Set<number>()
+  /** Pseudo-element id to the id of the element it belongs to. */
+  private originators = new Map<number, number>()
   private size: { w: number, h: number }
 
   constructor(
@@ -557,7 +605,7 @@ class SlideWalker {
     const style = this.styleOf(node)
     if (!style)
       return false
-    if (isVisible(withOpacity(parseColor(style.backgroundColor), style.opacity)))
+    if (isVisible(withOpacity(parseColor(style.backgroundColor), node.opacity)))
       return true
     return (['Top', 'Right', 'Bottom', 'Left'] as const).some(side => borderOf(style, side))
   }
@@ -604,6 +652,7 @@ class SlideWalker {
         isolate: node.isolate,
         hideDescendants: node.hideDescendants,
         clip: this.pageRects.get(node.sourceId),
+        isolateId: this.originators.get(node.sourceId),
       })
 
       /**
@@ -626,6 +675,8 @@ class SlideWalker {
 
   private emitRaster(node: RawNode, reason: RasterReason): void {
     this.pageRects.set(node.id, node.pageRect)
+    if (node.tag === '::BEFORE' || node.tag === '::AFTER')
+      this.originators.set(node.id, node.parent)
     const isolate = needsIsolation(reason)
     const visible = clipToSlide(node.rect, this.size)
     if (!visible)
@@ -667,7 +718,14 @@ class SlideWalker {
   }
 
   private emitBox(node: RawNode, style: RawStyle): void {
-    const fill = withOpacity(parseColor(style.backgroundColor), style.opacity)
+    // `emitTextGroup` paints every group node and descendant before the text,
+    // and a layout container inside that subtree is then handed to `visit`,
+    // which paints it again. Two opaque fills only waste a shape; two
+    // translucent ones composite and come out visibly darker.
+    if (this.boxed.has(node.id))
+      return
+    this.boxed.add(node.id)
+    const fill = withOpacity(parseColor(style.backgroundColor), node.opacity)
     const borders: [Border?, Border?, Border?, Border?] = [
       borderOf(style, 'Top'),
       borderOf(style, 'Right'),
@@ -742,6 +800,12 @@ class SlideWalker {
       // on top of the isolated picture.
       if (!needsIsolation(reason))
         return
+      // But NOT its own box. The screenshot already contains this element's
+      // background and borders, so drawing them again paints an opaque fill
+      // straight over the picture that was taken to preserve the image, and
+      // composites a translucent one twice.
+      this.visitChildren(node)
+      return
     }
 
     if (style)
@@ -812,7 +876,14 @@ class SlideWalker {
         //
         // Given its own box at its own glyph bounds, the label is anchored to
         // where the browser actually put it, so the two cannot drift apart.
-        if (this.hasDecoration(child)) {
+        //
+        // Only when it is the WHOLE of its container. Slidev styles inline
+        // `<code>` with a background, so an unconditional split cut ordinary
+        // sentences into three boxes and forced the code span to centre; when
+        // such a sentence wrapped, the two halves both laid out from the
+        // container's left edge and overlapped. A chip is a label on its own,
+        // not a word in the middle of a line.
+        if (this.hasDecoration(child) && children.length === 1) {
           flush()
           this.emitTextGroup([child])
           continue
@@ -892,23 +963,59 @@ class SlideWalker {
 
     const runs: IrRun[] = []
     const rects: Rect[] = []
-    let breakPending = false
+
+    /**
+     * Line breaks waiting to be attached to the next run.
+     *
+     * A count, not a flag. `softBreakBefore` is one break per run, so two
+     * consecutive `<br>` need an empty run between them or the blank line
+     * disappears. Held against the NEXT run rather than the previous one, so a
+     * trailing break does not add an empty line at the end of the box.
+     */
+    let pendingBreaks = 0
+
+    const push = (text: string, style: RawStyle, node: RawNode) => {
+      // One empty run per surplus break, so the blank lines survive.
+      while (pendingBreaks > 1 && runs.length) {
+        runs.push({ ...runFrom('', style, this.fontResolution, undefined, node.opacity), breakBefore: true })
+        pendingBreaks--
+      }
+      const run = runFrom(text, style, this.fontResolution, this.linkFor(node), node.opacity)
+      if (pendingBreaks && runs.length)
+        run.breakBefore = true
+      pendingBreaks = 0
+      runs.push(run)
+    }
+
     for (const textNode of textNodes) {
       if (textNode.tag === 'BR') {
-        // Recorded against the NEXT run rather than the previous one, because
-        // a trailing <br> should not add an empty line at the end of the box.
-        if (runs.length)
-          breakPending = true
+        pendingBreaks++
         continue
       }
       const style = this.inheritedStyle(textNode)
       if (!style)
         continue
-      const text = style.whiteSpace.startsWith('pre')
-        ? textNode.text ?? ''
-        : (textNode.text ?? '').replace(/\s+/g, ' ')
-      if (!text)
+      const raw = textNode.text ?? ''
+      if (!raw)
         continue
+
+      // `white-space: pre` keeps its newlines, and they are the ONLY record of
+      // where one line of a code block ends. Shiki renders each line as an
+      // inline span separated by a "\n" text node, so folding those into
+      // spaces joins the whole block into one re-wrapped paragraph.
+      if (style.whiteSpace.startsWith('pre')) {
+        const lines = raw.split('\n')
+        lines.forEach((line, index) => {
+          if (index > 0)
+            pendingBreaks++
+          if (line)
+            push(line, style, textNode)
+        })
+        rects.push(...(textNode.glyphRects ?? []))
+        continue
+      }
+
+      const text = raw.replace(/\s+/g, ' ')
       if (!text.trim()) {
         // A whitespace-only node is the space between two inline elements.
         // Dropping it exports `<span>Hello</span> <span>World</span>` as
@@ -918,12 +1025,7 @@ class SlideWalker {
           runs[runs.length - 1].text += ' '
         continue
       }
-      const run = runFrom(text, style, this.fontResolution, this.linkFor(textNode))
-      if (breakPending) {
-        run.breakBefore = true
-        breakPending = false
-      }
-      runs.push(run)
+      push(text, style, textNode)
       rects.push(...(textNode.glyphRects ?? [textNode.rect]))
     }
     if (!runs.length || !rects.length)
@@ -976,6 +1078,13 @@ class SlideWalker {
       }
     }
 
+    // Clipped like every other emitted node. Text was the one kind that was
+    // not, so anything the browser clipped away landed off the PowerPoint
+    // canvas where it cannot be selected, and still counted toward the text
+    // total that suppresses the whole-slide fallback.
+    if (!clipToSlide(rect, this.size))
+      return
+
     this.nodes.push({
       kind: 'text',
       sourceId: group[0].id,
@@ -999,6 +1108,7 @@ class SlideWalker {
 }
 
 export function normalize(snapshot: RawSnapshot, options: NormalizeOptions): NormalizeResult {
+  unparsedColors = new Set()
   const slides: SlideIr[] = []
   const rasterRequests: RasterRequest[] = []
 
@@ -1041,5 +1151,5 @@ export function normalize(snapshot: RawSnapshot, options: NormalizeOptions): Nor
     slides.push(ir)
   }
 
-  return { slides, rasterRequests }
+  return { slides, rasterRequests, unparsedColors: [...unparsedColors].sort() }
 }

--- a/packages/slidev/node/commands/pptx/normalize.ts
+++ b/packages/slidev/node/commands/pptx/normalize.ts
@@ -856,8 +856,11 @@ class SlideWalker {
         elementRect: markerRect,
         lineCount: 1,
         align: 'left',
+        // Centred in the line box, which is where a browser puts a marker.
+        // Anchored to the top it rode above its own item's first line.
+        valign: 'middle',
         lineHeight: resolveLineHeight(style),
-        runs: [runFrom(node.marker, style, this.fontResolution)],
+        runs: [runFrom(node.marker, style, this.fontResolution, undefined, node.opacity)],
       })
     }
 

--- a/packages/slidev/node/commands/pptx/normalize.ts
+++ b/packages/slidev/node/commands/pptx/normalize.ts
@@ -693,18 +693,30 @@ class SlideWalker {
     const visible = clipToSlide(node.rect, this.size)
     if (!visible)
       return
+    // An element that runs past the slide is captured as a page clip rather
+    // than as itself, and placed at that same clipped rectangle so the picture
+    // is not squashed. Screenshotting such an element whole is not merely
+    // wasteful: Slidev's own starter deck carries one measuring tens of
+    // millions of pixels, and asking Chromium to rasterize it kills the
+    // renderer, which surfaces later as "Target page, context or browser has
+    // been closed".
+    const overflows = visible.w !== node.rect.w || visible.h !== node.rect.h
+    if (overflows && node.pageRect) {
+      this.pageRects.set(node.id, {
+        x: node.pageRect.x + (visible.x - node.rect.x),
+        y: node.pageRect.y + (visible.y - node.rect.y),
+        w: visible.w,
+        h: visible.h,
+      })
+    }
+
     this.nodes.push({
       kind: 'raster',
       sourceId: node.id,
       // Its children are walked and redrawn only when it is a backdrop, so
       // only then is it safe to hide them for the capture.
       hideDescendants: isolate,
-      // The element's FULL rect, not the clipped one. The screenshot is of the
-      // whole element, so drawing it into a smaller box squashes the picture
-      // and shows content that should have been cropped away. PowerPoint has
-      // no clipping, so the honest choice is to place it truthfully and let
-      // the overhang sit off-canvas, exactly as the browser clipped it.
-      rect: node.rect,
+      rect: overflows ? visible : node.rect,
       data: '',
       reason,
       isolate,

--- a/packages/slidev/node/commands/pptx/normalize.ts
+++ b/packages/slidev/node/commands/pptx/normalize.ts
@@ -564,6 +564,8 @@ class SlideWalker {
   private rasterArea = 0
   private pageRects = new Map<number, Rect | undefined>()
   private boxed = new Set<number>()
+  /** Paint layer per emitted node, parallel to `nodes`. */
+  private layers: { tier: number, z: number }[] = []
   /** Pseudo-element id to the id of the element it belongs to. */
   private originators = new Map<number, number>()
   private size: { w: number, h: number }
@@ -580,6 +582,40 @@ class SlideWalker {
       siblings.push(node)
       this.children.set(node.parent, siblings)
     }
+  }
+
+  /**
+   * Where an element paints, rather than where it sits in the tree.
+   *
+   * CSS paints positioned elements ABOVE in-flow content whatever the document
+   * order says. A slide's page counter is the first child of its container and
+   * is `position: absolute`, so a full-bleed background further down the tree
+   * covered it completely when paint order was taken to be array order.
+   *
+   * Two tiers and a z-index is not the full stacking algorithm, which also has
+   * negative layers, stacking contexts and floats, but it covers what a slide
+   * deck actually does.
+   */
+  private layerOf(node: RawNode): { tier: number, z: number } {
+    // The NEAREST POSITIONED ANCESTOR, not the nearest styled one. A page
+    // counter is a positioned `<footer>` wrapping a plain `<div>`, and reading
+    // the div alone called the whole thing in-flow, so it kept painting
+    // underneath the background it is supposed to sit on.
+    let current: RawNode | undefined = node
+    while (current) {
+      const style = this.styleOf(current)
+      if (style && style.position !== 'static' && style.position !== '') {
+        const z = Number.parseInt(style.zIndex, 10)
+        return { tier: 1, z: Number.isNaN(z) ? 0 : z }
+      }
+      current = this.byId.get(current.parent)
+    }
+    return { tier: 0, z: 0 }
+  }
+
+  private push(node: IrNode, source: RawNode): void {
+    this.nodes.push(node)
+    this.layers.push(this.layerOf(source))
   }
 
   private styleOf(node: RawNode): RawStyle | undefined {
@@ -632,6 +668,15 @@ class SlideWalker {
   run(): { nodes: IrNode[], requests: RasterRequest[], rasterArea: number, textCount: number } {
     for (const root of this.childrenOf(-1))
       this.visit(root)
+
+    // Reordered into CSS paint order before anything reads the array, since
+    // everything downstream, including the overlap tests below and the
+    // builder, treats array order as paint order. A stable sort keeps document
+    // order within a layer, which is what CSS does too.
+    const order = this.nodes.map((node, index) => ({ node, index, layer: this.layers[index] }))
+    order.sort((a, b) =>
+      a.layer.tier - b.layer.tier || a.layer.z - b.layer.z || a.index - b.index)
+    this.nodes = order.map(entry => entry.node)
 
     const texts = this.nodes.filter(n => n.kind === 'text')
     // Pictures are drawn from their own screenshots, so a picture overlapping
@@ -710,7 +755,7 @@ class SlideWalker {
       })
     }
 
-    this.nodes.push({
+    this.push({
       kind: 'raster',
       sourceId: node.id,
       // Its children are walked and redrawn only when it is a backdrop, so
@@ -720,7 +765,7 @@ class SlideWalker {
       data: '',
       reason,
       isolate,
-    })
+    }, node)
   }
 
   private emitImage(node: RawNode): void {
@@ -731,14 +776,14 @@ class SlideWalker {
     const rect = clipToSlide(node.rect, this.size)
     if (!rect)
       return
-    this.nodes.push({
+    this.push({
       kind: 'image',
       sourceId: node.id,
       rect,
       data: node.src,
       alt: node.alt,
       link: this.linkFor(node),
-    })
+    }, node)
   }
 
   private emitBox(node: RawNode, style: RawStyle): void {
@@ -776,7 +821,7 @@ class SlideWalker {
     const shadow = parseShadow(style.boxShadow)
     if (shadow)
       box.shadow = shadow
-    this.nodes.push(box)
+    this.push(box, node)
   }
 
   private visit(node: RawNode): void {
@@ -793,7 +838,7 @@ class SlideWalker {
       }
       this.emitBox(node, style)
       if (node.text) {
-        this.nodes.push({
+        this.push({
           kind: 'text',
           sourceId: node.id,
           rect: node.rect,
@@ -803,7 +848,7 @@ class SlideWalker {
           valign: 'middle',
           lineHeight: resolveLineHeight(style),
           runs: [runFrom(node.text, style, this.fontResolution)],
-        })
+        }, node)
       }
       return
     }
@@ -849,7 +894,7 @@ class SlideWalker {
         w: parseLength(style.fontSize) * 1.2,
         h: resolveLineHeight(style),
       }
-      this.nodes.push({
+      this.push({
         kind: 'text',
         sourceId: node.id,
         rect: markerRect,
@@ -861,7 +906,7 @@ class SlideWalker {
         valign: 'middle',
         lineHeight: resolveLineHeight(style),
         runs: [runFrom(node.marker, style, this.fontResolution, undefined, node.opacity)],
-      })
+      }, node)
     }
 
     this.visitChildren(node)
@@ -1140,7 +1185,7 @@ class SlideWalker {
     if (!clipToSlide(rect, this.size))
       return
 
-    this.nodes.push({
+    this.push({
       kind: 'text',
       sourceId: group[0].id,
       rect,
@@ -1150,7 +1195,7 @@ class SlideWalker {
       valign,
       lineHeight: resolveLineHeight(anchorStyle),
       runs,
-    })
+    }, group[0])
   }
 
   private forEachDescendant(node: RawNode, fn: (node: RawNode) => void): void {

--- a/packages/slidev/node/commands/pptx/normalize.ts
+++ b/packages/slidev/node/commands/pptx/normalize.ts
@@ -143,10 +143,15 @@ export function rasterReasonFor(node: RawNode, style: RawStyle | undefined): Ras
     return tagReason
   if (!style)
     return undefined
-  if (style.backgroundImage && style.backgroundImage !== 'none')
-    return 'background-image'
+  // Before `background-image`, because gradient text is BOTH: a gradient
+  // clipped to the glyphs, with `color` left as a flat fallback. Reported as a
+  // background image it counts as a backdrop, so the text is drawn again over
+  // the picture, and the fallback color hides the gradient it was standing in
+  // for.
   if (style.webkitBackgroundClip === 'text')
     return 'background-clip-text'
+  if (style.backgroundImage && style.backgroundImage !== 'none')
+    return 'background-image'
   if (style.filter && style.filter !== 'none')
     return 'filter'
   if (style.backdropFilter && style.backdropFilter !== 'none')

--- a/packages/slidev/node/commands/pptx/normalize.ts
+++ b/packages/slidev/node/commands/pptx/normalize.ts
@@ -769,14 +769,15 @@ class SlideWalker {
     return { nodes: this.nodes, requests: this.requests, rasterArea: this.rasterArea, textCount: texts.length }
   }
 
-  private emitRaster(node: RawNode, reason: RasterReason): void {
+  /** Whether a picture was actually emitted for this element. */
+  private emitRaster(node: RawNode, reason: RasterReason): boolean {
     this.pageRects.set(node.id, node.pageRect)
     if (node.tag === '::BEFORE' || node.tag === '::AFTER')
       this.originators.set(node.id, node.parent)
     const isolate = needsIsolation(reason)
     const visible = clipToSlide(node.rect, this.size)
     if (!visible)
-      return
+      return false
     // An element that runs past the slide is captured as a page clip rather
     // than as itself, and placed at that same clipped rectangle so the picture
     // is not squashed. Screenshotting such an element whole is not merely
@@ -805,6 +806,7 @@ class SlideWalker {
       reason,
       isolate,
     }, node)
+    return true
   }
 
   private emitImage(node: RawNode): void {
@@ -878,10 +880,8 @@ class SlideWalker {
       if (!style)
         return
       const reason = rasterReasonFor(node, style)
-      if (reason) {
-        this.emitRaster(node, reason)
+      if (reason && this.emitRaster(node, reason))
         return
-      }
       this.emitBox(node, style)
       if (node.text) {
         this.push({
@@ -908,8 +908,12 @@ class SlideWalker {
 
     const style = this.styleOf(node)
     const reason = rasterReasonFor(node, style)
-    if (reason) {
-      this.emitRaster(node, reason)
+    // A raster that could not be placed leaves NOTHING behind, so treating the
+    // element as rasterized would silently drop its whole subtree. A theme
+    // rotating a decoration through a zero-sized wrapper does exactly that:
+    // the wrapper has no box of its own, while the absolutely positioned art
+    // inside it does, and the entire corner decoration vanished from the deck.
+    if (reason && this.emitRaster(node, reason)) {
       // A leaf such as an <svg> has no shapes worth recovering underneath it.
       // A backdrop does: its children are real content and are drawn as shapes
       // on top of the isolated picture.
@@ -1024,11 +1028,11 @@ class SlideWalker {
     }
     const style = this.styleOf(node)
     const reason = rasterReasonFor(node, style)
-    if (reason) {
-      // An inline <svg> icon inside a sentence still has to become a picture.
-      this.emitRaster(node, reason)
+    // An inline <svg> icon inside a sentence still has to become a picture,
+    // but only if it has a box to be a picture of. Otherwise its subtree is
+    // walked as usual rather than being dropped along with the raster.
+    if (reason && this.emitRaster(node, reason))
       return
-    }
     // A <br> has no text node of its own, so without this marker the text
     // either side of it is concatenated into consecutive runs with no break
     // and `line one<br>line two` exports as "line oneline two".

--- a/packages/slidev/node/commands/pptx/normalize.ts
+++ b/packages/slidev/node/commands/pptx/normalize.ts
@@ -805,8 +805,17 @@ function buildSlideIr(
       emitImage(node)
       return
     }
-    // A layout container nested inside an inline run still lays out boxes.
-    if (style && LAYOUT_DISPLAY.test(style.display)) {
+    // Anything that is not inline establishes its own box rather than flowing
+    // with the text around it, so it lays out on its own instead of being
+    // folded into this paragraph. Shiki's `<code>` is `display: inline` and
+    // TwoSlash renders a diagnostic as a `<div>` inside it, which ran the
+    // message onto the end of the code line: "= 2Cannot assign to 'value'".
+    //
+    // Not the same test as `visitChildren` makes. There `LAYOUT_DISPLAY` asks
+    // whether to stop grouping children, which a `table-cell` must not do.
+    // Here the question is only whether this subtree flows with its
+    // surroundings, and no non-inline box does.
+    if (style && !isInline(node)) {
       visit(node)
       return
     }

--- a/packages/slidev/node/commands/pptx/normalize.ts
+++ b/packages/slidev/node/commands/pptx/normalize.ts
@@ -912,7 +912,25 @@ class SlideWalker {
      * exact and carry no wrapping risk.
      */
     let rect = glyphs
-    if (lineCount > 1 && container && containerStyle) {
+    let align = alignOf(anchorStyle)
+    let valign: IrText['valign']
+
+    /**
+     * A chip label belongs to its chip, not to its own ink.
+     *
+     * Its background is an absolutely positioned shape, so pinning the text to
+     * the decoration's box and centring it there keeps the label evenly inset
+     * however the font measures. Positioning from the glyphs instead leaves
+     * the label hard against one edge as soon as PowerPoint sets the string
+     * even slightly wider than the browser did.
+     */
+    const decorated = group.length === 1 && group[0].tag !== '#text' && this.hasDecoration(group[0])
+    if (decorated) {
+      rect = group[0].rect
+      align = 'center'
+      valign = 'middle'
+    }
+    else if (lineCount > 1 && container && containerStyle) {
       const left = parseLength(containerStyle.paddingLeft)
       const right = parseLength(containerStyle.paddingRight)
       const width = container.rect.w - left - right
@@ -927,7 +945,8 @@ class SlideWalker {
       rect,
       elementRect: container?.rect ?? glyphs,
       lineCount,
-      align: alignOf(anchorStyle),
+      align,
+      valign,
       lineHeight: resolveLineHeight(anchorStyle),
       runs,
     })

--- a/packages/slidev/node/commands/pptx/normalize.ts
+++ b/packages/slidev/node/commands/pptx/normalize.ts
@@ -32,14 +32,29 @@ const RASTER_AREA_LIMIT = 0.6
  * sets the same string a little wider than Chromium, so a shrink-wrapped container
  * gains a wrap. The headroom scales with the line.
  */
+/**
+ * How much loose text a row of chips may hold and still be a row of chips.
+ *
+ * A separator between keys is punctuation; a sentence carrying inline `<code>`
+ * is words, and that stays one editable box.
+ */
+const SEPARATOR_MAX_CHARS = 3
+
 const WRAP_HEADROOM = 0.02
 const WRAP_HEADROOM_MIN_PX = 4
 
-/** CSS `display` values whose children are laid out, not flowed as text. Prefix match: `table` covers `table-row` and `table-cell`. */
-// `list-item` is deliberately absent: a list item flows its children as text,
-// and treating it as a layout container fragments `<li>plain <b>bold</b> tail</li>`
-// into separate boxes. Its ::marker is emitted before the children are visited.
-const LAYOUT_DISPLAY = /^(?:flex|grid|inline-flex|inline-grid|table)/
+/**
+ * CSS `display` values whose children are laid out, not flowed as text.
+ *
+ * `table-cell` and `table-caption` are excluded: a table lays out its rows and
+ * a row its cells, but the CONTENTS of a cell flow like any block, so treating
+ * one as a layout container split `<kbd>right</kbd> / <kbd>space</kbd>` into
+ * three boxes and left the slash sitting on the first key.
+ *
+ * `list-item` is absent for the same reason: it flows its children as text,
+ * and its ::marker is emitted before they are visited.
+ */
+const LAYOUT_DISPLAY = /^(?:flex|grid|inline-flex|inline-grid|table(?!-cell|-caption))/
 
 /**
  * `display` values whose box participates in a line box and whose children flow as
@@ -718,16 +733,43 @@ function buildSlideIr(
         group = []
       }
     }
+    // A chip is padded and spaced by its own box, which flowed text cannot
+    // reproduce: `<kbd>right</kbd> / <kbd>space</kbd>` set as one run drifts
+    // off keys that keep their measured gaps, and two adjacent chips run their
+    // labels together entirely. So each part of a row of chips is placed on
+    // its own glyph bounds instead.
+    //
+    // Only when the row occupies a single line. Fragments can be positioned
+    // exactly while they do not wrap; a wrapping sentence has to flow, or its
+    // halves lay out from the same origin and overlap. That is also what keeps
+    // an ordinary sentence carrying one inline `<code>` in one editable box.
+    // Glyph bounds for a text node: its element rect is not where its ink is.
+    const lineBox = (child: RawNode): Rect =>
+      child.glyphRects?.length ? boundsOf(child.glyphRects) : child.rect
+    const placed = children.filter(child => isInline(child) && lineBox(child).h > 0)
+    // By overlap, not by matching tops: a padded chip's box starts above the
+    // glyph bounds of the text beside it, so equal tops never held here.
+    const oneLine = placed.length > 1 && lineGroups(placed.map(lineBox)).length === 1
+    // Everything outside the chips. A separator is punctuation; a sentence is
+    // words, and a sentence stays one editable box even though its inline
+    // `<code>` drifts by the width of its own padding.
+    const loose = children
+      .filter(child => child.tag === '#text')
+      .map(child => (child.text ?? '').replace(/\s+/g, ''))
+      .join('')
+    const labelRow = oneLine && loose.length <= SEPARATOR_MAX_CHARS
+      && placed.some(child => hasDecoration(child))
+
     for (const child of children) {
       if (isInline(child)) {
         // An inline element carrying its own background or border is a chip: its
         // decoration is a positioned shape, so its label gets its own text box anchored
         // to the glyph bounds, keeping metric differences from sliding the label off
-        // the chip. Only when it is the whole of its container: Slidev styles inline
-        // `<code>` with a background, and an unconditional split overlaps a wrapped sentence.
-        if (hasDecoration(child) && children.length === 1) {
+        // the chip. Only when it stands alone: Slidev styles inline `<code>` with a
+        // background, and an unconditional split overlaps a wrapped sentence.
+        if (labelRow || (hasDecoration(child) && children.length === 1)) {
           flush()
-          emitTextGroup([child])
+          emitTextGroup([child], labelRow)
           continue
         }
         group.push(child)
@@ -807,7 +849,7 @@ function buildSlideIr(
     return undefined
   }
 
-  function emitTextGroup(group: RawNode[]): void {
+  function emitTextGroup(group: RawNode[], fragment = false): void {
     // Inline decorations first: paint order is array order, so a chip emitted
     // after its label would cover it.
     for (const node of group) {
@@ -899,14 +941,20 @@ function buildSlideIr(
     // Whitespace at line boundaries collapses in the browser but survives the
     // fold above and shifts a centered line by half a space. Every line
     // boundary counts, not just the box edges: a run after a break opens a new line.
-    runs.forEach((run, index) => {
-      const opensLine = index === 0 || run.breakBefore
-      const closesLine = index === runs.length - 1 || runs[index + 1]?.breakBefore
-      if (opensLine)
-        run.text = run.text.replace(/^ +/, '')
-      if (closesLine)
-        run.text = run.text.replace(/ +$/, '')
-    })
+    // Not for a fragment: its edges are mid-line, where the browser rendered
+    // the spaces and the glyph bounds include them. Trimming there drew the
+    // text where the leading space had been, putting a separator on the key
+    // beside it.
+    if (!fragment) {
+      runs.forEach((run, index) => {
+        const opensLine = index === 0 || run.breakBefore
+        const closesLine = index === runs.length - 1 || runs[index + 1]?.breakBefore
+        if (opensLine)
+          run.text = run.text.replace(/^ +/, '')
+        if (closesLine)
+          run.text = run.text.replace(/ +$/, '')
+      })
+    }
 
     const container = byId.get(group[0].parent)
     const containerStyle = container ? styleOf(container) : undefined

--- a/packages/slidev/node/commands/pptx/normalize.ts
+++ b/packages/slidev/node/commands/pptx/normalize.ts
@@ -512,17 +512,56 @@ function boundsOf(rects: Rect[]): Rect {
  * integers and report one line as two. That flips `wrap` in the builder, which
  * is the exact decision this number exists to make.
  */
-function countLines(rects: Rect[]): number {
-  const tops = rects.map(r => r.y).sort((a, b) => a - b)
-  let lines = 0
-  let last = Number.NEGATIVE_INFINITY
-  for (const top of tops) {
-    if (top - last > 2) {
-      lines++
-      last = top
+/**
+ * Group glyph rects into line boxes by vertical OVERLAP.
+ *
+ * Not by equal top: runs of different sizes on the SAME line have different
+ * tops, because a browser aligns them on the shared baseline. A heading
+ * reading `Needed a **Pros-Cons comparison** in now?` therefore counted four
+ * lines where it has two, and the line spacing derived from that count stacked
+ * its two real lines on top of each other.
+ *
+ * Two rects share a line when they overlap by more than half the shorter one,
+ * which distinguishes a small run sitting inside a large one from the couple
+ * of pixels of ink that adjacent lines can share when leading is tight.
+ */
+function lineGroups(rects: Rect[]): { top: number, bottom: number }[] {
+  const groups: { top: number, bottom: number }[] = []
+  for (const rect of [...rects].sort((a, b) => a.y - b.y)) {
+    const current = groups[groups.length - 1]
+    const overlap = current ? Math.min(current.bottom, rect.y + rect.h) - Math.max(current.top, rect.y) : 0
+    if (current && overlap > 0.5 * Math.min(rect.h, current.bottom - current.top)) {
+      current.bottom = Math.max(current.bottom, rect.y + rect.h)
+      current.top = Math.min(current.top, rect.y)
+    }
+    else {
+      groups.push({ top: rect.y, bottom: rect.y + rect.h })
     }
   }
-  return lines
+  return groups
+}
+
+function countLines(rects: Rect[]): number {
+  return lineGroups(rects).length
+}
+
+/**
+ * How far apart the browser actually set the lines, or undefined for one line.
+ *
+ * The computed `line-height` belongs to the element, while a line box is as
+ * tall as the largest run ON that line. Where those disagree, and they do
+ * whenever a heading mixes sizes, the computed value is far too small and
+ * PowerPoint sets the lines overlapping. The median keeps one unusually tall
+ * line, such as one carrying an inline image, from stretching the rest.
+ */
+export function measuredLineHeight(rects: Rect[]): number | undefined {
+  const groups = lineGroups(rects)
+  if (groups.length < 2)
+    return undefined
+  const gaps = groups.slice(1).map((group, index) => group.top - groups[index].top)
+  gaps.sort((a, b) => a - b)
+  const median = gaps[Math.floor(gaps.length / 2)]
+  return median > 0 ? median : undefined
 }
 
 /**
@@ -1193,7 +1232,7 @@ class SlideWalker {
       lineCount,
       align,
       valign,
-      lineHeight: resolveLineHeight(anchorStyle),
+      lineHeight: measuredLineHeight(rects) ?? resolveLineHeight(anchorStyle),
       runs,
     }, group[0])
   }

--- a/packages/slidev/node/commands/pptx/normalize.ts
+++ b/packages/slidev/node/commands/pptx/normalize.ts
@@ -69,6 +69,12 @@ const RASTER_TAGS: Record<string, RasterReason> = {
 export interface RasterRequest {
   /** The `data-slidev-export-id` of the element to capture. */
   sourceId: number
+  /**
+   * Page coordinates to clip instead of targeting a locator.
+   *
+   * Set for a pseudo-element, which has no element to select.
+   */
+  clip?: Rect
   /** Hide everything outside this element's own subtree. */
   isolate: boolean
   /** Also hide its children, which is only safe when they are redrawn. */
@@ -499,6 +505,7 @@ class SlideWalker {
   private nodes: IrNode[] = []
   private requests: RasterRequest[] = []
   private rasterArea = 0
+  private pageRects = new Map<number, Rect | undefined>()
   private size: { w: number, h: number }
 
   constructor(
@@ -596,6 +603,7 @@ class SlideWalker {
         sourceId: node.sourceId,
         isolate: node.isolate,
         hideDescendants: node.hideDescendants,
+        clip: this.pageRects.get(node.sourceId),
       })
 
       /**
@@ -617,6 +625,7 @@ class SlideWalker {
   }
 
   private emitRaster(node: RawNode, reason: RasterReason): void {
+    this.pageRects.set(node.id, node.pageRect)
     const isolate = needsIsolation(reason)
     const visible = clipToSlide(node.rect, this.size)
     if (!visible)
@@ -689,6 +698,34 @@ class SlideWalker {
   }
 
   private visit(node: RawNode): void {
+    // A pseudo-element paints either an image or a short string. It has no
+    // children and never contains anything else.
+    if (node.tag === '::BEFORE' || node.tag === '::AFTER') {
+      const style = this.styleOf(node)
+      if (!style)
+        return
+      const reason = rasterReasonFor(node, style)
+      if (reason) {
+        this.emitRaster(node, reason)
+        return
+      }
+      this.emitBox(node, style)
+      if (node.text) {
+        this.nodes.push({
+          kind: 'text',
+          sourceId: node.id,
+          rect: node.rect,
+          elementRect: node.rect,
+          lineCount: 1,
+          align: alignOf(style),
+          valign: 'middle',
+          lineHeight: resolveLineHeight(style),
+          runs: [runFrom(node.text, style, this.fontResolution)],
+        })
+      }
+      return
+    }
+
     if (node.tag === '#text') {
       // Reached only when a text node has no block container of its own, which
       // `visitChildren` already handles. Guarded so a stray one is not lost.

--- a/packages/slidev/node/commands/pptx/normalize.ts
+++ b/packages/slidev/node/commands/pptx/normalize.ts
@@ -1,0 +1,892 @@
+import type {
+  Border,
+  IrBox,
+  IrNode,
+  IrRun,
+  IrText,
+  RasterReason,
+  RawNode,
+  RawSlide,
+  RawSnapshot,
+  RawStyle,
+  Rect,
+  Rgba,
+  SlideIr,
+} from './ir'
+
+/**
+ * `RawSnapshot` to `SlideIr`: every judgement in the exporter, in one pure
+ * module.
+ *
+ * Nothing here touches the DOM or Playwright, so each rule is testable by
+ * writing a fixture by hand. That is the entire reason the walker was kept
+ * dumb: the interesting decisions are the ones that get them wrong, and a
+ * decision made inside `page.evaluate` cannot be tested at all.
+ *
+ * Where a rule below looks over-specific, it is because it is a bug that
+ * already happened. See the named cases in `normalize.test.ts`.
+ */
+
+/**
+ * Fraction of the slide that may be rasterized before vectorizing is judged
+ * pointless and the whole slide falls back to a picture.
+ *
+ * Past this point the file is mostly images anyway, and a half-vector slide is
+ * worse than an honest one: it invites editing that will not work.
+ */
+const RASTER_AREA_LIMIT = 0.6
+
+/** CSS `display` values whose children are laid out, not flowed as text. */
+// Prefix match, so `table` already covers `table-row` and `table-cell`.
+//
+// `list-item` is deliberately ABSENT. A list item flows its children as text
+// like any block, and treating it as a layout container fragmented
+// `<li>plain <b>bold</b> tail</li>` into four separate boxes, which is the
+// trap-7 bug on the commonest slide content there is. Its ::marker is emitted
+// before the children are visited, so it needs no help from this list.
+const LAYOUT_DISPLAY = /^(?:flex|grid|inline-flex|inline-grid|table)/
+
+/**
+ * CSS `display` values whose box participates in a line box AND whose children
+ * flow as text.
+ *
+ * `inline-flex`, `inline-grid` and `inline-table` are excluded on purpose.
+ * They are inline-LEVEL, so a naive `^inline` match calls them inline and the
+ * text walk descends through them, concatenating their cells: the exact
+ * "Left cellRight cell" bug that LAYOUT_DISPLAY exists to prevent, one
+ * display value over. Badges and stat rows are commonly built this way.
+ */
+const INLINE_DISPLAY = /^(?:inline(?:-block)?$|contents|ruby)/
+
+const RASTER_TAGS: Record<string, RasterReason> = {
+  SVG: 'svg',
+  CANVAS: 'canvas',
+  VIDEO: 'media',
+  AUDIO: 'media',
+  IFRAME: 'iframe',
+}
+
+export interface RasterRequest {
+  /** The `data-slidev-export-id` of the element to capture. */
+  sourceId: number
+  isolate: boolean
+}
+
+export interface NormalizeOptions {
+  /** Note text per 1-based slide number. */
+  notes: Map<number, string | undefined>
+}
+
+export interface NormalizeResult {
+  slides: SlideIr[]
+  rasterRequests: RasterRequest[]
+}
+
+// ---------------------------------------------------------------------------
+// Value parsing
+// ---------------------------------------------------------------------------
+
+/** Colour strings we could not read, so the caller can say so once. */
+const unparsedColors = new Set<string>()
+
+export function takeUnparsedColors(): string[] {
+  const seen = [...unparsedColors]
+  unparsedColors.clear()
+  return seen
+}
+
+function numbers(body: string): number[] {
+  return body.split(/[\s,/]+/).filter(Boolean).map((token) => {
+    const n = Number.parseFloat(token)
+    return token.endsWith('%') ? n / 100 : n
+  })
+}
+
+function srgbChannel(v: number): number {
+  // The sRGB transfer function, for converting linear light back to 0-255.
+  const c = v <= 0.0031308 ? v * 12.92 : 1.055 * v ** (1 / 2.4) - 0.055
+  return Math.max(0, Math.min(255, Math.round(c * 255)))
+}
+
+/** Oklab to sRGB, per the CSS Color 4 conversion. */
+function oklabToRgb(L: number, a: number, b: number): [number, number, number] {
+  const l = (L + 0.3963377774 * a + 0.2158037573 * b) ** 3
+  const m = (L - 0.1055613458 * a - 0.0638541728 * b) ** 3
+  const s = (L - 0.0894841775 * a - 1.2914855480 * b) ** 3
+  return [
+    srgbChannel(4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s),
+    srgbChannel(-1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s),
+    srgbChannel(-0.0041960863 * l - 0.7034186147 * m + 1.7076147010 * s),
+  ]
+}
+
+function hueToRgb(h: number, s: number, l: number): [number, number, number] {
+  const c = (1 - Math.abs(2 * l - 1)) * s
+  const hp = (((h % 360) + 360) % 360) / 60
+  const x = c * (1 - Math.abs((hp % 2) - 1))
+  const [r, g, b]
+    = hp < 1
+      ? [c, x, 0]
+      : hp < 2
+        ? [x, c, 0]
+        : hp < 3
+          ? [0, c, x]
+          : hp < 4
+            ? [0, x, c]
+            : hp < 5
+              ? [x, 0, c]
+              : [c, 0, x]
+  const m = l - c / 2
+  const to255 = (v: number) => Math.max(0, Math.min(255, Math.round((v + m) * 255)))
+  return [to255(r), to255(g), to255(b)]
+}
+
+/**
+ * A computed CSS colour, in any syntax Chromium actually serializes.
+ *
+ * `rgb()` covers Slidev's own UnoCSS output, but a theme authored in modern
+ * syntax keeps `oklch()`, `color()` or `hsl()` in the computed value, and
+ * returning undefined for those silently drops every fill, border and text
+ * colour on the slide with nothing in the log to explain it.
+ */
+export function parseColor(value: string | undefined): Rgba | undefined {
+  if (!value)
+    return undefined
+  const text = value.trim()
+  if (text === 'transparent')
+    return { r: 0, g: 0, b: 0, a: 0 }
+
+  const fn = text.match(/^([a-z-]+)\(([^)]+)\)$/i)
+  if (!fn) {
+    unparsedColors.add(text)
+    return undefined
+  }
+  const name = fn[1].toLowerCase()
+
+  if (name === 'color') {
+    // Handled before the numeric guard: the first token is a colour space
+    // name, so parsing the whole body as numbers yields NaN and would reject
+    // every `color()` value outright.
+    const tokens = fn[2].trim().split(/[\s,/]+/).filter(Boolean)
+    const channels = numbers(tokens.slice(1).join(' '))
+    if (tokens[0] === 'srgb' && channels.length >= 3 && !channels.slice(0, 3).some(Number.isNaN)) {
+      return {
+        r: Math.round(channels[0] * 255),
+        g: Math.round(channels[1] * 255),
+        b: Math.round(channels[2] * 255),
+        a: channels.length > 3 && !Number.isNaN(channels[3]) ? channels[3] : 1,
+      }
+    }
+    unparsedColors.add(text)
+    return undefined
+  }
+
+  const parts = numbers(fn[2])
+  if (parts.some(Number.isNaN)) {
+    unparsedColors.add(text)
+    return undefined
+  }
+  const alpha = (index: number) => (parts.length > index ? parts[index] : 1)
+
+  if (name === 'rgb' || name === 'rgba') {
+    if (parts.length < 3)
+      return undefined
+    // Percentage channels were divided by 100 above, so scale them back.
+    const channel = (v: number, raw: string) => (raw.includes('%') ? v * 255 : v)
+    const raw = fn[2].split(/[\s,/]+/).filter(Boolean)
+    return {
+      r: channel(parts[0], raw[0] ?? ''),
+      g: channel(parts[1], raw[1] ?? ''),
+      b: channel(parts[2], raw[2] ?? ''),
+      a: alpha(3),
+    }
+  }
+
+  if (name === 'hsl' || name === 'hsla') {
+    if (parts.length < 3)
+      return undefined
+    const [r, g, b] = hueToRgb(parts[0], parts[1], parts[2])
+    return { r, g, b, a: alpha(3) }
+  }
+
+  if (name === 'oklch' || name === 'oklab') {
+    if (parts.length < 3)
+      return undefined
+    const L = parts[0]
+    const [a, b] = name === 'oklch'
+      ? [parts[1] * Math.cos((parts[2] * Math.PI) / 180), parts[1] * Math.sin((parts[2] * Math.PI) / 180)]
+      : [parts[1], parts[2]]
+    const [r, g, bb] = oklabToRgb(L, a, b)
+    return { r, g, b: bb, a: alpha(3) }
+  }
+
+  unparsedColors.add(text)
+  return undefined
+}
+
+/**
+ * A CSS length in pixels.
+ *
+ * `basis` resolves a percentage. Chromium keeps `border-radius` as a
+ * percentage in the computed value rather than resolving it, so a plain
+ * `parseFloat` turns `border-radius: 50%` on a 200px box into 50px instead of
+ * 100px, and the corners come out barely rounded.
+ */
+export function parseLength(value: string | undefined, basis?: number): number {
+  if (!value)
+    return 0
+  const n = Number.parseFloat(value)
+  if (Number.isNaN(n))
+    return 0
+  if (value.trim().endsWith('%'))
+    return basis === undefined ? 0 : (n / 100) * basis
+  return n
+}
+
+/**
+ * The part of `rect` that is actually on the slide, or undefined if none is.
+ *
+ * A slide container is `overflow: hidden`, so anything outside it is invisible
+ * to the audience. PowerPoint has no clipping: an unclamped shape stays on the
+ * canvas, off the edge, where it is both wrong and impossible to select.
+ *
+ * This also keeps the tier-4 area accounting sane. Slidev's own starter deck
+ * has an element whose rect runs to tens of millions of pixels, which reported
+ * a slide as "104064986954% rasterized" before the clamp existed.
+ */
+export function clipToSlide(rect: Rect, size: { w: number, h: number }): Rect | undefined {
+  const x = Math.max(rect.x, 0)
+  const y = Math.max(rect.y, 0)
+  const right = Math.min(rect.x + rect.w, size.w)
+  const bottom = Math.min(rect.y + rect.h, size.h)
+  if (right <= x || bottom <= y)
+    return undefined
+  return { x, y, w: right - x, h: bottom - y }
+}
+
+function isVisible(color: Rgba | undefined): boolean {
+  return !!color && color.a > 0
+}
+
+/**
+ * Fold an element's `opacity` into a colour's own alpha.
+ *
+ * DrawingML has no element-level opacity, only per-fill alpha, so an
+ * `opacity: 0.5` overlay exported fully opaque and hid whatever sat behind it.
+ * Inherited opacity is not compounded: the walker records each element's own
+ * computed value, and CSS opacity on an ancestor already applies to the group.
+ */
+function withOpacity(color: Rgba | undefined, opacity: string | undefined): Rgba | undefined {
+  if (!color)
+    return undefined
+  const factor = opacity === undefined || opacity === '' ? 1 : Number(opacity)
+  if (!Number.isFinite(factor) || factor >= 1)
+    return color
+  return { ...color, a: color.a * Math.max(0, factor) }
+}
+
+function borderOf(style: RawStyle, side: 'Top' | 'Right' | 'Bottom' | 'Left'): Border | undefined {
+  const width = parseLength((style as any)[`border${side}Width`])
+  const lineStyle = (style as any)[`border${side}Style`] as string
+  const color = parseColor((style as any)[`border${side}Color`])
+  if (width <= 0 || !lineStyle || lineStyle === 'none' || lineStyle === 'hidden' || !isVisible(color))
+    return undefined
+  return {
+    width,
+    color: color!,
+    style: lineStyle === 'dashed' ? 'dashed' : lineStyle === 'dotted' ? 'dotted' : 'solid',
+  }
+}
+
+/**
+ * Why this element cannot be drawn as shapes, or undefined if it can.
+ *
+ * Everything listed here is something DrawingML has no primitive for. The
+ * honest move is one picture of that element at its exact box, rather than an
+ * approximation that looks nearly right and cannot be edited back.
+ */
+export function rasterReasonFor(node: RawNode, style: RawStyle | undefined): RasterReason | undefined {
+  // Checked BEFORE the tag map, which would otherwise report a mermaid diagram
+  // as a plain 'svg'. Both rasterize, but the reason reaches the log and the
+  // picture's alt text, and "its labels are foreignObject HTML" is the useful
+  // diagnosis for something that looks like vector art and is not.
+  if (node.hasForeignObject)
+    return 'foreign-object'
+  const tagReason = RASTER_TAGS[node.tag]
+  if (tagReason)
+    return tagReason
+  if (!style)
+    return undefined
+  if (style.backgroundImage && style.backgroundImage !== 'none')
+    return 'background-image'
+  if (style.webkitBackgroundClip === 'text')
+    return 'background-clip-text'
+  if (style.filter && style.filter !== 'none')
+    return 'filter'
+  if (style.backdropFilter && style.backdropFilter !== 'none')
+    return 'backdrop-filter'
+  if (style.mixBlendMode && style.mixBlendMode !== 'normal')
+    return 'mix-blend-mode'
+  if (style.clipPath && style.clipPath !== 'none')
+    return 'clip-path'
+  if (style.transform && style.transform !== 'none')
+    return 'transform'
+  if (style.writingMode && style.writingMode !== 'horizontal-tb')
+    return 'writing-mode'
+  return undefined
+}
+
+/**
+ * Whether a rasterized element needs its siblings hidden during capture.
+ *
+ * A backdrop has content painted on top of it. `locator.screenshot()` clips
+ * the page to the element's box rather than isolating the element, so without
+ * hiding siblings the content bakes into the backdrop picture AND is drawn
+ * again as shapes, doubling every word on the slide.
+ *
+ * A leaf such as an `<svg>` or an `<iframe>` has nothing on top of it, so
+ * isolating it would only cost a DOM mutation.
+ */
+function needsIsolation(reason: RasterReason): boolean {
+  return reason === 'background-image'
+    || reason === 'backdrop-filter'
+    || reason === 'filter'
+    || reason === 'mix-blend-mode'
+}
+
+// ---------------------------------------------------------------------------
+// Text
+// ---------------------------------------------------------------------------
+
+function applyTransform(text: string, transform: string | undefined): string {
+  switch (transform) {
+    case 'uppercase':
+      return text.toUpperCase()
+    case 'lowercase':
+      return text.toLowerCase()
+    case 'capitalize':
+      return text.replace(/\b\p{L}/gu, c => c.toUpperCase())
+    default:
+      return text
+  }
+}
+
+function resolveLineHeight(style: RawStyle): number {
+  const fontSize = parseLength(style.fontSize)
+  if (!style.lineHeight || style.lineHeight === 'normal')
+    return fontSize * 1.2
+  return parseLength(style.lineHeight) || fontSize * 1.2
+}
+
+function alignOf(style: RawStyle | undefined): IrText['align'] {
+  switch (style?.textAlign) {
+    case 'center':
+      return 'center'
+    case 'right':
+    case 'end':
+      return 'right'
+    case 'justify':
+      return 'justify'
+    default:
+      return 'left'
+  }
+}
+
+function runFrom(text: string, style: RawStyle, fontResolution: Record<string, string>, link?: string): IrRun {
+  const weight = Number(style.fontWeight)
+  const decoration = style.textDecorationLine || ''
+  const family = fontResolution[style.fontFamily]
+    || style.fontFamily.split(',')[0].trim().replace(/^["']|["']$/g, '').replace(/\s+Variable$/, '')
+    || 'Arial'
+  const run: IrRun = {
+    text: applyTransform(text, style.textTransform),
+    fontSize: parseLength(style.fontSize),
+    fontFamily: family,
+  }
+  if (weight >= 600)
+    run.bold = true
+  if (style.fontStyle === 'italic' || style.fontStyle === 'oblique')
+    run.italic = true
+  if (decoration.includes('underline'))
+    run.underline = true
+  if (decoration.includes('line-through'))
+    run.strike = true
+  const color = withOpacity(parseColor(style.color), style.opacity)
+  if (isVisible(color))
+    run.color = color
+  const spacing = parseLength(style.letterSpacing)
+  if (spacing)
+    run.letterSpacing = spacing
+  if (link)
+    run.link = link
+  return run
+}
+
+function boundsOf(rects: Rect[]): Rect {
+  const x = Math.min(...rects.map(r => r.x))
+  const y = Math.min(...rects.map(r => r.y))
+  return {
+    x,
+    y,
+    w: Math.max(...rects.map(r => r.x + r.w)) - x,
+    h: Math.max(...rects.map(r => r.y + r.h)) - y,
+  }
+}
+
+/**
+ * Distinct line boxes, which is the only reliable line count available.
+ *
+ * Grouped with a tolerance rather than by rounding. Sub-pixel layout puts
+ * fragments of the same visual line at 10.4 and 10.6, which round to different
+ * integers and report one line as two. That flips `wrap` in the builder, which
+ * is the exact decision this number exists to make.
+ */
+function countLines(rects: Rect[]): number {
+  const tops = rects.map(r => r.y).sort((a, b) => a - b)
+  let lines = 0
+  let last = Number.NEGATIVE_INFINITY
+  for (const top of tops) {
+    if (top - last > 2) {
+      lines++
+      last = top
+    }
+  }
+  return lines
+}
+
+/**
+ * The first non-inset `box-shadow`, as PowerPoint's polar form.
+ *
+ * CSS gives an x/y offset; DrawingML wants an angle and a distance. Multiple
+ * shadows and inset shadows have no equivalent and are dropped.
+ */
+export function parseShadow(value: string | undefined): IrBox['shadow'] {
+  if (!value || value === 'none' || value.includes('inset'))
+    return undefined
+  // Any functional colour notation; `rgb()` is already covered by this.
+  const color = parseColor(value.match(/^[a-z-]+\([^)]+\)/i)?.[0])
+  if (!isVisible(color))
+    return undefined
+  const lengths = [...value.matchAll(/(-?[\d.]+)px/g)].map(m => Number(m[1]))
+  if (lengths.length < 2)
+    return undefined
+  const [x, y, blur = 0] = lengths
+  return {
+    blur,
+    offset: Math.round(Math.hypot(x, y) * 100) / 100,
+    // DrawingML measures clockwise from the positive x axis, like CSS's y-down
+    // coordinate space, so no sign flip is needed.
+    angle: Math.round(((Math.atan2(y, x) * 180) / Math.PI + 360) % 360),
+    color: color!,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The walk
+// ---------------------------------------------------------------------------
+
+class SlideWalker {
+  private byId = new Map<number, RawNode>()
+  private children = new Map<number, RawNode[]>()
+  private nodes: IrNode[] = []
+  private requests: RasterRequest[] = []
+  private rasterArea = 0
+  private size: { w: number, h: number }
+
+  constructor(
+    slide: RawSlide,
+    private styles: RawStyle[],
+    private fontResolution: Record<string, string>,
+  ) {
+    this.size = slide.size
+    for (const node of slide.nodes) {
+      this.byId.set(node.id, node)
+      const siblings = this.children.get(node.parent) ?? []
+      siblings.push(node)
+      this.children.set(node.parent, siblings)
+    }
+  }
+
+  private styleOf(node: RawNode): RawStyle | undefined {
+    return node.style >= 0 ? this.styles[node.style] : undefined
+  }
+
+  private childrenOf(id: number): RawNode[] {
+    return this.children.get(id) ?? []
+  }
+
+  /** The nearest ancestor element's style, which is what styles a text node. */
+  private inheritedStyle(node: RawNode): RawStyle | undefined {
+    let current: RawNode | undefined = node
+    while (current) {
+      const style = this.styleOf(current)
+      if (style)
+        return style
+      current = this.byId.get(current.parent)
+    }
+    return undefined
+  }
+
+  private linkFor(node: RawNode): string | undefined {
+    let current: RawNode | undefined = node
+    while (current) {
+      if (current.href)
+        return current.href
+      current = this.byId.get(current.parent)
+    }
+    return undefined
+  }
+
+  private isInline(node: RawNode): boolean {
+    if (node.tag === '#text')
+      return true
+    const style = this.styleOf(node)
+    return !!style && INLINE_DISPLAY.test(style.display)
+  }
+
+  run(): { nodes: IrNode[], requests: RasterRequest[], rasterArea: number, textCount: number } {
+    for (const root of this.childrenOf(-1))
+      this.visit(root)
+    const textCount = this.nodes.filter(n => n.kind === 'text').length
+    return { nodes: this.nodes, requests: this.requests, rasterArea: this.rasterArea, textCount }
+  }
+
+  private emitRaster(node: RawNode, reason: RasterReason): void {
+    const isolate = needsIsolation(reason)
+    const visible = clipToSlide(node.rect, this.size)
+    if (!visible)
+      return
+    this.nodes.push({
+      kind: 'raster',
+      sourceId: node.id,
+      // The element's FULL rect, not the clipped one. The screenshot is of the
+      // whole element, so drawing it into a smaller box squashes the picture
+      // and shows content that should have been cropped away. PowerPoint has
+      // no clipping, so the honest choice is to place it truthfully and let
+      // the overhang sit off-canvas, exactly as the browser clipped it.
+      rect: node.rect,
+      data: '',
+      reason,
+      isolate,
+    })
+    this.requests.push({ sourceId: node.id, isolate })
+    // An isolated backdrop does NOT count. It covers the slide by definition -
+    // a full-bleed cover photo is 100% of it - but the content painted on top
+    // is still walked and still becomes editable text. Counting it sent every
+    // deck with a cover image straight to the whole-slide fallback.
+    if (!isolate)
+      this.rasterArea += visible.w * visible.h
+  }
+
+  private emitImage(node: RawNode): void {
+    if (!node.src)
+      return
+    // Clipped like every other shape. This was the one emitter that skipped
+    // it, so a partly off-slide image landed outside the PowerPoint canvas.
+    const rect = clipToSlide(node.rect, this.size)
+    if (!rect)
+      return
+    this.nodes.push({
+      kind: 'image',
+      sourceId: node.id,
+      rect,
+      data: node.src,
+      alt: node.alt,
+      link: this.linkFor(node),
+    })
+  }
+
+  private emitBox(node: RawNode, style: RawStyle): void {
+    const fill = withOpacity(parseColor(style.backgroundColor), style.opacity)
+    const borders: [Border?, Border?, Border?, Border?] = [
+      borderOf(style, 'Top'),
+      borderOf(style, 'Right'),
+      borderOf(style, 'Bottom'),
+      borderOf(style, 'Left'),
+    ]
+    const hasBorder = borders.some(Boolean)
+    // Chromium keeps `border-radius` as a percentage in the computed value, so
+    // it needs a basis. Without one, `border-radius: 50%` on a 200px box came
+    // out as 50px rather than 100px and the corners were barely rounded.
+    const radius = parseLength(style.borderTopLeftRadius, Math.min(node.rect.w, node.rect.h))
+    if (!isVisible(fill) && !hasBorder)
+      return
+    const rect = clipToSlide(node.rect, this.size)
+    if (!rect)
+      return
+    const box: IrBox = { kind: 'box', sourceId: node.id, rect }
+    if (isVisible(fill))
+      box.fill = fill
+    if (hasBorder)
+      box.borders = borders
+    if (radius > 0)
+      box.radius = radius
+    const shadow = parseShadow(style.boxShadow)
+    if (shadow)
+      box.shadow = shadow
+    this.nodes.push(box)
+  }
+
+  private visit(node: RawNode): void {
+    if (node.tag === '#text') {
+      // Reached only when a text node has no block container of its own, which
+      // `visitChildren` already handles. Guarded so a stray one is not lost.
+      this.emitTextGroup([node])
+      return
+    }
+
+    const style = this.styleOf(node)
+    const reason = rasterReasonFor(node, style)
+    if (reason) {
+      this.emitRaster(node, reason)
+      // A leaf such as an <svg> has no shapes worth recovering underneath it.
+      // A backdrop does: its children are real content and are drawn as shapes
+      // on top of the isolated picture.
+      if (!needsIsolation(reason))
+        return
+    }
+
+    if (style)
+      this.emitBox(node, style)
+
+    if (node.tag === 'IMG') {
+      this.emitImage(node)
+      return
+    }
+
+    // A ::marker is a pseudo-element, so the bullet glyph has no text node and
+    // a plain walk drops every bullet in the deck.
+    if (node.marker && style) {
+      const markerRect: Rect = {
+        x: Math.max(0, node.rect.x - parseLength(style.fontSize) * 1.2),
+        y: node.rect.y,
+        w: parseLength(style.fontSize) * 1.2,
+        h: resolveLineHeight(style),
+      }
+      this.nodes.push({
+        kind: 'text',
+        sourceId: node.id,
+        rect: markerRect,
+        elementRect: markerRect,
+        lineCount: 1,
+        align: 'left',
+        lineHeight: resolveLineHeight(style),
+        runs: [runFrom(node.marker, style, this.fontResolution)],
+      })
+    }
+
+    this.visitChildren(node)
+  }
+
+  private visitChildren(node: RawNode): void {
+    const style = this.styleOf(node)
+    const children = this.childrenOf(node.id)
+    if (!children.length)
+      return
+
+    // A grid or flex container lays its children out as boxes, not as a line
+    // box. Grouping them as one run of text concatenates unrelated cells into
+    // strings like "Left cellRight cell".
+    if (style && LAYOUT_DISPLAY.test(style.display)) {
+      for (const child of children)
+        this.visit(child)
+      return
+    }
+
+    // Consecutive inline children form one anonymous block box, which is one
+    // text box. Treating each as its own shape makes a bold lead-in and the
+    // rest of its sentence lay out from the same origin, printing on top of
+    // each other.
+    let group: RawNode[] = []
+    const flush = () => {
+      if (group.length) {
+        this.emitTextGroup(group)
+        group = []
+      }
+    }
+    for (const child of children) {
+      if (this.isInline(child)) {
+        group.push(child)
+      }
+      else {
+        flush()
+        this.visit(child)
+      }
+    }
+    flush()
+  }
+
+  /** Every text node under an inline subtree, in document order. */
+  private collectText(node: RawNode, out: RawNode[]): void {
+    if (node.tag === '#text') {
+      out.push(node)
+      return
+    }
+    const style = this.styleOf(node)
+    const reason = rasterReasonFor(node, style)
+    if (reason) {
+      // An inline <svg> icon inside a sentence still has to become a picture.
+      this.emitRaster(node, reason)
+      return
+    }
+    // A <br> has no text node of its own, so without this marker the text
+    // either side of it is concatenated into consecutive runs with no break
+    // and `line one<br>line two` exports as "line oneline two".
+    if (node.tag === 'BR') {
+      out.push(node)
+      return
+    }
+    // An inline <img> reaches here rather than `visit`, and has no text under
+    // it, so it used to vanish from the slide entirely. Drawn at its measured
+    // box, which is where the browser put it.
+    if (node.tag === 'IMG') {
+      this.emitImage(node)
+      return
+    }
+    // Defensive: a layout container nested inside an inline run still lays its
+    // children out as boxes. Descending as text merges its cells.
+    if (style && LAYOUT_DISPLAY.test(style.display)) {
+      this.visit(node)
+      return
+    }
+    for (const child of this.childrenOf(node.id))
+      this.collectText(child, out)
+  }
+
+  private emitTextGroup(group: RawNode[]): void {
+    // Inline decorations first. A <span> with a coloured background behind
+    // white text has to be painted BEFORE the text, because paint order is
+    // array order; emitted after, the chip covers its own label.
+    for (const node of group) {
+      if (node.tag === '#text')
+        continue
+      // The group node ITSELF first, not only its descendants. The chip is
+      // usually the outermost inline element in the group, so walking only
+      // downwards from it missed the one background that mattered.
+      const own = this.styleOf(node)
+      if (own)
+        this.emitBox(node, own)
+      this.forEachDescendant(node, (descendant) => {
+        const style = this.styleOf(descendant)
+        if (style)
+          this.emitBox(descendant, style)
+      })
+    }
+
+    const textNodes: RawNode[] = []
+    for (const node of group)
+      this.collectText(node, textNodes)
+    if (!textNodes.length)
+      return
+
+    const runs: IrRun[] = []
+    const rects: Rect[] = []
+    let breakPending = false
+    for (const textNode of textNodes) {
+      if (textNode.tag === 'BR') {
+        // Recorded against the NEXT run rather than the previous one, because
+        // a trailing <br> should not add an empty line at the end of the box.
+        if (runs.length)
+          breakPending = true
+        continue
+      }
+      const style = this.inheritedStyle(textNode)
+      if (!style)
+        continue
+      const text = style.whiteSpace.startsWith('pre')
+        ? textNode.text ?? ''
+        : (textNode.text ?? '').replace(/\s+/g, ' ')
+      if (!text)
+        continue
+      if (!text.trim()) {
+        // A whitespace-only node is the space between two inline elements.
+        // Dropping it exports `<span>Hello</span> <span>World</span>` as
+        // "HelloWorld". Folded into the previous run so it does not become a
+        // run of its own with its own styling.
+        if (runs.length && !runs[runs.length - 1].text.endsWith(' '))
+          runs[runs.length - 1].text += ' '
+        continue
+      }
+      const run = runFrom(text, style, this.fontResolution, this.linkFor(textNode))
+      if (breakPending) {
+        run.breakBefore = true
+        breakPending = false
+      }
+      runs.push(run)
+      rects.push(...(textNode.glyphRects ?? [textNode.rect]))
+    }
+    if (!runs.length || !rects.length)
+      return
+
+    const container = this.byId.get(group[0].parent)
+    const containerStyle = container ? this.styleOf(container) : undefined
+    const anchorStyle = containerStyle ?? this.inheritedStyle(textNodes[0])!
+
+    this.nodes.push({
+      kind: 'text',
+      sourceId: group[0].id,
+      // Glyph bounds, not the element box. Positioning from the element rect
+      // offsets the text by the container's padding and makes it re-wrap.
+      rect: boundsOf(rects),
+      elementRect: container?.rect ?? boundsOf(rects),
+      lineCount: countLines(rects),
+      align: alignOf(anchorStyle),
+      lineHeight: resolveLineHeight(anchorStyle),
+      runs,
+    })
+  }
+
+  private forEachDescendant(node: RawNode, fn: (node: RawNode) => void): void {
+    for (const child of this.childrenOf(node.id)) {
+      if (child.tag !== '#text')
+        fn(child)
+      this.forEachDescendant(child, fn)
+    }
+  }
+}
+
+export function normalize(snapshot: RawSnapshot, options: NormalizeOptions): NormalizeResult {
+  const slides: SlideIr[] = []
+  const rasterRequests: RasterRequest[] = []
+
+  for (const raw of snapshot.slides) {
+    const walker = new SlideWalker(raw, snapshot.styles, snapshot.fontResolution)
+    const { nodes, requests, rasterArea, textCount } = walker.run()
+
+    const ir: SlideIr = {
+      no: raw.no,
+      clickIndex: raw.clickIndex,
+      containerId: raw.containerId,
+      size: raw.size,
+      // The slide's own background. Without it every slide exported onto
+      // PowerPoint's default white, so a dark theme came out as light text on
+      // a white page.
+      background: parseColor(raw.background),
+      nodes,
+      note: options.notes.get(raw.no),
+    }
+
+    const slideArea = raw.size.w * raw.size.h
+    const hasSourceText = raw.nodes.some(n => n.tag === '#text' && (n.text ?? '').trim())
+
+    // The safety valve. Both conditions describe a slide where vectorizing has
+    // produced something worse than the picture it replaced, and both degrade
+    // to exactly what `--format pptx` does today rather than to a broken file.
+    if (hasSourceText && textCount === 0) {
+      ir.fallbackReason = 'no text could be recovered from a slide that has text'
+    }
+    else if (slideArea > 0 && rasterArea / slideArea > RASTER_AREA_LIMIT) {
+      // Capped: rasters can overlap, so the raw sum can exceed the slide and a
+      // percentage over 100 reads as a bug rather than as a diagnosis.
+      const percent = Math.min(100, Math.round((rasterArea / slideArea) * 100))
+      ir.fallbackReason = `${percent}% of the slide had to be rasterized`
+    }
+
+    if (!ir.fallbackReason)
+      rasterRequests.push(...requests)
+
+    slides.push(ir)
+  }
+
+  return { slides, rasterRequests }
+}

--- a/packages/slidev/node/commands/pptx/normalize.ts
+++ b/packages/slidev/node/commands/pptx/normalize.ts
@@ -817,6 +817,11 @@ class SlideWalker {
     const rect = clipToSlide(node.rect, this.size)
     if (!rect)
       return
+    // Clipping the BOX alone squeezed the whole image into it. The slide
+    // container has `overflow: hidden`, so a browser shows the top of an
+    // oversized image and cuts the rest off; scaling it to fit instead came
+    // out vertically compressed and showed content the audience never saw.
+    const clipped = rect.w !== node.rect.w || rect.h !== node.rect.h
     this.push({
       kind: 'image',
       sourceId: node.id,
@@ -824,6 +829,16 @@ class SlideWalker {
       data: node.src,
       alt: node.alt,
       link: this.linkFor(node),
+      ...(clipped
+        ? {
+            crop: {
+              x: rect.x - node.rect.x,
+              y: rect.y - node.rect.y,
+              w: node.rect.w,
+              h: node.rect.h,
+            },
+          }
+        : {}),
     }, node)
   }
 

--- a/packages/slidev/node/commands/pptx/normalize.ts
+++ b/packages/slidev/node/commands/pptx/normalize.ts
@@ -246,7 +246,7 @@ export function fallbackFamily(stack: string): string {
   return 'Arial'
 }
 
-function runFrom(text: string, style: RawStyle, fontResolution: Record<string, string>, unparsed: UnparsedColors, link?: string, opacity?: number): IrRun {
+function runFrom(text: string, style: RawStyle, fontResolution: Record<string, string>, unparsed: UnparsedColors, link?: string, opacity?: number, rule?: IrRun['underlineStyle']): IrRun {
   const weight = Number(style.fontWeight)
   const decoration = style.textDecorationLine || ''
   const family = fontResolution[style.fontFamily] || fallbackFamily(style.fontFamily)
@@ -259,8 +259,16 @@ function runFrom(text: string, style: RawStyle, fontResolution: Record<string, s
     run.bold = true
   if (style.fontStyle === 'italic' || style.fontStyle === 'oblique')
     run.italic = true
-  if (decoration.includes('underline'))
+  if (decoration.includes('underline')) {
     run.underline = true
+  }
+  else if (rule) {
+    // An inline `border-bottom` IS an underline. Drawn as a separate line it
+    // has to be positioned against text PowerPoint may re-lay, and it cannot
+    // move when the text is edited, which is the whole point of this format.
+    run.underline = true
+    run.underlineStyle = rule
+  }
   if (decoration.includes('line-through'))
     run.strike = true
   const color = withOpacity(parseColor(style.color, unparsed), opacity)
@@ -764,6 +772,41 @@ function buildSlideIr(
       collectText(child, out)
   }
 
+  /**
+   * The underline an inline element draws with `border-bottom`, if that is all
+   * it draws. Slidev rules its links this way.
+   *
+   * Only when the bottom is the only border and there is no fill: anything
+   * more is a box, and a box has to stay a shape.
+   */
+  function underlineRule(node: RawNode): IrRun['underlineStyle'] | undefined {
+    const style = styleOf(node)
+    if (!style || !isInline(node))
+      return undefined
+    if (isVisible(parseColor(style.backgroundColor, unparsed)))
+      return undefined
+    const bottom = borderOf(style, 'Bottom', unparsed)
+    if (!bottom)
+      return undefined
+    for (const side of ['Top', 'Right', 'Left'] as const) {
+      if (borderOf(style, side, unparsed))
+        return undefined
+    }
+    return bottom.style === 'dashed' ? 'dash' : bottom.style === 'dotted' ? 'dotted' : 'sng'
+  }
+
+  /** The underline rule an ancestor of this text node draws, if any. */
+  function ruleOver(node: RawNode): IrRun['underlineStyle'] | undefined {
+    let current: RawNode | undefined = byId.get(node.parent)
+    while (current) {
+      const rule = underlineRule(current)
+      if (rule)
+        return rule
+      current = byId.get(current.parent)
+    }
+    return undefined
+  }
+
   function emitTextGroup(group: RawNode[]): void {
     // Inline decorations first: paint order is array order, so a chip emitted
     // after its label would cover it.
@@ -772,6 +815,9 @@ function buildSlideIr(
         continue
       // The group node itself too: the chip is usually the outermost inline element in the group.
       const own = styleOf(node)
+      // A node whose only decoration is an underline is drawn by the run.
+      if (underlineRule(node))
+        boxed.add(node.id)
       if (own)
         emitBox(node, own)
       forEachDescendant(node, (descendant) => {
@@ -802,7 +848,7 @@ function buildSlideIr(
         runs.push({ ...runFrom('', style, fontResolution, unparsed, undefined, node.opacity), breakBefore: true })
         pendingBreaks--
       }
-      const newRun = runFrom(text, style, fontResolution, unparsed, linkFor(node), node.opacity)
+      const newRun = runFrom(text, style, fontResolution, unparsed, linkFor(node), node.opacity, ruleOver(node))
       if (pendingBreaks && runs.length)
         newRun.breakBefore = true
       pendingBreaks = 0

--- a/packages/slidev/node/commands/pptx/normalize.ts
+++ b/packages/slidev/node/commands/pptx/normalize.ts
@@ -36,6 +36,18 @@ import type {
  */
 const RASTER_AREA_LIMIT = 0.6
 
+/**
+ * Fraction of a line's width kept free so PowerPoint does not re-wrap it.
+ *
+ * PowerPoint sets the same string a little wider than Chromium does. When a
+ * container shrink-wraps its text there is no room for that difference, so the
+ * longest line wraps and the block gains a line nobody asked for. The headroom
+ * has to scale with the line: a fixed couple of pixels is nothing on a 500px
+ * line of display type.
+ */
+const WRAP_HEADROOM = 0.02
+const WRAP_HEADROOM_MIN_PX = 4
+
 /** CSS `display` values whose children are laid out, not flowed as text. */
 // Prefix match, so `table` already covers `table-row` and `table-cell`.
 //
@@ -1031,6 +1043,20 @@ class SlideWalker {
     if (!runs.length || !rects.length)
       return
 
+    // Whitespace at the start and end of a LINE collapses away in the browser,
+    // but it survives `replace(/\s+/g, ' ')` and shifts a centred line
+    // sideways by half a space, because markup normally puts each sentence on
+    // its own source line. Every line boundary counts, not just the box edges:
+    // a run after a break opens a new line.
+    runs.forEach((run, index) => {
+      const opensLine = index === 0 || run.breakBefore
+      const closesLine = index === runs.length - 1 || runs[index + 1]?.breakBefore
+      if (opensLine)
+        run.text = run.text.replace(/^ +/, '')
+      if (closesLine)
+        run.text = run.text.replace(/ +$/, '')
+    })
+
     const container = this.byId.get(group[0].parent)
     const containerStyle = container ? this.styleOf(container) : undefined
     const anchorStyle = containerStyle ?? this.inheritedStyle(textNodes[0])!
@@ -1052,6 +1078,20 @@ class SlideWalker {
      */
     let rect = glyphs
     let align = alignOf(anchorStyle)
+
+    /** Widen a box that has no room for PowerPoint's wider metrics. */
+    const withHeadroom = (box: Rect): Rect => {
+      const headroom = box.w - glyphs.w
+      const wanted = Math.max(WRAP_HEADROOM_MIN_PX, glyphs.w * WRAP_HEADROOM)
+      if (headroom >= wanted)
+        return box
+      const extra = wanted - Math.max(0, headroom)
+      // Grown about the anchor, so the text does not slide sideways.
+      const x = align === 'center'
+        ? box.x - extra / 2
+        : align === 'right' ? box.x - extra : box.x
+      return { x, y: box.y, w: box.w + extra, h: box.h }
+    }
     let valign: IrText['valign']
 
     /**
@@ -1074,7 +1114,7 @@ class SlideWalker {
       const right = parseLength(containerStyle.paddingRight)
       const width = container.rect.w - left - right
       if (width > 0) {
-        rect = { x: container.rect.x + left, y: glyphs.y, w: width, h: glyphs.h }
+        rect = withHeadroom({ x: container.rect.x + left, y: glyphs.y, w: width, h: glyphs.h })
       }
     }
 

--- a/packages/slidev/node/commands/pptx/normalize.ts
+++ b/packages/slidev/node/commands/pptx/normalize.ts
@@ -118,13 +118,15 @@ export interface NormalizeResult {
 // ---------------------------------------------------------------------------
 
 /**
- * Colour strings no parser understood, for the current `normalize()` call.
+ * Somewhere to record a colour string no parser understood.
  *
- * Reset at the start of every run rather than drained by the caller: drained
- * state leaks into the next export whenever the current one throws before the
- * caller gets to it, and this module claims to be pure.
+ * Passed in rather than held in the module. As module state it was reset at
+ * the start of every run, which is correct for the export itself, but
+ * `parseColor` is exported and any call made outside a run accumulated into
+ * whatever export came next in the same process. A parameter costs one
+ * argument and makes the claim of purity at the top of this file true.
  */
-let unparsedColors = new Set<string>()
+export type UnparsedColors = Set<string> | undefined
 
 function numbers(body: string): number[] {
   return body.split(/[\s,/]+/).filter(Boolean).map((token) => {
@@ -180,7 +182,7 @@ function hueToRgb(h: number, s: number, l: number): [number, number, number] {
  * returning undefined for those silently drops every fill, border and text
  * colour on the slide with nothing in the log to explain it.
  */
-export function parseColor(value: string | undefined): Rgba | undefined {
+export function parseColor(value: string | undefined, unparsed?: UnparsedColors): Rgba | undefined {
   if (!value)
     return undefined
   const text = value.trim()
@@ -189,7 +191,7 @@ export function parseColor(value: string | undefined): Rgba | undefined {
 
   const fn = text.match(/^([a-z-]+)\(([^)]+)\)$/i)
   if (!fn) {
-    unparsedColors.add(text)
+    unparsed?.add(text)
     return undefined
   }
   const name = fn[1].toLowerCase()
@@ -208,13 +210,13 @@ export function parseColor(value: string | undefined): Rgba | undefined {
         a: channels.length > 3 && !Number.isNaN(channels[3]) ? channels[3] : 1,
       }
     }
-    unparsedColors.add(text)
+    unparsed?.add(text)
     return undefined
   }
 
   const parts = numbers(fn[2])
   if (parts.some(Number.isNaN)) {
-    unparsedColors.add(text)
+    unparsed?.add(text)
     return undefined
   }
   const alpha = (index: number) => (parts.length > index ? parts[index] : 1)
@@ -251,7 +253,7 @@ export function parseColor(value: string | undefined): Rgba | undefined {
     return { r, g, b: bb, a: alpha(3) }
   }
 
-  unparsedColors.add(text)
+  unparsed?.add(text)
   return undefined
 }
 
@@ -321,10 +323,10 @@ function withOpacity(color: Rgba | undefined, opacity: number | undefined): Rgba
   return { ...color, a: color.a * Math.max(0, opacity) }
 }
 
-function borderOf(style: RawStyle, side: 'Top' | 'Right' | 'Bottom' | 'Left'): Border | undefined {
+function borderOf(style: RawStyle, side: 'Top' | 'Right' | 'Bottom' | 'Left', unparsed: UnparsedColors): Border | undefined {
   const width = parseLength((style as any)[`border${side}Width`])
   const lineStyle = (style as any)[`border${side}Style`] as string
-  const color = parseColor((style as any)[`border${side}Color`])
+  const color = parseColor((style as any)[`border${side}Color`], unparsed)
   if (width <= 0 || !lineStyle || lineStyle === 'none' || lineStyle === 'hidden' || !isVisible(color))
     return undefined
   return {
@@ -470,7 +472,7 @@ export function fallbackFamily(stack: string): string {
   return 'Arial'
 }
 
-function runFrom(text: string, style: RawStyle, fontResolution: Record<string, string>, link?: string, opacity?: number): IrRun {
+function runFrom(text: string, style: RawStyle, fontResolution: Record<string, string>, unparsed: UnparsedColors, link?: string, opacity?: number): IrRun {
   const weight = Number(style.fontWeight)
   const decoration = style.textDecorationLine || ''
   const family = fontResolution[style.fontFamily] || fallbackFamily(style.fontFamily)
@@ -487,7 +489,7 @@ function runFrom(text: string, style: RawStyle, fontResolution: Record<string, s
     run.underline = true
   if (decoration.includes('line-through'))
     run.strike = true
-  const color = withOpacity(parseColor(style.color), opacity)
+  const color = withOpacity(parseColor(style.color, unparsed), opacity)
   if (isVisible(color))
     run.color = color
   const spacing = parseLength(style.letterSpacing)
@@ -575,11 +577,11 @@ export function measuredLineHeight(rects: Rect[]): number | undefined {
  * CSS gives an x/y offset; DrawingML wants an angle and a distance. Multiple
  * shadows and inset shadows have no equivalent and are dropped.
  */
-export function parseShadow(value: string | undefined): IrBox['shadow'] {
+export function parseShadow(value: string | undefined, unparsed?: UnparsedColors): IrBox['shadow'] {
   if (!value || value === 'none' || value.includes('inset'))
     return undefined
   // Any functional colour notation; `rgb()` is already covered by this.
-  const color = parseColor(value.match(/^[a-z-]+\([^)]+\)/i)?.[0])
+  const color = parseColor(value.match(/^[a-z-]+\([^)]+\)/i)?.[0], unparsed)
   if (!isVisible(color))
     return undefined
   const lengths = [...value.matchAll(/(-?[\d.]+)px/g)].map(m => Number(m[1]))
@@ -618,6 +620,7 @@ class SlideWalker {
     slide: RawSlide,
     private styles: RawStyle[],
     private fontResolution: Record<string, string>,
+    private unparsed: UnparsedColors,
   ) {
     this.size = slide.size
     for (const node of slide.nodes) {
@@ -697,9 +700,9 @@ class SlideWalker {
     const style = this.styleOf(node)
     if (!style)
       return false
-    if (isVisible(withOpacity(parseColor(style.backgroundColor), node.opacity)))
+    if (isVisible(withOpacity(parseColor(style.backgroundColor, this.unparsed), node.opacity)))
       return true
-    return (['Top', 'Right', 'Bottom', 'Left'] as const).some(side => borderOf(style, side))
+    return (['Top', 'Right', 'Bottom', 'Left'] as const).some(side => borderOf(style, side, this.unparsed))
   }
 
   private isInline(node: RawNode): boolean {
@@ -776,9 +779,17 @@ class SlideWalker {
 
   /** Whether a picture was actually emitted for this element. */
   private emitRaster(node: RawNode, reason: RasterReason): boolean {
-    this.pageRects.set(node.id, node.pageRect)
-    if (node.tag === '::BEFORE' || node.tag === '::AFTER')
+    // A pseudo-element has no DOM node to point a screenshot at, so it is the
+    // one thing that MUST be captured by clipping the page at coordinates
+    // measured here. Everything else has an id, and is better captured from
+    // its box read live at capture time, which cannot be stale.
+    //
+    // This used to be set for every element, which made the live path dead
+    // code and quietly contradicted the contract `RasterRequest.clip` states.
+    if (node.tag === '::BEFORE' || node.tag === '::AFTER') {
+      this.pageRects.set(node.id, node.pageRect)
       this.originators.set(node.id, node.parent)
+    }
     const isolate = needsIsolation(reason)
     const visible = clipToSlide(node.rect, this.size)
     if (!visible)
@@ -855,12 +866,12 @@ class SlideWalker {
     if (this.boxed.has(node.id))
       return
     this.boxed.add(node.id)
-    const fill = withOpacity(parseColor(style.backgroundColor), node.opacity)
+    const fill = withOpacity(parseColor(style.backgroundColor, this.unparsed), node.opacity)
     const borders: [Border?, Border?, Border?, Border?] = [
-      borderOf(style, 'Top'),
-      borderOf(style, 'Right'),
-      borderOf(style, 'Bottom'),
-      borderOf(style, 'Left'),
+      borderOf(style, 'Top', this.unparsed),
+      borderOf(style, 'Right', this.unparsed),
+      borderOf(style, 'Bottom', this.unparsed),
+      borderOf(style, 'Left', this.unparsed),
     ]
     const hasBorder = borders.some(Boolean)
     // Chromium keeps `border-radius` as a percentage in the computed value, so
@@ -869,7 +880,7 @@ class SlideWalker {
     const radius = parseLength(style.borderTopLeftRadius, Math.min(node.rect.w, node.rect.h))
     if (!isVisible(fill) && !hasBorder)
       return
-    const shadow = parseShadow(style.boxShadow)
+    const shadow = parseShadow(style.boxShadow, this.unparsed)
     // One shape per line fragment for a wrapped inline element, because that
     // is what a browser paints. Drawn as one rect over the union instead, an
     // inline `<code>` running across several lines filled the ragged space at
@@ -913,7 +924,7 @@ class SlideWalker {
           align: alignOf(style),
           valign: 'middle',
           lineHeight: resolveLineHeight(style),
-          runs: [runFrom(node.text, style, this.fontResolution)],
+          runs: [runFrom(node.text, style, this.fontResolution, this.unparsed)],
         }, node)
       }
       return
@@ -975,7 +986,7 @@ class SlideWalker {
         // Anchored to the top it rode above its own item's first line.
         valign: 'middle',
         lineHeight: resolveLineHeight(style),
-        runs: [runFrom(node.marker, style, this.fontResolution, undefined, node.opacity)],
+        runs: [runFrom(node.marker, style, this.fontResolution, this.unparsed, undefined, node.opacity)],
       }, node)
     }
 
@@ -1119,10 +1130,10 @@ class SlideWalker {
     const push = (text: string, style: RawStyle, node: RawNode) => {
       // One empty run per surplus break, so the blank lines survive.
       while (pendingBreaks > 1 && runs.length) {
-        runs.push({ ...runFrom('', style, this.fontResolution, undefined, node.opacity), breakBefore: true })
+        runs.push({ ...runFrom('', style, this.fontResolution, this.unparsed, undefined, node.opacity), breakBefore: true })
         pendingBreaks--
       }
-      const run = runFrom(text, style, this.fontResolution, this.linkFor(node), node.opacity)
+      const run = runFrom(text, style, this.fontResolution, this.unparsed, this.linkFor(node), node.opacity)
       if (pendingBreaks && runs.length)
         run.breakBefore = true
       pendingBreaks = 0
@@ -1278,12 +1289,12 @@ class SlideWalker {
 }
 
 export function normalize(snapshot: RawSnapshot, options: NormalizeOptions): NormalizeResult {
-  unparsedColors = new Set()
+  const unparsedColors = new Set<string>()
   const slides: SlideIr[] = []
   const rasterRequests: RasterRequest[] = []
 
   for (const raw of snapshot.slides) {
-    const walker = new SlideWalker(raw, snapshot.styles, snapshot.fontResolution)
+    const walker = new SlideWalker(raw, snapshot.styles, snapshot.fontResolution, unparsedColors)
     const { nodes, requests, rasterArea, textCount } = walker.run()
 
     const ir: SlideIr = {
@@ -1294,7 +1305,7 @@ export function normalize(snapshot: RawSnapshot, options: NormalizeOptions): Nor
       // The slide's own background. Without it every slide exported onto
       // PowerPoint's default white, so a dark theme came out as light text on
       // a white page.
-      background: parseColor(raw.background),
+      background: parseColor(raw.background, unparsedColors),
       nodes,
       note: options.notes.get(raw.no),
     }

--- a/packages/slidev/node/commands/pptx/normalize.ts
+++ b/packages/slidev/node/commands/pptx/normalize.ts
@@ -348,6 +348,11 @@ export function rasterReasonFor(node: RawNode, style: RawStyle | undefined): Ras
   // diagnosis for something that looks like vector art and is not.
   if (node.hasForeignObject)
     return 'foreign-object'
+  // Before the tag map too: a formula's root is a `<span>`, so nothing else
+  // here would catch it, and its parts are ordinary spans that walk as text
+  // perfectly well while meaning nothing apart.
+  if (node.isMath)
+    return 'math'
   const tagReason = RASTER_TAGS[node.tag]
   if (tagReason)
     return tagReason

--- a/packages/slidev/node/commands/pptx/normalize.ts
+++ b/packages/slidev/node/commands/pptx/normalize.ts
@@ -264,6 +264,11 @@ export function clipToSlide(rect: Rect, size: { w: number, h: number }): Rect | 
   return { x, y, w: right - x, h: bottom - y }
 }
 
+/** Whether two rects share any area at all. */
+function overlaps(a: Rect, b: Rect): boolean {
+  return a.x < b.x + b.w && b.x < a.x + a.w && a.y < b.y + b.h && b.y < a.y + a.h
+}
+
 function isVisible(color: Rgba | undefined): boolean {
   return !!color && color.a > 0
 }
@@ -547,8 +552,33 @@ class SlideWalker {
   run(): { nodes: IrNode[], requests: RasterRequest[], rasterArea: number, textCount: number } {
     for (const root of this.childrenOf(-1))
       this.visit(root)
-    const textCount = this.nodes.filter(n => n.kind === 'text').length
-    return { nodes: this.nodes, requests: this.requests, rasterArea: this.rasterArea, textCount }
+
+    const texts = this.nodes.filter(n => n.kind === 'text')
+
+    /**
+     * Raster area that bought us nothing.
+     *
+     * A picture with editable text drawn ON TOP of it is not wasted work: a
+     * full-bleed cover photo or a decorative background graphic covers the
+     * whole slide by definition, while the title over it vectorizes perfectly.
+     * Counting those sent every cover slide straight to the whole-slide
+     * fallback and threw away its text.
+     *
+     * So only a raster that nothing was recovered over counts against the
+     * budget. This generalises the rule that used to apply to isolated
+     * backdrops alone, which missed leaf pictures such as a full-bleed `<svg>`.
+     */
+    for (const node of this.nodes) {
+      if (node.kind !== 'raster')
+        continue
+      if (texts.some(text => overlaps(text.rect, node.rect)))
+        continue
+      const visible = clipToSlide(node.rect, this.size)
+      if (visible)
+        this.rasterArea += visible.w * visible.h
+    }
+
+    return { nodes: this.nodes, requests: this.requests, rasterArea: this.rasterArea, textCount: texts.length }
   }
 
   private emitRaster(node: RawNode, reason: RasterReason): void {
@@ -570,12 +600,6 @@ class SlideWalker {
       isolate,
     })
     this.requests.push({ sourceId: node.id, isolate })
-    // An isolated backdrop does NOT count. It covers the slide by definition -
-    // a full-bleed cover photo is 100% of it - but the content painted on top
-    // is still walked and still becomes editable text. Counting it sent every
-    // deck with a cover image straight to the whole-slide fallback.
-    if (!isolate)
-      this.rasterArea += visible.w * visible.h
   }
 
   private emitImage(node: RawNode): void {

--- a/packages/slidev/node/commands/pptx/normalize.ts
+++ b/packages/slidev/node/commands/pptx/normalize.ts
@@ -1,3 +1,4 @@
+import type { UnparsedColors } from './color'
 import type {
   Border,
   IrBox,
@@ -10,63 +11,40 @@ import type {
   RawSnapshot,
   RawStyle,
   Rect,
-  Rgba,
   SlideIr,
 } from './ir'
+import { isVisible, parseColor, withOpacity } from './color'
 
 /**
- * `RawSnapshot` to `SlideIr`: every judgement in the exporter, in one pure
- * module.
- *
- * Nothing here touches the DOM or Playwright, so each rule is testable by
- * writing a fixture by hand. That is the entire reason the walker was kept
- * dumb: the interesting decisions are the ones that get them wrong, and a
- * decision made inside `page.evaluate` cannot be tested at all.
- *
- * Where a rule below looks over-specific, it is because it is a bug that
- * already happened. See the named cases in `normalize.test.ts`.
+ * `RawSnapshot` to `SlideIr`: every judgement in the exporter, in one pure module with
+ * no DOM or Playwright access, so each rule is testable from a hand-written fixture.
+ * Where a rule looks over-specific, it is a bug that already happened; see `normalize.test.ts`.
  */
 
 /**
- * Fraction of the slide that may be rasterized before vectorizing is judged
- * pointless and the whole slide falls back to a picture.
- *
- * Past this point the file is mostly images anyway, and a half-vector slide is
- * worse than an honest one: it invites editing that will not work.
+ * Fraction of the slide that may be rasterized before the whole slide falls back to
+ * a picture: past this, a half-vector slide invites editing that will not work.
  */
 const RASTER_AREA_LIMIT = 0.6
 
 /**
- * Fraction of a line's width kept free so PowerPoint does not re-wrap it.
- *
- * PowerPoint sets the same string a little wider than Chromium does. When a
- * container shrink-wraps its text there is no room for that difference, so the
- * longest line wraps and the block gains a line nobody asked for. The headroom
- * has to scale with the line: a fixed couple of pixels is nothing on a 500px
- * line of display type.
+ * Fraction of a line's width kept free so PowerPoint does not re-wrap it: PowerPoint
+ * sets the same string a little wider than Chromium, so a shrink-wrapped container
+ * gains a wrap. The headroom scales with the line.
  */
 const WRAP_HEADROOM = 0.02
 const WRAP_HEADROOM_MIN_PX = 4
 
-/** CSS `display` values whose children are laid out, not flowed as text. */
-// Prefix match, so `table` already covers `table-row` and `table-cell`.
-//
-// `list-item` is deliberately ABSENT. A list item flows its children as text
-// like any block, and treating it as a layout container fragmented
-// `<li>plain <b>bold</b> tail</li>` into four separate boxes, which is the
-// trap-7 bug on the commonest slide content there is. Its ::marker is emitted
-// before the children are visited, so it needs no help from this list.
+/** CSS `display` values whose children are laid out, not flowed as text. Prefix match: `table` covers `table-row` and `table-cell`. */
+// `list-item` is deliberately absent: a list item flows its children as text,
+// and treating it as a layout container fragments `<li>plain <b>bold</b> tail</li>`
+// into separate boxes. Its ::marker is emitted before the children are visited.
 const LAYOUT_DISPLAY = /^(?:flex|grid|inline-flex|inline-grid|table)/
 
 /**
- * CSS `display` values whose box participates in a line box AND whose children
- * flow as text.
- *
- * `inline-flex`, `inline-grid` and `inline-table` are excluded on purpose.
- * They are inline-LEVEL, so a naive `^inline` match calls them inline and the
- * text walk descends through them, concatenating their cells: the exact
- * "Left cellRight cell" bug that LAYOUT_DISPLAY exists to prevent, one
- * display value over. Badges and stat rows are commonly built this way.
+ * `display` values whose box participates in a line box and whose children flow as
+ * text. `inline-flex`, `inline-grid` and `inline-table` are excluded on purpose: they
+ * lay their children out as boxes, so a naive `^inline` match would concatenate their cells.
  */
 const INLINE_DISPLAY = /^(?:inline(?:-block)?$|contents|ruby)/
 
@@ -81,23 +59,13 @@ const RASTER_TAGS: Record<string, RasterReason> = {
 export interface RasterRequest {
   /** The `data-slidev-export-id` of the element to capture. */
   sourceId: number
-  /**
-   * Page coordinates to clip instead of targeting a locator.
-   *
-   * Set for a pseudo-element, which has no element to select.
-   */
+  /** Page coordinates to clip, for a pseudo-element that has no element to select. */
   clip?: Rect
   /** Hide everything outside this element's own subtree. */
   isolate: boolean
   /** Also hide its children, which is only safe when they are redrawn. */
   hideDescendants: boolean
-  /**
-   * The element to isolate against, when it is not the captured node itself.
-   *
-   * A pseudo-element has no DOM node and so no id attribute to find, but its
-   * originating element does, and hiding that element's siblings is what keeps
-   * the surrounding slide out of the clip.
-   */
+  /** The element to isolate against for a pseudo-element, which has no id attribute of its own; its originating element does. */
   isolateId?: number
 }
 
@@ -109,162 +77,10 @@ export interface NormalizeOptions {
 export interface NormalizeResult {
   slides: SlideIr[]
   rasterRequests: RasterRequest[]
-  /** Colour strings no parser understood, so the caller can report them. */
+  /** Color strings no parser understood, so the caller can report them. */
   unparsedColors: string[]
 }
 
-// ---------------------------------------------------------------------------
-// Value parsing
-// ---------------------------------------------------------------------------
-
-/**
- * Somewhere to record a colour string no parser understood.
- *
- * Passed in rather than held in the module. As module state it was reset at
- * the start of every run, which is correct for the export itself, but
- * `parseColor` is exported and any call made outside a run accumulated into
- * whatever export came next in the same process. A parameter costs one
- * argument and makes the claim of purity at the top of this file true.
- */
-export type UnparsedColors = Set<string> | undefined
-
-function numbers(body: string): number[] {
-  return body.split(/[\s,/]+/).filter(Boolean).map((token) => {
-    const n = Number.parseFloat(token)
-    return token.endsWith('%') ? n / 100 : n
-  })
-}
-
-function srgbChannel(v: number): number {
-  // The sRGB transfer function, for converting linear light back to 0-255.
-  const c = v <= 0.0031308 ? v * 12.92 : 1.055 * v ** (1 / 2.4) - 0.055
-  return Math.max(0, Math.min(255, Math.round(c * 255)))
-}
-
-/** Oklab to sRGB, per the CSS Color 4 conversion. */
-function oklabToRgb(L: number, a: number, b: number): [number, number, number] {
-  const l = (L + 0.3963377774 * a + 0.2158037573 * b) ** 3
-  const m = (L - 0.1055613458 * a - 0.0638541728 * b) ** 3
-  const s = (L - 0.0894841775 * a - 1.2914855480 * b) ** 3
-  return [
-    srgbChannel(4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s),
-    srgbChannel(-1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s),
-    srgbChannel(-0.0041960863 * l - 0.7034186147 * m + 1.7076147010 * s),
-  ]
-}
-
-function hueToRgb(h: number, s: number, l: number): [number, number, number] {
-  const c = (1 - Math.abs(2 * l - 1)) * s
-  const hp = (((h % 360) + 360) % 360) / 60
-  const x = c * (1 - Math.abs((hp % 2) - 1))
-  const [r, g, b]
-    = hp < 1
-      ? [c, x, 0]
-      : hp < 2
-        ? [x, c, 0]
-        : hp < 3
-          ? [0, c, x]
-          : hp < 4
-            ? [0, x, c]
-            : hp < 5
-              ? [x, 0, c]
-              : [c, 0, x]
-  const m = l - c / 2
-  const to255 = (v: number) => Math.max(0, Math.min(255, Math.round((v + m) * 255)))
-  return [to255(r), to255(g), to255(b)]
-}
-
-/**
- * A computed CSS colour, in any syntax Chromium actually serializes.
- *
- * `rgb()` covers Slidev's own UnoCSS output, but a theme authored in modern
- * syntax keeps `oklch()`, `color()` or `hsl()` in the computed value, and
- * returning undefined for those silently drops every fill, border and text
- * colour on the slide with nothing in the log to explain it.
- */
-export function parseColor(value: string | undefined, unparsed?: UnparsedColors): Rgba | undefined {
-  if (!value)
-    return undefined
-  const text = value.trim()
-  if (text === 'transparent')
-    return { r: 0, g: 0, b: 0, a: 0 }
-
-  const fn = text.match(/^([a-z-]+)\(([^)]+)\)$/i)
-  if (!fn) {
-    unparsed?.add(text)
-    return undefined
-  }
-  const name = fn[1].toLowerCase()
-
-  if (name === 'color') {
-    // Handled before the numeric guard: the first token is a colour space
-    // name, so parsing the whole body as numbers yields NaN and would reject
-    // every `color()` value outright.
-    const tokens = fn[2].trim().split(/[\s,/]+/).filter(Boolean)
-    const channels = numbers(tokens.slice(1).join(' '))
-    if (tokens[0] === 'srgb' && channels.length >= 3 && !channels.slice(0, 3).some(Number.isNaN)) {
-      return {
-        r: Math.round(channels[0] * 255),
-        g: Math.round(channels[1] * 255),
-        b: Math.round(channels[2] * 255),
-        a: channels.length > 3 && !Number.isNaN(channels[3]) ? channels[3] : 1,
-      }
-    }
-    unparsed?.add(text)
-    return undefined
-  }
-
-  const parts = numbers(fn[2])
-  if (parts.some(Number.isNaN)) {
-    unparsed?.add(text)
-    return undefined
-  }
-  const alpha = (index: number) => (parts.length > index ? parts[index] : 1)
-
-  if (name === 'rgb' || name === 'rgba') {
-    if (parts.length < 3)
-      return undefined
-    // Percentage channels were divided by 100 above, so scale them back.
-    const channel = (v: number, raw: string) => (raw.includes('%') ? v * 255 : v)
-    const raw = fn[2].split(/[\s,/]+/).filter(Boolean)
-    return {
-      r: channel(parts[0], raw[0] ?? ''),
-      g: channel(parts[1], raw[1] ?? ''),
-      b: channel(parts[2], raw[2] ?? ''),
-      a: alpha(3),
-    }
-  }
-
-  if (name === 'hsl' || name === 'hsla') {
-    if (parts.length < 3)
-      return undefined
-    const [r, g, b] = hueToRgb(parts[0], parts[1], parts[2])
-    return { r, g, b, a: alpha(3) }
-  }
-
-  if (name === 'oklch' || name === 'oklab') {
-    if (parts.length < 3)
-      return undefined
-    const L = parts[0]
-    const [a, b] = name === 'oklch'
-      ? [parts[1] * Math.cos((parts[2] * Math.PI) / 180), parts[1] * Math.sin((parts[2] * Math.PI) / 180)]
-      : [parts[1], parts[2]]
-    const [r, g, bb] = oklabToRgb(L, a, b)
-    return { r, g, b: bb, a: alpha(3) }
-  }
-
-  unparsed?.add(text)
-  return undefined
-}
-
-/**
- * A CSS length in pixels.
- *
- * `basis` resolves a percentage. Chromium keeps `border-radius` as a
- * percentage in the computed value rather than resolving it, so a plain
- * `parseFloat` turns `border-radius: 50%` on a 200px box into 50px instead of
- * 100px, and the corners come out barely rounded.
- */
 export function parseLength(value: string | undefined, basis?: number): number {
   if (!value)
     return 0
@@ -277,15 +93,9 @@ export function parseLength(value: string | undefined, basis?: number): number {
 }
 
 /**
- * The part of `rect` that is actually on the slide, or undefined if none is.
- *
- * A slide container is `overflow: hidden`, so anything outside it is invisible
- * to the audience. PowerPoint has no clipping: an unclamped shape stays on the
- * canvas, off the edge, where it is both wrong and impossible to select.
- *
- * This also keeps the tier-4 area accounting sane. Slidev's own starter deck
- * has an element whose rect runs to tens of millions of pixels, which reported
- * a slide as "104064986954% rasterized" before the clamp existed.
+ * The part of `rect` on the slide, or undefined. Slides are `overflow: hidden`
+ * while PowerPoint has no clipping, so an unclamped shape stays on the canvas off
+ * the edge; a rect can also run to tens of millions of pixels.
  */
 export function clipToSlide(rect: Rect, size: { w: number, h: number }): Rect | undefined {
   const x = Math.max(rect.x, 0)
@@ -302,27 +112,6 @@ function overlaps(a: Rect, b: Rect): boolean {
   return a.x < b.x + b.w && b.x < a.x + a.w && a.y < b.y + b.h && b.y < a.y + a.h
 }
 
-function isVisible(color: Rgba | undefined): boolean {
-  return !!color && color.a > 0
-}
-
-/**
- * Fold an element's effective opacity into a colour's own alpha.
- *
- * DrawingML has no element-level opacity and no group opacity, only per-fill
- * alpha, so an `opacity: 0.5` overlay exported fully opaque and hid whatever
- * sat behind it. The value is compounded down the tree by the walker, because
- * CSS `opacity` does not inherit: a child of a half-transparent wrapper
- * computes 1 and would otherwise export at full strength.
- */
-function withOpacity(color: Rgba | undefined, opacity: number | undefined): Rgba | undefined {
-  if (!color)
-    return undefined
-  if (opacity === undefined || !Number.isFinite(opacity) || opacity >= 1)
-    return color
-  return { ...color, a: color.a * Math.max(0, opacity) }
-}
-
 function borderOf(style: RawStyle, side: 'Top' | 'Right' | 'Bottom' | 'Left', unparsed: UnparsedColors): Border | undefined {
   const width = parseLength((style as any)[`border${side}Width`])
   const lineStyle = (style as any)[`border${side}Style`] as string
@@ -337,22 +126,16 @@ function borderOf(style: RawStyle, side: 'Top' | 'Right' | 'Bottom' | 'Left', un
 }
 
 /**
- * Why this element cannot be drawn as shapes, or undefined if it can.
- *
- * Everything listed here is something DrawingML has no primitive for. The
- * honest move is one picture of that element at its exact box, rather than an
- * approximation that looks nearly right and cannot be edited back.
+ * Why this element cannot be drawn as shapes, or undefined if it can. Everything listed
+ * lacks a DrawingML primitive; the honest move is one picture at the exact box.
  */
 export function rasterReasonFor(node: RawNode, style: RawStyle | undefined): RasterReason | undefined {
-  // Checked BEFORE the tag map, which would otherwise report a mermaid diagram
-  // as a plain 'svg'. Both rasterize, but the reason reaches the log and the
-  // picture's alt text, and "its labels are foreignObject HTML" is the useful
-  // diagnosis for something that looks like vector art and is not.
+  // Before the tag map, which would report a Mermaid diagram as a plain 'svg';
+  // the reason reaches the log and the picture's alt text.
   if (node.hasForeignObject)
     return 'foreign-object'
-  // Before the tag map too: a formula's root is a `<span>`, so nothing else
-  // here would catch it, and its parts are ordinary spans that walk as text
-  // perfectly well while meaning nothing apart.
+  // Also before the tag map: a formula's root is a `<span>`, so nothing else
+  // here would catch it.
   if (node.isMath)
     return 'math'
   const tagReason = RASTER_TAGS[node.tag]
@@ -380,15 +163,9 @@ export function rasterReasonFor(node: RawNode, style: RawStyle | undefined): Ras
 }
 
 /**
- * Whether a rasterized element needs its siblings hidden during capture.
- *
- * A backdrop has content painted on top of it. `locator.screenshot()` clips
- * the page to the element's box rather than isolating the element, so without
- * hiding siblings the content bakes into the backdrop picture AND is drawn
- * again as shapes, doubling every word on the slide.
- *
- * A leaf such as an `<svg>` or an `<iframe>` has nothing on top of it, so
- * isolating it would only cost a DOM mutation.
+ * Whether a rasterized element needs its siblings hidden during capture: a backdrop has
+ * content painted on top of it, which would bake into the picture and be drawn again as
+ * shapes. A leaf such as an `<svg>` has nothing on top.
  */
 function needsIsolation(reason: RasterReason): boolean {
   return reason === 'background-image'
@@ -396,10 +173,6 @@ function needsIsolation(reason: RasterReason): boolean {
     || reason === 'filter'
     || reason === 'mix-blend-mode'
 }
-
-// ---------------------------------------------------------------------------
-// Text
-// ---------------------------------------------------------------------------
 
 function applyTransform(text: string, transform: string | undefined): string {
   switch (transform) {
@@ -436,12 +209,8 @@ function alignOf(style: RawStyle | undefined): IrText['align'] {
 }
 
 /**
- * CSS keywords rather than typefaces. Naming one asks PowerPoint for a font
- * that exists nowhere, so it substitutes its own default silently.
- *
- * The walker already skips these when probing, but when NOTHING in a stack
- * resolves it reports an empty string, and falling back to the head of the
- * stack put `system-ui` straight back into the file.
+ * CSS keywords rather than typefaces; naming one in the file makes PowerPoint
+ * substitute its default silently, so the fallback must skip these as well.
  */
 const GENERIC_FAMILIES = new Set([
   'system-ui',
@@ -512,25 +281,9 @@ function boundsOf(rects: Rect[]): Rect {
 }
 
 /**
- * Distinct line boxes, which is the only reliable line count available.
- *
- * Grouped with a tolerance rather than by rounding. Sub-pixel layout puts
- * fragments of the same visual line at 10.4 and 10.6, which round to different
- * integers and report one line as two. That flips `wrap` in the builder, which
- * is the exact decision this number exists to make.
- */
-/**
- * Group glyph rects into line boxes by vertical OVERLAP.
- *
- * Not by equal top: runs of different sizes on the SAME line have different
- * tops, because a browser aligns them on the shared baseline. A heading
- * reading `Needed a **Pros-Cons comparison** in now?` therefore counted four
- * lines where it has two, and the line spacing derived from that count stacked
- * its two real lines on top of each other.
- *
- * Two rects share a line when they overlap by more than half the shorter one,
- * which distinguishes a small run sitting inside a large one from the couple
- * of pixels of ink that adjacent lines can share when leading is tight.
+ * Group glyph rects into line boxes by vertical overlap, not by equal top: runs of
+ * different sizes on the same line align on the baseline, so their tops differ, and
+ * sub-pixel layout defeats rounding. A shared line overlaps by more than half the shorter rect.
  */
 function lineGroups(rects: Rect[]): { top: number, bottom: number }[] {
   const groups: { top: number, bottom: number }[] = []
@@ -553,13 +306,9 @@ function countLines(rects: Rect[]): number {
 }
 
 /**
- * How far apart the browser actually set the lines, or undefined for one line.
- *
- * The computed `line-height` belongs to the element, while a line box is as
- * tall as the largest run ON that line. Where those disagree, and they do
- * whenever a heading mixes sizes, the computed value is far too small and
- * PowerPoint sets the lines overlapping. The median keeps one unusually tall
- * line, such as one carrying an inline image, from stretching the rest.
+ * How far apart the browser actually set the lines, or undefined for one line. The computed
+ * `line-height` is too small whenever a heading mixes sizes; the median keeps one
+ * unusually tall line from stretching the rest.
  */
 export function measuredLineHeight(rects: Rect[]): number | undefined {
   const groups = lineGroups(rects)
@@ -572,15 +321,13 @@ export function measuredLineHeight(rects: Rect[]): number | undefined {
 }
 
 /**
- * The first non-inset `box-shadow`, as PowerPoint's polar form.
- *
- * CSS gives an x/y offset; DrawingML wants an angle and a distance. Multiple
- * shadows and inset shadows have no equivalent and are dropped.
+ * The first non-inset `box-shadow`, as PowerPoint's polar form: an angle and a
+ * distance. Multiple shadows and inset shadows have no equivalent and are dropped.
  */
 export function parseShadow(value: string | undefined, unparsed?: UnparsedColors): IrBox['shadow'] {
   if (!value || value === 'none' || value.includes('inset'))
     return undefined
-  // Any functional colour notation; `rgb()` is already covered by this.
+  // Any functional color notation; `rgb()` included.
   const color = parseColor(value.match(/^[a-z-]+\([^)]+\)/i)?.[0], unparsed)
   if (!isVisible(color))
     return undefined
@@ -591,219 +338,177 @@ export function parseShadow(value: string | undefined, unparsed?: UnparsedColors
   return {
     blur,
     offset: Math.round(Math.hypot(x, y) * 100) / 100,
-    // DrawingML measures clockwise from the positive x axis, like CSS's y-down
-    // coordinate space, so no sign flip is needed.
+    // DrawingML measures clockwise from the positive x axis, like CSS's y-down space; no sign flip.
     angle: Math.round(((Math.atan2(y, x) * 180) / Math.PI + 360) % 360),
     color: color!,
   }
 }
 
-// ---------------------------------------------------------------------------
-// The walk
-// ---------------------------------------------------------------------------
-
-class SlideWalker {
-  private byId = new Map<number, RawNode>()
-  private children = new Map<number, RawNode[]>()
-  private nodes: IrNode[] = []
-  private requests: RasterRequest[] = []
-  private rasterArea = 0
-  private pageRects = new Map<number, Rect | undefined>()
-  private boxed = new Set<number>()
+/** One slide's `RawNode` tree to its `IrNode` list. Every helper below closes over the per-slide index and accumulators. */
+function buildSlideIr(
+  slide: RawSlide,
+  styles: RawStyle[],
+  fontResolution: Record<string, string>,
+  unparsed: UnparsedColors,
+): { nodes: IrNode[], requests: RasterRequest[], rasterArea: number, textCount: number } {
+  const byId = new Map<number, RawNode>()
+  const childIndex = new Map<number, RawNode[]>()
+  let nodes: IrNode[] = []
+  const requests: RasterRequest[] = []
+  let rasterArea = 0
+  const pageRects = new Map<number, Rect | undefined>()
+  const boxed = new Set<number>()
   /** Paint layer per emitted node, parallel to `nodes`. */
-  private layers: { tier: number, z: number }[] = []
+  const layers: { tier: number, z: number }[] = []
   /** Pseudo-element id to the id of the element it belongs to. */
-  private originators = new Map<number, number>()
-  private size: { w: number, h: number }
+  const originators = new Map<number, number>()
+  const size = slide.size
 
-  constructor(
-    slide: RawSlide,
-    private styles: RawStyle[],
-    private fontResolution: Record<string, string>,
-    private unparsed: UnparsedColors,
-  ) {
-    this.size = slide.size
-    for (const node of slide.nodes) {
-      this.byId.set(node.id, node)
-      const siblings = this.children.get(node.parent) ?? []
-      siblings.push(node)
-      this.children.set(node.parent, siblings)
-    }
+  for (const node of slide.nodes) {
+    byId.set(node.id, node)
+    const siblings = childIndex.get(node.parent) ?? []
+    siblings.push(node)
+    childIndex.set(node.parent, siblings)
   }
 
   /**
-   * Where an element paints, rather than where it sits in the tree.
-   *
-   * CSS paints positioned elements ABOVE in-flow content whatever the document
-   * order says. A slide's page counter is the first child of its container and
-   * is `position: absolute`, so a full-bleed background further down the tree
-   * covered it completely when paint order was taken to be array order.
-   *
-   * Two tiers and a z-index is not the full stacking algorithm, which also has
-   * negative layers, stacking contexts and floats, but it covers what a slide
-   * deck actually does.
+   * Where an element paints: CSS puts positioned elements above in-flow content
+   * whatever the document order says. Two tiers and a z-index cover what a slide deck actually does.
    */
-  private layerOf(node: RawNode): { tier: number, z: number } {
-    // The NEAREST POSITIONED ANCESTOR, not the nearest styled one. A page
-    // counter is a positioned `<footer>` wrapping a plain `<div>`, and reading
-    // the div alone called the whole thing in-flow, so it kept painting
-    // underneath the background it is supposed to sit on.
+  function layerOf(node: RawNode): { tier: number, z: number } {
+    // The nearest positioned ancestor, not the nearest styled one: a page
+    // counter is a positioned `<footer>` wrapping a plain `<div>`.
     let current: RawNode | undefined = node
     while (current) {
-      const style = this.styleOf(current)
+      const style = styleOf(current)
       if (style && style.position !== 'static' && style.position !== '') {
         const z = Number.parseInt(style.zIndex, 10)
         return { tier: 1, z: Number.isNaN(z) ? 0 : z }
       }
-      current = this.byId.get(current.parent)
+      current = byId.get(current.parent)
     }
     return { tier: 0, z: 0 }
   }
 
-  private push(node: IrNode, source: RawNode): void {
-    this.nodes.push(node)
-    this.layers.push(this.layerOf(source))
+  function push(node: IrNode, source: RawNode): void {
+    nodes.push(node)
+    layers.push(layerOf(source))
   }
 
-  private styleOf(node: RawNode): RawStyle | undefined {
-    return node.style >= 0 ? this.styles[node.style] : undefined
+  function styleOf(node: RawNode): RawStyle | undefined {
+    return node.style >= 0 ? styles[node.style] : undefined
   }
 
-  private childrenOf(id: number): RawNode[] {
-    return this.children.get(id) ?? []
+  function childrenOf(id: number): RawNode[] {
+    return childIndex.get(id) ?? []
   }
 
   /** The nearest ancestor element's style, which is what styles a text node. */
-  private inheritedStyle(node: RawNode): RawStyle | undefined {
+  function inheritedStyle(node: RawNode): RawStyle | undefined {
     let current: RawNode | undefined = node
     while (current) {
-      const style = this.styleOf(current)
+      const style = styleOf(current)
       if (style)
         return style
-      current = this.byId.get(current.parent)
+      current = byId.get(current.parent)
     }
     return undefined
   }
 
-  private linkFor(node: RawNode): string | undefined {
+  function linkFor(node: RawNode): string | undefined {
     let current: RawNode | undefined = node
     while (current) {
       if (current.href)
         return current.href
-      current = this.byId.get(current.parent)
+      current = byId.get(current.parent)
     }
     return undefined
   }
 
   /** Whether an inline element paints something of its own behind its text. */
-  private hasDecoration(node: RawNode): boolean {
-    const style = this.styleOf(node)
+  function hasDecoration(node: RawNode): boolean {
+    const style = styleOf(node)
     if (!style)
       return false
-    if (isVisible(withOpacity(parseColor(style.backgroundColor, this.unparsed), node.opacity)))
+    if (isVisible(withOpacity(parseColor(style.backgroundColor, unparsed), node.opacity)))
       return true
-    return (['Top', 'Right', 'Bottom', 'Left'] as const).some(side => borderOf(style, side, this.unparsed))
+    return (['Top', 'Right', 'Bottom', 'Left'] as const).some(side => borderOf(style, side, unparsed))
   }
 
-  private isInline(node: RawNode): boolean {
+  function isInline(node: RawNode): boolean {
     if (node.tag === '#text')
       return true
-    const style = this.styleOf(node)
+    const style = styleOf(node)
     return !!style && INLINE_DISPLAY.test(style.display)
   }
 
-  run(): { nodes: IrNode[], requests: RasterRequest[], rasterArea: number, textCount: number } {
-    for (const root of this.childrenOf(-1))
-      this.visit(root)
+  function run(): { nodes: IrNode[], requests: RasterRequest[], rasterArea: number, textCount: number } {
+    for (const root of childrenOf(-1))
+      visit(root)
 
-    // Reordered into CSS paint order before anything reads the array, since
-    // everything downstream, including the overlap tests below and the
-    // builder, treats array order as paint order. A stable sort keeps document
-    // order within a layer, which is what CSS does too.
-    const order = this.nodes.map((node, index) => ({ node, index, layer: this.layers[index] }))
+    // Everything downstream treats array order as paint order, so reorder into
+    // CSS paint order first; a stable sort keeps document order within a layer.
+    const order = nodes.map((node, index) => ({ node, index, layer: layers[index] }))
     order.sort((a, b) =>
       a.layer.tier - b.layer.tier || a.layer.z - b.layer.z || a.index - b.index)
-    this.nodes = order.map(entry => entry.node)
+    nodes = order.map(entry => entry.node)
 
-    const texts = this.nodes.filter(n => n.kind === 'text')
-    // Pictures are drawn from their own screenshots, so a picture overlapping
-    // another picture is not the doubling problem below.
-    const drawnOver = this.nodes.filter(n => n.kind === 'text' || n.kind === 'image')
+    const texts = nodes.filter(n => n.kind === 'text')
+    // Picture over picture is not the doubling problem below: each is drawn from its own screenshot.
+    const drawnOver = nodes.filter(n => n.kind === 'text' || n.kind === 'image')
 
-    for (const node of this.nodes) {
+    for (const node of nodes) {
       if (node.kind !== 'raster')
         continue
 
-      /**
-       * Anything we ALSO draw as a shape inside this picture's box.
-       *
-       * `locator.screenshot()` clips the page to the element's box rather than
-       * isolating the element, so every overlapping thing lands in the
-       * picture. Drawing it again as a shape then prints it twice, which is
-       * exactly what a cover title over a full-bleed graphic looked like.
-       *
-       * Isolation used to be decided from the CSS reason - backdrops and the
-       * filter family - but that was only ever a proxy for "something is
-       * painted on top of this". Overlap tests the real thing, so a leaf
-       * picture such as a full-bleed `<svg>` is covered too.
-       */
+      // `locator.screenshot()` clips the page rather than isolating, so
+      // anything also drawn as a shape inside this picture's box would print
+      // twice. Overlap tests that directly; the CSS reason was only a proxy.
       const covered = drawnOver.some(other => overlaps(other.rect, node.rect))
       if (covered)
         node.isolate = true
 
-      this.requests.push({
+      requests.push({
         sourceId: node.sourceId,
         isolate: node.isolate,
         hideDescendants: node.hideDescendants,
-        clip: this.pageRects.get(node.sourceId),
-        isolateId: this.originators.get(node.sourceId),
+        clip: pageRects.get(node.sourceId),
+        isolateId: originators.get(node.sourceId),
       })
 
-      /**
-       * Raster area that bought us nothing.
-       *
-       * A picture with editable text over it is not wasted work: a cover photo
-       * covers the whole slide by definition while the title over it
-       * vectorizes perfectly. Counting those sent every cover slide to the
-       * whole-slide fallback and threw its text away.
-       */
+      // Count only raster area with no editable text over it: a cover photo
+      // covers the whole slide by definition while its title vectorizes
+      // perfectly, and counting those sent every cover slide to the fallback.
       if (texts.some(text => overlaps(text.rect, node.rect)))
         continue
-      const visible = clipToSlide(node.rect, this.size)
+      const visible = clipToSlide(node.rect, size)
       if (visible)
-        this.rasterArea += visible.w * visible.h
+        rasterArea += visible.w * visible.h
     }
 
-    return { nodes: this.nodes, requests: this.requests, rasterArea: this.rasterArea, textCount: texts.length }
+    return { nodes, requests, rasterArea, textCount: texts.length }
   }
 
   /** Whether a picture was actually emitted for this element. */
-  private emitRaster(node: RawNode, reason: RasterReason): boolean {
-    // A pseudo-element has no DOM node to point a screenshot at, so it is the
-    // one thing that MUST be captured by clipping the page at coordinates
-    // measured here. Everything else has an id, and is better captured from
-    // its box read live at capture time, which cannot be stale.
-    //
-    // This used to be set for every element, which made the live path dead
-    // code and quietly contradicted the contract `RasterRequest.clip` states.
+  function emitRaster(node: RawNode, reason: RasterReason): boolean {
+    // A pseudo-element has no DOM node to screenshot, so it alone is captured
+    // by clipping the page at coordinates measured here; everything else is
+    // captured from its box read live at capture time, which cannot be stale.
     if (node.tag === '::BEFORE' || node.tag === '::AFTER') {
-      this.pageRects.set(node.id, node.pageRect)
-      this.originators.set(node.id, node.parent)
+      pageRects.set(node.id, node.pageRect)
+      originators.set(node.id, node.parent)
     }
     const isolate = needsIsolation(reason)
-    const visible = clipToSlide(node.rect, this.size)
+    const visible = clipToSlide(node.rect, size)
     if (!visible)
       return false
-    // An element that runs past the slide is captured as a page clip rather
-    // than as itself, and placed at that same clipped rectangle so the picture
-    // is not squashed. Screenshotting such an element whole is not merely
-    // wasteful: Slidev's own starter deck carries one measuring tens of
-    // millions of pixels, and asking Chromium to rasterize it kills the
-    // renderer, which surfaces later as "Target page, context or browser has
-    // been closed".
+    // An element that runs past the slide is captured as a page clip and
+    // placed at that same clipped rectangle so the picture is not squashed.
+    // Screenshotting it whole can ask Chromium to rasterize tens of millions
+    // of pixels, which kills the renderer.
     const overflows = visible.w !== node.rect.w || visible.h !== node.rect.h
     if (overflows && node.pageRect) {
-      this.pageRects.set(node.id, {
+      pageRects.set(node.id, {
         x: node.pageRect.x + (visible.x - node.rect.x),
         y: node.pageRect.y + (visible.y - node.rect.y),
         w: visible.w,
@@ -811,11 +516,10 @@ class SlideWalker {
       })
     }
 
-    this.push({
+    push({
       kind: 'raster',
       sourceId: node.id,
-      // Its children are walked and redrawn only when it is a backdrop, so
-      // only then is it safe to hide them for the capture.
+      // Children are walked and redrawn only for a backdrop; only then is hiding them safe.
       hideDescendants: isolate,
       rect: overflows ? visible : node.rect,
       data: '',
@@ -825,26 +529,23 @@ class SlideWalker {
     return true
   }
 
-  private emitImage(node: RawNode): void {
+  function emitImage(node: RawNode): void {
     if (!node.src)
       return
-    // Clipped like every other shape. This was the one emitter that skipped
-    // it, so a partly off-slide image landed outside the PowerPoint canvas.
-    const rect = clipToSlide(node.rect, this.size)
+    // Clipped like every other shape, or a partly off-slide image lands outside the canvas.
+    const rect = clipToSlide(node.rect, size)
     if (!rect)
       return
-    // Clipping the BOX alone squeezed the whole image into it. The slide
-    // container has `overflow: hidden`, so a browser shows the top of an
-    // oversized image and cuts the rest off; scaling it to fit instead came
-    // out vertically compressed and showed content the audience never saw.
+    // Show the visible part of an oversized image and crop the rest, as
+    // `overflow: hidden` does; scaling it to fit would compress it.
     const clipped = rect.w !== node.rect.w || rect.h !== node.rect.h
-    this.push({
+    push({
       kind: 'image',
       sourceId: node.id,
       rect,
       data: node.src,
       alt: node.alt,
-      link: this.linkFor(node),
+      link: linkFor(node),
       ...(clipped
         ? {
             crop: {
@@ -858,36 +559,31 @@ class SlideWalker {
     }, node)
   }
 
-  private emitBox(node: RawNode, style: RawStyle): void {
-    // `emitTextGroup` paints every group node and descendant before the text,
-    // and a layout container inside that subtree is then handed to `visit`,
-    // which paints it again. Two opaque fills only waste a shape; two
-    // translucent ones composite and come out visibly darker.
-    if (this.boxed.has(node.id))
+  function emitBox(node: RawNode, style: RawStyle): void {
+    // `emitTextGroup` and `visit` can both reach the same node; two
+    // translucent fills would composite visibly darker.
+    if (boxed.has(node.id))
       return
-    this.boxed.add(node.id)
-    const fill = withOpacity(parseColor(style.backgroundColor, this.unparsed), node.opacity)
+    boxed.add(node.id)
+    const fill = withOpacity(parseColor(style.backgroundColor, unparsed), node.opacity)
     const borders: [Border?, Border?, Border?, Border?] = [
-      borderOf(style, 'Top', this.unparsed),
-      borderOf(style, 'Right', this.unparsed),
-      borderOf(style, 'Bottom', this.unparsed),
-      borderOf(style, 'Left', this.unparsed),
+      borderOf(style, 'Top', unparsed),
+      borderOf(style, 'Right', unparsed),
+      borderOf(style, 'Bottom', unparsed),
+      borderOf(style, 'Left', unparsed),
     ]
     const hasBorder = borders.some(Boolean)
-    // Chromium keeps `border-radius` as a percentage in the computed value, so
-    // it needs a basis. Without one, `border-radius: 50%` on a 200px box came
-    // out as 50px rather than 100px and the corners were barely rounded.
+    // Chromium keeps `border-radius` percentages in the computed value, so a
+    // basis is needed: `border-radius: 50%` on a 200px box is 100px, not 50px.
     const radius = parseLength(style.borderTopLeftRadius, Math.min(node.rect.w, node.rect.h))
     if (!isVisible(fill) && !hasBorder)
       return
-    const shadow = parseShadow(style.boxShadow, this.unparsed)
-    // One shape per line fragment for a wrapped inline element, because that
-    // is what a browser paints. Drawn as one rect over the union instead, an
-    // inline `<code>` running across several lines filled the ragged space at
-    // the end of every line with its own background.
+    const shadow = parseShadow(style.boxShadow, unparsed)
+    // One shape per line fragment for a wrapped inline element, as the browser
+    // paints; one rect over the union would fill the ragged line ends.
     const boxes = node.fragments?.length ? node.fragments : [node.rect]
     for (const source of boxes) {
-      const rect = clipToSlide(source, this.size)
+      const rect = clipToSlide(source, size)
       if (!rect)
         continue
       const box: IrBox = { kind: 'box', sourceId: node.id, rect }
@@ -899,23 +595,22 @@ class SlideWalker {
         box.radius = radius
       if (shadow)
         box.shadow = shadow
-      this.push(box, node)
+      push(box, node)
     }
   }
 
-  private visit(node: RawNode): void {
-    // A pseudo-element paints either an image or a short string. It has no
-    // children and never contains anything else.
+  function visit(node: RawNode): void {
+    // A pseudo-element paints either an image or a short string, and has no children.
     if (node.tag === '::BEFORE' || node.tag === '::AFTER') {
-      const style = this.styleOf(node)
+      const style = styleOf(node)
       if (!style)
         return
       const reason = rasterReasonFor(node, style)
-      if (reason && this.emitRaster(node, reason))
+      if (reason && emitRaster(node, reason))
         return
-      this.emitBox(node, style)
+      emitBox(node, style)
       if (node.text) {
-        this.push({
+        push({
           kind: 'text',
           sourceId: node.id,
           rect: node.rect,
@@ -924,50 +619,44 @@ class SlideWalker {
           align: alignOf(style),
           valign: 'middle',
           lineHeight: resolveLineHeight(style),
-          runs: [runFrom(node.text, style, this.fontResolution, this.unparsed)],
+          runs: [runFrom(node.text, style, fontResolution, unparsed)],
         }, node)
       }
       return
     }
 
     if (node.tag === '#text') {
-      // Reached only when a text node has no block container of its own, which
-      // `visitChildren` already handles. Guarded so a stray one is not lost.
-      this.emitTextGroup([node])
+      // Reached only when a text node has no block container of its own; guarded so a stray one is not lost.
+      emitTextGroup([node])
       return
     }
 
-    const style = this.styleOf(node)
+    const style = styleOf(node)
     const reason = rasterReasonFor(node, style)
-    // A raster that could not be placed leaves NOTHING behind, so treating the
-    // element as rasterized would silently drop its whole subtree. A theme
-    // rotating a decoration through a zero-sized wrapper does exactly that:
-    // the wrapper has no box of its own, while the absolutely positioned art
-    // inside it does, and the entire corner decoration vanished from the deck.
-    if (reason && this.emitRaster(node, reason)) {
-      // A leaf such as an <svg> has no shapes worth recovering underneath it.
-      // A backdrop does: its children are real content and are drawn as shapes
-      // on top of the isolated picture.
+    // Treat the element as rasterized only when a picture was actually placed:
+    // a zero-sized wrapper has no box of its own while its positioned
+    // descendants do, and dropping the subtree would lose them.
+    if (reason && emitRaster(node, reason)) {
+      // A leaf such as an <svg> has no shapes worth recovering underneath it;
+      // a backdrop does, its children being drawn on top of the isolated picture.
       if (!needsIsolation(reason))
         return
-      // But NOT its own box. The screenshot already contains this element's
-      // background and borders, so drawing them again paints an opaque fill
-      // straight over the picture that was taken to preserve the image, and
-      // composites a translucent one twice.
-      this.visitChildren(node)
+      // But not its own box: the screenshot already contains this element's
+      // background and borders, so drawing them again composites twice.
+      visitChildren(node)
       return
     }
 
     if (style)
-      this.emitBox(node, style)
+      emitBox(node, style)
 
     if (node.tag === 'IMG') {
-      this.emitImage(node)
+      emitImage(node)
       return
     }
 
-    // A ::marker is a pseudo-element, so the bullet glyph has no text node and
-    // a plain walk drops every bullet in the deck.
+    // A ::marker is a pseudo-element: the bullet glyph has no text node, so a
+    // plain walk drops every bullet in the deck.
     if (node.marker && style) {
       const markerRect: Rect = {
         x: Math.max(0, node.rect.x - parseLength(style.fontSize) * 1.2),
@@ -975,142 +664,121 @@ class SlideWalker {
         w: parseLength(style.fontSize) * 1.2,
         h: resolveLineHeight(style),
       }
-      this.push({
+      push({
         kind: 'text',
         sourceId: node.id,
         rect: markerRect,
         elementRect: markerRect,
         lineCount: 1,
         align: 'left',
-        // Centred in the line box, which is where a browser puts a marker.
-        // Anchored to the top it rode above its own item's first line.
+        // Centered in the line box, where a browser puts a marker; anchored to
+        // the top it rides above its own item's first line.
         valign: 'middle',
         lineHeight: resolveLineHeight(style),
-        runs: [runFrom(node.marker, style, this.fontResolution, this.unparsed, undefined, node.opacity)],
+        runs: [runFrom(node.marker, style, fontResolution, unparsed, undefined, node.opacity)],
       }, node)
     }
 
-    this.visitChildren(node)
+    visitChildren(node)
   }
 
-  private visitChildren(node: RawNode): void {
-    const style = this.styleOf(node)
-    const children = this.childrenOf(node.id)
+  function visitChildren(node: RawNode): void {
+    const style = styleOf(node)
+    const children = childrenOf(node.id)
     if (!children.length)
       return
 
-    // A grid or flex container lays its children out as boxes, not as a line
-    // box. Grouping them as one run of text concatenates unrelated cells into
-    // strings like "Left cellRight cell".
+    // A grid or flex container lays its children out as boxes; grouping them
+    // as one run of text concatenates unrelated cells.
     if (style && LAYOUT_DISPLAY.test(style.display)) {
       for (const child of children)
-        this.visit(child)
+        visit(child)
       return
     }
 
     // Consecutive inline children form one anonymous block box, which is one
-    // text box. Treating each as its own shape makes a bold lead-in and the
-    // rest of its sentence lay out from the same origin, printing on top of
-    // each other.
+    // text box; one shape each would lay out from the same origin and overlap.
     let group: RawNode[] = []
     const flush = () => {
       if (group.length) {
-        this.emitTextGroup(group)
+        emitTextGroup(group)
         group = []
       }
     }
     for (const child of children) {
-      if (this.isInline(child)) {
-        // An inline element carrying its own background or border is a chip,
-        // and its decoration is an absolutely positioned shape while the text
-        // around it is a flowed text box. Left in the same box, any difference
-        // between PowerPoint's metrics and the browser's accumulates across
-        // the earlier runs and slides the label off its own chip.
-        //
-        // Given its own box at its own glyph bounds, the label is anchored to
-        // where the browser actually put it, so the two cannot drift apart.
-        //
-        // Only when it is the WHOLE of its container. Slidev styles inline
-        // `<code>` with a background, so an unconditional split cut ordinary
-        // sentences into three boxes and forced the code span to centre; when
-        // such a sentence wrapped, the two halves both laid out from the
-        // container's left edge and overlapped. A chip is a label on its own,
-        // not a word in the middle of a line.
-        if (this.hasDecoration(child) && children.length === 1) {
+      if (isInline(child)) {
+        // An inline element carrying its own background or border is a chip: its
+        // decoration is a positioned shape, so its label gets its own text box anchored
+        // to the glyph bounds, keeping metric differences from sliding the label off
+        // the chip. Only when it is the whole of its container: Slidev styles inline
+        // `<code>` with a background, and an unconditional split overlaps a wrapped sentence.
+        if (hasDecoration(child) && children.length === 1) {
           flush()
-          this.emitTextGroup([child])
+          emitTextGroup([child])
           continue
         }
         group.push(child)
       }
       else {
         flush()
-        this.visit(child)
+        visit(child)
       }
     }
     flush()
   }
 
   /** Every text node under an inline subtree, in document order. */
-  private collectText(node: RawNode, out: RawNode[]): void {
+  function collectText(node: RawNode, out: RawNode[]): void {
     if (node.tag === '#text') {
       out.push(node)
       return
     }
-    const style = this.styleOf(node)
+    const style = styleOf(node)
     const reason = rasterReasonFor(node, style)
-    // An inline <svg> icon inside a sentence still has to become a picture,
-    // but only if it has a box to be a picture of. Otherwise its subtree is
-    // walked as usual rather than being dropped along with the raster.
-    if (reason && this.emitRaster(node, reason))
+    // An inline <svg> icon still becomes a picture, but only if it has a box;
+    // otherwise its subtree is walked as usual rather than dropped.
+    if (reason && emitRaster(node, reason))
       return
-    // A <br> has no text node of its own, so without this marker the text
-    // either side of it is concatenated into consecutive runs with no break
-    // and `line one<br>line two` exports as "line oneline two".
+    // A <br> has no text node of its own, so without this marker the text on
+    // either side of it concatenates with no break.
     if (node.tag === 'BR') {
       out.push(node)
       return
     }
-    // An inline <img> reaches here rather than `visit`, and has no text under
-    // it, so it used to vanish from the slide entirely. Drawn at its measured
-    // box, which is where the browser put it.
+    // An inline <img> reaches here rather than `visit`; drawn at its measured box.
     if (node.tag === 'IMG') {
-      this.emitImage(node)
+      emitImage(node)
       return
     }
-    // Defensive: a layout container nested inside an inline run still lays its
-    // children out as boxes. Descending as text merges its cells.
+    // A layout container nested inside an inline run still lays out boxes.
     if (style && LAYOUT_DISPLAY.test(style.display)) {
-      this.visit(node)
+      visit(node)
       return
     }
-    for (const child of this.childrenOf(node.id))
-      this.collectText(child, out)
+    for (const child of childrenOf(node.id))
+      collectText(child, out)
   }
 
-  private emitTextGroup(group: RawNode[]): void {
-    // Inline decorations first. A <span> with a coloured background behind
-    // white text has to be painted BEFORE the text, because paint order is
-    // array order; emitted after, the chip covers its own label.
+  function emitTextGroup(group: RawNode[]): void {
+    // Inline decorations first: paint order is array order, so a chip emitted
+    // after its label would cover it.
     for (const node of group) {
       if (node.tag === '#text')
         continue
-      // The group node ITSELF first, not only its descendants. The chip is
-      // usually the outermost inline element in the group, so walking only
-      // downwards from it missed the one background that mattered.
-      const own = this.styleOf(node)
+      // The group node itself too: the chip is usually the outermost inline element in the group.
+      const own = styleOf(node)
       if (own)
-        this.emitBox(node, own)
-      this.forEachDescendant(node, (descendant) => {
-        const style = this.styleOf(descendant)
+        emitBox(node, own)
+      forEachDescendant(node, (descendant) => {
+        const style = styleOf(descendant)
         if (style)
-          this.emitBox(descendant, style)
+          emitBox(descendant, style)
       })
     }
 
     const textNodes: RawNode[] = []
     for (const node of group)
-      this.collectText(node, textNodes)
+      collectText(node, textNodes)
     if (!textNodes.length)
       return
 
@@ -1118,26 +786,22 @@ class SlideWalker {
     const rects: Rect[] = []
 
     /**
-     * Line breaks waiting to be attached to the next run.
-     *
-     * A count, not a flag. `softBreakBefore` is one break per run, so two
-     * consecutive `<br>` need an empty run between them or the blank line
-     * disappears. Held against the NEXT run rather than the previous one, so a
-     * trailing break does not add an empty line at the end of the box.
+     * Line breaks waiting for the next run; a count, since two consecutive `<br>` need an
+     * empty run between them. Held against the next run so a trailing break does not add an empty last line.
      */
     let pendingBreaks = 0
 
-    const push = (text: string, style: RawStyle, node: RawNode) => {
+    const addRun = (text: string, style: RawStyle, node: RawNode) => {
       // One empty run per surplus break, so the blank lines survive.
       while (pendingBreaks > 1 && runs.length) {
-        runs.push({ ...runFrom('', style, this.fontResolution, this.unparsed, undefined, node.opacity), breakBefore: true })
+        runs.push({ ...runFrom('', style, fontResolution, unparsed, undefined, node.opacity), breakBefore: true })
         pendingBreaks--
       }
-      const run = runFrom(text, style, this.fontResolution, this.unparsed, this.linkFor(node), node.opacity)
+      const newRun = runFrom(text, style, fontResolution, unparsed, linkFor(node), node.opacity)
       if (pendingBreaks && runs.length)
-        run.breakBefore = true
+        newRun.breakBefore = true
       pendingBreaks = 0
-      runs.push(run)
+      runs.push(newRun)
     }
 
     for (const textNode of textNodes) {
@@ -1145,24 +809,23 @@ class SlideWalker {
         pendingBreaks++
         continue
       }
-      const style = this.inheritedStyle(textNode)
+      const style = inheritedStyle(textNode)
       if (!style)
         continue
       const raw = textNode.text ?? ''
       if (!raw)
         continue
 
-      // `white-space: pre` keeps its newlines, and they are the ONLY record of
-      // where one line of a code block ends. Shiki renders each line as an
-      // inline span separated by a "\n" text node, so folding those into
-      // spaces joins the whole block into one re-wrapped paragraph.
+      // `white-space: pre` keeps its newlines, the only record of where a code
+      // block's lines end: Shiki separates line spans with "\n" text nodes, so
+      // folding them into spaces re-wraps the block into one paragraph.
       if (style.whiteSpace.startsWith('pre')) {
         const lines = raw.split('\n')
         lines.forEach((line, index) => {
           if (index > 0)
             pendingBreaks++
           if (line)
-            push(line, style, textNode)
+            addRun(line, style, textNode)
         })
         rects.push(...(textNode.glyphRects ?? []))
         continue
@@ -1170,25 +833,21 @@ class SlideWalker {
 
       const text = raw.replace(/\s+/g, ' ')
       if (!text.trim()) {
-        // A whitespace-only node is the space between two inline elements.
-        // Dropping it exports `<span>Hello</span> <span>World</span>` as
-        // "HelloWorld". Folded into the previous run so it does not become a
-        // run of its own with its own styling.
+        // A whitespace-only node is the space between two inline elements;
+        // folded into the previous run so it keeps no styling of its own.
         if (runs.length && !runs[runs.length - 1].text.endsWith(' '))
           runs[runs.length - 1].text += ' '
         continue
       }
-      push(text, style, textNode)
+      addRun(text, style, textNode)
       rects.push(...(textNode.glyphRects ?? [textNode.rect]))
     }
     if (!runs.length || !rects.length)
       return
 
-    // Whitespace at the start and end of a LINE collapses away in the browser,
-    // but it survives `replace(/\s+/g, ' ')` and shifts a centred line
-    // sideways by half a space, because markup normally puts each sentence on
-    // its own source line. Every line boundary counts, not just the box edges:
-    // a run after a break opens a new line.
+    // Whitespace at line boundaries collapses in the browser but survives the
+    // fold above and shifts a centered line by half a space. Every line
+    // boundary counts, not just the box edges: a run after a break opens a new line.
     runs.forEach((run, index) => {
       const opensLine = index === 0 || run.breakBefore
       const closesLine = index === runs.length - 1 || runs[index + 1]?.breakBefore
@@ -1198,24 +857,17 @@ class SlideWalker {
         run.text = run.text.replace(/ +$/, '')
     })
 
-    const container = this.byId.get(group[0].parent)
-    const containerStyle = container ? this.styleOf(container) : undefined
-    const anchorStyle = containerStyle ?? this.inheritedStyle(textNodes[0])!
+    const container = byId.get(group[0].parent)
+    const containerStyle = container ? styleOf(container) : undefined
+    const anchorStyle = containerStyle ?? inheritedStyle(textNodes[0])!
 
     const glyphs = boundsOf(rects)
     const lineCount = countLines(rects)
 
     /**
-     * The box PowerPoint will wrap inside.
-     *
-     * Glyph bounds are the ink, not the wrap width, and for text that already
-     * wrapped they are the width of the LONGEST LINE. Handing PowerPoint that
-     * guarantees a second, tighter wrap: a caption reading "a short caption"
-     * over two lines came back over three and overflowed its box.
-     *
-     * The browser wrapped against the container's content box, so that is the
-     * width to reproduce. Single-line text keeps its glyph bounds, which are
-     * exact and carry no wrapping risk.
+     * The box PowerPoint will wrap inside. Wrapped text's glyph bounds are the width of
+     * the longest line, which guarantees a second, tighter wrap; the browser wrapped
+     * against the container's content box, so reproduce that. Single-line text keeps its exact glyph bounds.
      */
     let rect = glyphs
     let align = alignOf(anchorStyle)
@@ -1236,15 +888,11 @@ class SlideWalker {
     let valign: IrText['valign']
 
     /**
-     * A chip label belongs to its chip, not to its own ink.
-     *
-     * Its background is an absolutely positioned shape, so pinning the text to
-     * the decoration's box and centring it there keeps the label evenly inset
-     * however the font measures. Positioning from the glyphs instead leaves
-     * the label hard against one edge as soon as PowerPoint sets the string
-     * even slightly wider than the browser did.
+     * A chip label is pinned to its chip's box and centered there, keeping the inset even
+     * however the font measures; positioned from the glyphs it ends hard against one edge
+     * as soon as PowerPoint sets the string wider.
      */
-    const decorated = group.length === 1 && group[0].tag !== '#text' && this.hasDecoration(group[0])
+    const decorated = group.length === 1 && group[0].tag !== '#text' && hasDecoration(group[0])
     if (decorated) {
       rect = group[0].rect
       align = 'center'
@@ -1259,14 +907,12 @@ class SlideWalker {
       }
     }
 
-    // Clipped like every other emitted node. Text was the one kind that was
-    // not, so anything the browser clipped away landed off the PowerPoint
-    // canvas where it cannot be selected, and still counted toward the text
-    // total that suppresses the whole-slide fallback.
-    if (!clipToSlide(rect, this.size))
+    // Clipped like every other node, or browser-clipped text lands off the
+    // canvas while still suppressing the whole-slide fallback.
+    if (!clipToSlide(rect, size))
       return
 
-    this.push({
+    push({
       kind: 'text',
       sourceId: group[0].id,
       rect,
@@ -1279,13 +925,15 @@ class SlideWalker {
     }, group[0])
   }
 
-  private forEachDescendant(node: RawNode, fn: (node: RawNode) => void): void {
-    for (const child of this.childrenOf(node.id)) {
+  function forEachDescendant(node: RawNode, fn: (node: RawNode) => void): void {
+    for (const child of childrenOf(node.id)) {
       if (child.tag !== '#text')
         fn(child)
-      this.forEachDescendant(child, fn)
+      forEachDescendant(child, fn)
     }
   }
+
+  return run()
 }
 
 export function normalize(snapshot: RawSnapshot, options: NormalizeOptions): NormalizeResult {
@@ -1294,17 +942,15 @@ export function normalize(snapshot: RawSnapshot, options: NormalizeOptions): Nor
   const rasterRequests: RasterRequest[] = []
 
   for (const raw of snapshot.slides) {
-    const walker = new SlideWalker(raw, snapshot.styles, snapshot.fontResolution, unparsedColors)
-    const { nodes, requests, rasterArea, textCount } = walker.run()
+    const { nodes, requests, rasterArea, textCount } = buildSlideIr(raw, snapshot.styles, snapshot.fontResolution, unparsedColors)
 
     const ir: SlideIr = {
       no: raw.no,
       clickIndex: raw.clickIndex,
       containerId: raw.containerId,
       size: raw.size,
-      // The slide's own background. Without it every slide exported onto
-      // PowerPoint's default white, so a dark theme came out as light text on
-      // a white page.
+      // Without the slide's own background, a dark theme exports as light text
+      // on PowerPoint's default white.
       background: parseColor(raw.background, unparsedColors),
       nodes,
       note: options.notes.get(raw.no),
@@ -1313,15 +959,13 @@ export function normalize(snapshot: RawSnapshot, options: NormalizeOptions): Nor
     const slideArea = raw.size.w * raw.size.h
     const hasSourceText = raw.nodes.some(n => n.tag === '#text' && (n.text ?? '').trim())
 
-    // The safety valve. Both conditions describe a slide where vectorizing has
-    // produced something worse than the picture it replaced, and both degrade
-    // to exactly what `--format pptx` does today rather than to a broken file.
+    // Both conditions describe a slide where vectorizing produced something
+    // worse than the picture it replaced; degrade to what `--format pptx` does.
     if (hasSourceText && textCount === 0) {
       ir.fallbackReason = 'no text could be recovered from a slide that has text'
     }
     else if (slideArea > 0 && rasterArea / slideArea > RASTER_AREA_LIMIT) {
-      // Capped: rasters can overlap, so the raw sum can exceed the slide and a
-      // percentage over 100 reads as a bug rather than as a diagnosis.
+      // Capped: rasters can overlap, so the raw sum can exceed the slide.
       const percent = Math.min(100, Math.round((rasterArea / slideArea) * 100))
       ir.fallbackReason = `${percent}% of the slide had to be rasterized`
     }

--- a/packages/slidev/node/commands/pptx/walker.test.ts
+++ b/packages/slidev/node/commands/pptx/walker.test.ts
@@ -1,3 +1,6 @@
+import fs from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import vm from 'node:vm'
 import { describe, expect, it } from 'vitest'
 import { collectSnapshot } from './walker'
@@ -212,5 +215,75 @@ describe('walker self-containedness', () => {
     const source = collectSnapshot.toString()
     for (const forbidden of ['require(', 'import(', 'exports.', 'module.exports'])
       expect(source).not.toContain(forbidden)
+  })
+})
+
+/**
+ * The walker as it is actually shipped.
+ *
+ * Everything above runs against Vitest's transform of the source, which is not
+ * what reaches a browser: `exportPptxEditable` hands Playwright the function
+ * from the bundle in `dist`, and a bundler is free to rewrite a body with
+ * helpers of its own. Testing only the transform leaves the invariant
+ * unenforced on the one artifact that matters.
+ *
+ * Needs a prior `pnpm build`, which is how this repository runs its tests
+ * anyway: workspace packages resolve through their built `dist`.
+ */
+function bundledWalker(): string {
+  const dist = join(dirname(fileURLToPath(import.meta.url)), '../../../dist')
+  const file = fs.readdirSync(dist).find(name => /^pptx-.+\.mjs$/.test(name))
+  if (!file)
+    throw new Error(`no built pptx bundle in ${dist}; run \`pnpm build\` first`)
+
+  const source = fs.readFileSync(join(dist, file), 'utf8')
+  const start = source.indexOf('function collectSnapshot')
+  if (start < 0)
+    throw new Error('collectSnapshot is not in the built bundle under its own name')
+
+  // Brace matching rather than a regex: the body is thousands of characters of
+  // nested functions and object literals.
+  let depth = 0
+  let index = source.indexOf('{', start)
+  const open = index
+  for (; index < source.length; index++) {
+    if (source[index] === '{')
+      depth++
+    else if (source[index] === '}' && --depth === 0)
+      break
+  }
+  return `function collectSnapshot${source.slice(source.indexOf('(', start), open)}${source.slice(open, index + 1)}`
+}
+
+/** Block comments only: enough for the bundler's annotations, and it cannot eat a regex literal. */
+function withoutComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, '')
+}
+
+describe('the built bundle keeps the walker self-contained', () => {
+  it('runs to completion using only browser globals', () => {
+    expect(() => runInSandbox(bundledWalker(), [containerStub()])).not.toThrow()
+  })
+
+  it('carries no bundler-injected identifiers', () => {
+    // tsdown and Vite rewrite bodies with helpers such as `__toESM`,
+    // `__publicField` or `__name`, none of which exist in the page.
+    //
+    // Block comments are stripped first: the bundler annotates calls with
+    // `/* @__PURE__ */`, which never executes and is not a leak.
+    expect(withoutComments(bundledWalker()).match(/\b__\w+/g)).toBeNull()
+  })
+
+  it('does not reference the module registry', () => {
+    const source = withoutComments(bundledWalker())
+    for (const forbidden of ['require(', 'import(', 'exports.', 'module.exports'])
+      expect(source).not.toContain(forbidden)
+  })
+
+  it('fails when the bundle leaks a helper into the walker', () => {
+    // The guard pinned against the mutation it exists to catch, so it cannot
+    // quietly stop working the next time the bundler changes.
+    const leaked = bundledWalker().replace(/const nodes = \[\]/, 'const nodes = __name([])')
+    expect(() => runInSandbox(leaked, [containerStub()])).toThrow(/__name/)
   })
 })

--- a/packages/slidev/node/commands/pptx/walker.test.ts
+++ b/packages/slidev/node/commands/pptx/walker.test.ts
@@ -3,25 +3,16 @@ import { describe, expect, it } from 'vitest'
 import { collectSnapshot } from './walker'
 
 /**
- * The walker is serialised by Playwright and evaluated in a page where none of
- * this module's scope exists. A single free variable - an import, a shared
- * constant, a bundler-injected helper - becomes a `ReferenceError` at runtime,
- * on someone else's machine, inside a browser nobody can attach to.
+ * The walker is serialized by Playwright and evaluated in a page where this
+ * module's scope does not exist, so a free variable becomes a `ReferenceError`
+ * inside someone else's browser. The guard has to run the reconstructed
+ * function, not compile it: an undeclared identifier resolves at call time, so
+ * `new Function(source)` accepts a body full of them. The sandbox global is a
+ * Proxy that throws on any identifier outside a browser allowlist.
  *
- * So the guard has to RUN the reconstructed function, not merely compile it.
- * Compiling proves nothing: an undeclared identifier is resolved at call time,
- * so `new Function(source)` accepts a body full of them and reports success.
- * (This test previously did exactly that, and passed happily with a leaked
- * module constant wired into the walker.)
- *
- * The sandbox global is a Proxy that throws on any identifier outside a small
- * browser allowlist, so a free variable fails loudly and by name.
- *
- * These tests do NOT check what the walker extracts. That needs a real layout
- * engine, and jsdom has none: `getBoundingClientRect` returns zeros there, so
- * a DOM test would assert everything sits at the origin and pass even when the
- * walker is broken. The extraction is kept thin for that reason, and the
- * judgement it feeds lives in `normalize.ts`, which is testable.
+ * What the walker extracts is not tested here. jsdom has no layout engine, so
+ * `getBoundingClientRect` returns zeros and a DOM test would pass with every
+ * rect at the origin. The judgement it feeds lives in `normalize.ts`.
  */
 
 /** Globals a browser really provides. Anything else is a leak. */

--- a/packages/slidev/node/commands/pptx/walker.test.ts
+++ b/packages/slidev/node/commands/pptx/walker.test.ts
@@ -45,6 +45,17 @@ function measureTextStub(): { width: number } {
   return { width: 100 }
 }
 
+/**
+ * A canvas whose text measurement changes only for the families named, which is
+ * how `isAvailable` tells a font that exists from one that fell through to the
+ * base. Everything else keeps the constant width, so it reads as absent.
+ */
+function installedFonts(...families: string[]) {
+  return function (this: { font: string }): { width: number } {
+    return { width: families.some(f => this.font.includes(`"${f}"`)) ? 140 : 100 }
+  }
+}
+
 const RECT = { left: 0, top: 0, width: 100, height: 20 }
 
 /**
@@ -90,13 +101,13 @@ function containerStub() {
 }
 
 /** Just enough DOM for the walker to run to completion. */
-function domStub(querySelectorAllResult: unknown[]) {
+function domStub(querySelectorAllResult: unknown[], measureText = measureTextStub) {
   return {
     createElement: () => ({
       getContext: () => ({
         font: '',
         fillStyle: '',
-        measureText: measureTextStub,
+        measureText,
         clearRect: () => {},
         fillRect: () => {},
         getImageData: () => ({ data: [0, 0, 0, 0] }),
@@ -111,11 +122,16 @@ function domStub(querySelectorAllResult: unknown[]) {
   }
 }
 
-function runInSandbox(source: string, containers: unknown[] = []): unknown {
+interface SandboxOptions {
+  measureText?: () => { width: number }
+  fontFamily?: string
+}
+
+function runInSandbox(source: string, containers: unknown[] = [], options: SandboxOptions = {}): unknown {
   const base: Record<string, unknown> = {
-    document: domStub(containers),
+    document: domStub(containers, options.measureText),
     getComputedStyle: () => ({
-      fontFamily: 'Inter, sans-serif',
+      fontFamily: options.fontFamily ?? 'Inter, sans-serif',
       display: 'block',
       visibility: 'visible',
       opacity: '1',
@@ -203,6 +219,38 @@ describe('walker self-containedness', () => {
     expect(snapshot).toHaveProperty('slides')
     expect(snapshot).toHaveProperty('styles')
     expect(snapshot).toHaveProperty('fontResolution')
+  })
+
+  it('detects a font the theme ships as a webfont, and names it without the suffix', () => {
+    // `@fontsource-variable/inter` registers the family as "Inter Variable",
+    // so probing the stripped name first asks whether a static "Inter" is
+    // installed. On a machine with no such copy, which is the normal case for
+    // a webfont, nothing in the stack matched and every run in the deck was
+    // written out as a system fallback instead of the theme's own face.
+    const snapshot = runInSandbox(collectSnapshot.toString(), [containerStub()], {
+      fontFamily: '"Inter Variable", Inter, sans-serif',
+      measureText: installedFonts('Inter Variable'),
+    }) as any
+    expect(snapshot.fontResolution['"Inter Variable", Inter, sans-serif']).toBe('Inter')
+  })
+
+  it('still resolves a family installed under its plain name', () => {
+    // The Google Fonts path, which registers "Inter" with no suffix. Every
+    // Slidev-themed deck takes it, which is why the bug above stayed invisible
+    // until a theme shipped its font through `@fontsource`.
+    const snapshot = runInSandbox(collectSnapshot.toString(), [containerStub()], {
+      fontFamily: 'Inter, sans-serif',
+      measureText: installedFonts('Inter'),
+    }) as any
+    expect(snapshot.fontResolution['Inter, sans-serif']).toBe('Inter')
+  })
+
+  it('reports no family when nothing in the stack resolves', () => {
+    const snapshot = runInSandbox(collectSnapshot.toString(), [containerStub()], {
+      fontFamily: '"Human Sans", sans-serif',
+      measureText: installedFonts('Something Else'),
+    }) as any
+    expect(snapshot.fontResolution['"Human Sans", sans-serif']).toBe('')
   })
 
   it('carries no bundler-injected identifiers', () => {

--- a/packages/slidev/node/commands/pptx/walker.test.ts
+++ b/packages/slidev/node/commands/pptx/walker.test.ts
@@ -27,6 +27,7 @@ import { collectSnapshot } from './walker'
 /** Globals a browser really provides. Anything else is a leak. */
 const BROWSER_GLOBALS = new Set([
   'document',
+  'window',
   'getComputedStyle',
   'Array',
   'Boolean',
@@ -50,16 +51,67 @@ function measureTextStub(): { width: number } {
   return { width: 100 }
 }
 
-/** Just enough DOM for the walker to run to completion over zero slides. */
+const RECT = { left: 0, top: 0, width: 100, height: 20 }
+
+/**
+ * A slide container with one element and one text node under it.
+ *
+ * Not decoration: with an empty container list the guard only ever ran the
+ * walker's top-level setup, so every free variable inside `walk` and its
+ * helpers went unnoticed. `window` was one of them, referenced for `scrollX`
+ * and absent from the allowlist, and the suite passed regardless.
+ */
+function containerStub() {
+  const text = { nodeType: 3, textContent: 'hello' }
+  const child: any = {
+    nodeType: 1,
+    tagName: 'DIV',
+    id: '',
+    childNodes: [text],
+    children: [],
+    classList: { contains: () => false },
+    shadowRoot: null,
+    parentElement: null,
+    setAttribute: () => {},
+    getAttribute: () => null,
+    getBoundingClientRect: () => RECT,
+    getClientRects: () => [RECT],
+  }
+  const container: any = {
+    nodeType: 1,
+    tagName: 'DIV',
+    id: '003-02',
+    childNodes: [child],
+    children: [child],
+    classList: { contains: () => false },
+    shadowRoot: null,
+    parentElement: null,
+    setAttribute: () => {},
+    getAttribute: () => null,
+    getBoundingClientRect: () => ({ ...RECT, width: 980, height: 552 }),
+    getClientRects: () => [RECT],
+  }
+  child.parentElement = container
+  return container
+}
+
+/** Just enough DOM for the walker to run to completion. */
 function domStub(querySelectorAllResult: unknown[]) {
   return {
     createElement: () => ({
-      getContext: () => ({ font: '', measureText: measureTextStub }),
+      getContext: () => ({
+        font: '',
+        fillStyle: '',
+        measureText: measureTextStub,
+        clearRect: () => {},
+        fillRect: () => {},
+        getImageData: () => ({ data: [0, 0, 0, 0] }),
+      }),
     }),
     querySelectorAll: () => querySelectorAllResult,
     createRange: () => ({
       selectNodeContents: () => {},
-      getClientRects: () => [],
+      getClientRects: () => [RECT],
       detach: () => {},
     }),
   }
@@ -68,7 +120,22 @@ function domStub(querySelectorAllResult: unknown[]) {
 function runInSandbox(source: string, containers: unknown[] = []): unknown {
   const base: Record<string, unknown> = {
     document: domStub(containers),
-    getComputedStyle: () => ({}),
+    getComputedStyle: () => ({
+      fontFamily: 'Inter, sans-serif',
+      display: 'block',
+      visibility: 'visible',
+      opacity: '1',
+      position: 'static',
+      backgroundColor: 'rgb(255, 255, 255)',
+      listStyleType: 'none',
+      content: 'none',
+      width: '100px',
+      height: '20px',
+      left: 'auto',
+      top: 'auto',
+      right: 'auto',
+      bottom: 'auto',
+    }),
     Array,
     Boolean,
     Error,
@@ -82,6 +149,7 @@ function runInSandbox(source: string, containers: unknown[] = []): unknown {
     String,
     Symbol,
     globalThis: undefined,
+    window: { scrollX: 0, scrollY: 0 },
   }
 
   const sandbox = new Proxy(base, {
@@ -106,6 +174,25 @@ function runInSandbox(source: string, containers: unknown[] = []): unknown {
 describe('walker self-containedness', () => {
   it('runs to completion using only browser globals', () => {
     expect(() => runInSandbox(collectSnapshot.toString())).not.toThrow()
+  })
+
+  it('runs to completion over a real container, not just an empty page', () => {
+    // The empty-page case exercises none of `walk`, which is most of the file.
+    const snapshot = runInSandbox(collectSnapshot.toString(), [containerStub()]) as any
+    expect(snapshot.slides).toHaveLength(1)
+    expect(snapshot.slides[0].nodes.length).toBeGreaterThan(0)
+  })
+
+  it('fails when a walked node closes over module scope', () => {
+    // The same guard as below, but pinned on a path only a container reaches.
+    const leaked = collectSnapshot
+      .toString()
+      // The record built for every ELEMENT, so it is reached only by walking a
+      // container. Matched on its first field because the compiled source has
+      // two other `const record` declarations, in the style interners, which a
+      // page with no pseudo-elements never runs.
+      .replace(/const record\s*(?:(: any)\s*)?=\s*\{\s*id,/, 'const record = { leaked: LEAKED_FROM_WALK, id,')
+    expect(() => runInSandbox(leaked, [containerStub()])).toThrow(/LEAKED_FROM_WALK/)
   })
 
   it('fails when the walker closes over module scope', () => {

--- a/packages/slidev/node/commands/pptx/walker.test.ts
+++ b/packages/slidev/node/commands/pptx/walker.test.ts
@@ -1,0 +1,138 @@
+import vm from 'node:vm'
+import { describe, expect, it } from 'vitest'
+import { collectSnapshot } from './walker'
+
+/**
+ * The walker is serialised by Playwright and evaluated in a page where none of
+ * this module's scope exists. A single free variable - an import, a shared
+ * constant, a bundler-injected helper - becomes a `ReferenceError` at runtime,
+ * on someone else's machine, inside a browser nobody can attach to.
+ *
+ * So the guard has to RUN the reconstructed function, not merely compile it.
+ * Compiling proves nothing: an undeclared identifier is resolved at call time,
+ * so `new Function(source)` accepts a body full of them and reports success.
+ * (This test previously did exactly that, and passed happily with a leaked
+ * module constant wired into the walker.)
+ *
+ * The sandbox global is a Proxy that throws on any identifier outside a small
+ * browser allowlist, so a free variable fails loudly and by name.
+ *
+ * These tests do NOT check what the walker extracts. That needs a real layout
+ * engine, and jsdom has none: `getBoundingClientRect` returns zeros there, so
+ * a DOM test would assert everything sits at the origin and pass even when the
+ * walker is broken. The extraction is kept thin for that reason, and the
+ * judgement it feeds lives in `normalize.ts`, which is testable.
+ */
+
+/** Globals a browser really provides. Anything else is a leak. */
+const BROWSER_GLOBALS = new Set([
+  'document',
+  'getComputedStyle',
+  'Array',
+  'Boolean',
+  'Error',
+  'JSON',
+  'Map',
+  'Math',
+  'Number',
+  'Object',
+  'RegExp',
+  'Set',
+  'String',
+  'Symbol',
+  'undefined',
+  'NaN',
+  'Infinity',
+  'globalThis',
+])
+
+function measureTextStub(): { width: number } {
+  return { width: 100 }
+}
+
+/** Just enough DOM for the walker to run to completion over zero slides. */
+function domStub(querySelectorAllResult: unknown[]) {
+  return {
+    createElement: () => ({
+      getContext: () => ({ font: '', measureText: measureTextStub }),
+    }),
+    querySelectorAll: () => querySelectorAllResult,
+    createRange: () => ({
+      selectNodeContents: () => {},
+      getClientRects: () => [],
+      detach: () => {},
+    }),
+  }
+}
+
+function runInSandbox(source: string, containers: unknown[] = []): unknown {
+  const base: Record<string, unknown> = {
+    document: domStub(containers),
+    getComputedStyle: () => ({}),
+    Array,
+    Boolean,
+    Error,
+    JSON,
+    Map,
+    Math,
+    Number,
+    Object,
+    RegExp,
+    Set,
+    String,
+    Symbol,
+    globalThis: undefined,
+  }
+
+  const sandbox = new Proxy(base, {
+    // Claim every name so V8 resolves lookups here rather than walking out.
+    has: () => true,
+    get(target, prop) {
+      if (typeof prop === 'symbol')
+        return (target as any)[prop]
+      if (BROWSER_GLOBALS.has(prop))
+        return target[prop]
+      throw new ReferenceError(
+        `walker referenced "${String(prop)}", which will not exist inside page.evaluate`,
+      )
+    },
+  })
+
+  const context = vm.createContext(sandbox)
+  const fn = vm.runInContext(`(${source})`, context)
+  return fn({ containerSelector: '.print-slide-container', idAttribute: 'data-slidev-export-id' })
+}
+
+describe('walker self-containedness', () => {
+  it('runs to completion using only browser globals', () => {
+    expect(() => runInSandbox(collectSnapshot.toString())).not.toThrow()
+  })
+
+  it('fails when the walker closes over module scope', () => {
+    // The mutation this guard exists to catch, pinned so the guard itself
+    // cannot silently stop working.
+    const leaked = collectSnapshot
+      .toString()
+      .replace('const styles', 'const styles = [LEAKED_FROM_MODULE_SCOPE]; const _unused')
+    expect(() => runInSandbox(leaked)).toThrow(/LEAKED_FROM_MODULE_SCOPE/)
+  })
+
+  it('returns the expected snapshot shape', () => {
+    const snapshot = runInSandbox(collectSnapshot.toString()) as any
+    expect(snapshot).toHaveProperty('slides')
+    expect(snapshot).toHaveProperty('styles')
+    expect(snapshot).toHaveProperty('fontResolution')
+  })
+
+  it('carries no bundler-injected identifiers', () => {
+    // tsdown and Vite rewrite bodies with helpers such as `__toESM`,
+    // `__publicField` or `__name`, none of which exist in the page.
+    expect(collectSnapshot.toString().match(/\b__\w+/g)).toBeNull()
+  })
+
+  it('does not reference the module registry', () => {
+    const source = collectSnapshot.toString()
+    for (const forbidden of ['require(', 'import(', 'exports.', 'module.exports'])
+      expect(source).not.toContain(forbidden)
+  })
+})

--- a/packages/slidev/node/commands/pptx/walker.ts
+++ b/packages/slidev/node/commands/pptx/walker.ts
@@ -343,12 +343,22 @@ export function collectSnapshot(options: {
       el.setAttribute(options.idAttribute, String(id))
       resolveStack(computed.fontFamily)
 
+      const box = el.getBoundingClientRect()
       const record: any = {
         id,
         parent,
         tag: el.tagName.toUpperCase(),
         style: internStyle(el),
-        rect: relative(el.getBoundingClientRect()),
+        rect: relative(box),
+        // Document coordinates too. An element that overflows the slide is
+        // captured as a page clip rather than as itself, and the clip needs a
+        // page-space rectangle.
+        pageRect: {
+          x: box.left + window.scrollX,
+          y: box.top + window.scrollY,
+          w: box.width,
+          h: box.height,
+        },
       }
       if (effectiveOpacity < 1)
         record.opacity = effectiveOpacity

--- a/packages/slidev/node/commands/pptx/walker.ts
+++ b/packages/slidev/node/commands/pptx/walker.ts
@@ -1,21 +1,14 @@
-import type { RawSnapshot } from './ir'
+import type { RawNode, RawSlide, RawSnapshot, RawStyle } from './ir'
 
 /**
- * The one function that runs inside the browser.
+ * The one function that runs inside the browser. Invariant: zero free variables.
+ * Playwright serializes this function's source and evaluates it where none of this
+ * module's imports exist, so everything it needs is nested inside it or passed as a
+ * parameter; `walker.test.ts` enforces this mechanically. The type-only import above
+ * is erased at compile time and is safe.
  *
- * INVARIANT: zero free variables. Everything it needs is nested inside it or
- * passed as a parameter, because Playwright serialises this function's source
- * and evaluates it in a context where none of this module's imports exist.
- * `walker.test.ts` enforces this mechanically; do not rely on remembering it.
- *
- * The type-only import above is erased at compile time and is therefore safe.
- *
- * It is also deliberately DUMB. It extracts facts that only a live layout
- * engine can supply, and makes no decisions at all. Every judgement - what is
- * a paragraph, what has to be rasterized, what colour that really is - lives
- * in `normalize.ts` on the Node side, where it can be unit-tested against a
- * hand-written fixture. An earlier version of this design put ~340 lines of
- * decision-making in here and none of it could be tested.
+ * It extracts facts only a live layout engine can supply and makes no decisions;
+ * every judgement lives in `normalize.ts`, where it can be unit-tested.
  */
 export function collectSnapshot(options: {
   containerSelector: string
@@ -72,18 +65,18 @@ export function collectSnapshot(options: {
     'overflow',
   ] as const
 
-  const styles: any[] = []
+  /** Strips the quotes CSS keeps around a `content` or font family value. */
+  const RE_QUOTES = /^["']|["']$/g
+
+  const styles: RawStyle[] = []
   const styleIndex = new Map<string, number>()
 
   /**
-   * Intern a computed style.
-   *
-   * `getComputedStyle` exposes several hundred properties and a slide has a few
-   * hundred nodes, so serialising a full style per node is what turns a
-   * snapshot into megabytes crossing the CDP boundary. In practice a few
-   * hundred nodes collapse to a few dozen distinct styles.
+   * Intern a computed style: `getComputedStyle` exposes several hundred properties,
+   * so serializing a full style per node turns a snapshot into megabytes crossing
+   * the CDP boundary. A few hundred nodes collapse to a few dozen distinct styles.
    */
-  function internPseudo(computed: CSSStyleDeclaration): number {
+  function intern(computed: CSSStyleDeclaration): number {
     const record: Record<string, string> = {}
     for (const key of STYLE_KEYS)
       record[key] = computed[key as any] ?? ''
@@ -92,34 +85,16 @@ export function collectSnapshot(options: {
     if (existing !== undefined)
       return existing
     const index = styles.length
-    styles.push(record)
-    styleIndex.set(key, index)
-    return index
-  }
-
-  function internStyle(el: Element): number {
-    const computed = getComputedStyle(el)
-    const record: Record<string, string> = {}
-    for (const key of STYLE_KEYS)
-      record[key] = computed[key as any] ?? ''
-    const key = JSON.stringify(record)
-    const existing = styleIndex.get(key)
-    if (existing !== undefined)
-      return existing
-    const index = styles.length
-    styles.push(record)
+    // Complete by construction: every `RawStyle` key comes from `STYLE_KEYS`.
+    styles.push(record as unknown as RawStyle)
     styleIndex.set(key, index)
     return index
   }
 
   /**
-   * Which family a CSS font stack actually resolves to on this machine.
-   *
-   * Measured by rendering a probe string and comparing widths, because
-   * `document.fonts.check()` returns TRUE for families that do not exist. A
-   * deck whose CSS leads with a licensed corporate face would otherwise name
-   * that face in the file, and every recipient would silently get a
-   * substitution while the export claimed success.
+   * Which family a CSS font stack actually resolves to on this machine, measured by
+   * rendering a probe string and comparing widths: `document.fonts.check()` returns
+   * true for families that do not exist.
    */
   const unplaceablePseudos: string[] = []
   const fontResolution: Record<string, string> = {}
@@ -136,17 +111,15 @@ export function collectSnapshot(options: {
   function isAvailable(family: string): boolean {
     for (const base of BASES) {
       probeContext.font = `72px "${family}", ${base}`
-      // A family that does not exist falls through to the base, so an
-      // identical width against EVERY base means it never took effect.
+      // A missing family falls through to the base, so an identical width
+      // against every base means it never took effect.
       if (probeContext.measureText(PROBE).width !== baseWidths[base])
         return true
     }
     return false
   }
 
-  // CSS keywords, not typefaces. Naming one of these in a .pptx asks
-  // PowerPoint for a font called "system-ui", which does not exist anywhere,
-  // so it substitutes its own default and the deck sets in something arbitrary.
+  // CSS keywords, not typefaces; naming one in a .pptx makes PowerPoint substitute its default.
   const GENERIC = [
     'system-ui',
     'ui-sans-serif',
@@ -170,13 +143,13 @@ export function collectSnapshot(options: {
     if (stack in fontResolution)
       return
     for (const raw of stack.split(',')) {
-      const family = raw.trim().replace(/^["']|["']$/g, '')
+      const family = raw.trim().replace(RE_QUOTES, '')
       if (!family)
         continue
       if (GENERIC.includes(family.toLowerCase()) || family.charAt(0) === '-')
         continue
-      // `@fontsource-variable` names its family "Inter Variable", which nobody
-      // has installed under that name. The face people actually have is "Inter".
+      // `@fontsource-variable` names its family "Inter Variable"; the face
+      // people actually have installed is "Inter".
       const cleaned = family.replace(/\s+Variable$/, '')
       if (isAvailable(cleaned)) {
         fontResolution[stack] = cleaned
@@ -187,21 +160,13 @@ export function collectSnapshot(options: {
   }
 
   /**
-   * The nearest painted background colour at or above the slide container.
-   *
-   * Slidev puts `bg-main` on an ancestor rather than on the container itself
-   * depending on the theme, so the first non-transparent colour up the chain is
-   * what the audience actually sees behind the slide.
+   * The nearest painted background color at or above the slide container; themes
+   * can put `bg-main` on an ancestor rather than on the container itself.
    */
   function backgroundOf(container: Element): string | undefined {
-    // Any FULLY transparent colour ends nothing and the walk continues past
-    // it. Matching only the literal `rgba(0, 0, 0, 0)` stopped on
-    // `rgba(255, 255, 255, 0)`, and on the `oklch(... / 0)` a theme authored
-    // in modern syntax computes to, and returned it as the slide background:
-    // the real painted colour further up was then never found at all.
-    //
-    // Read by asking the browser rather than by parsing, because the browser
-    // is what produced the string and knows every syntax it accepts.
+    // Any fully transparent color ends nothing: matching only the literal
+    // `rgba(0, 0, 0, 0)` misses `rgba(255, 255, 255, 0)` and `oklch(... / 0)`.
+    // The browser judges, since it accepts syntaxes no parser here does.
     const probe = document.createElement('canvas').getContext('2d')
     let node: Element | null = container
     while (node) {
@@ -209,8 +174,7 @@ export function collectSnapshot(options: {
       if (color && color !== 'transparent') {
         if (!probe)
           return color
-        // Painting over an opaque backdrop leaves it untouched only when the
-        // colour contributes nothing at all.
+        // Painting over an opaque backdrop leaves it untouched only when the color contributes nothing.
         probe.clearRect(0, 0, 1, 1)
         probe.fillStyle = color
         probe.fillRect(0, 0, 1, 1)
@@ -223,11 +187,8 @@ export function collectSnapshot(options: {
   }
 
   /**
-   * The text an ordinary list marker renders, which the DOM never exposes.
-   *
-   * Ordered lists need the item's ordinal, counted over previous list-item
-   * siblings and offset by the list's `start`, because the marker is a
-   * generated glyph rather than content.
+   * The text an ordinary list marker renders, which the DOM never exposes; ordered
+   * lists need the ordinal counted over previous list-item siblings.
    */
   function markerGlyph(el: Element, listStyleType: string): string {
     const BULLETS: Record<string, string> = {
@@ -261,20 +222,14 @@ export function collectSnapshot(options: {
   }
 
   const containers = Array.from(document.querySelectorAll(options.containerSelector))
-  const slides: any[] = []
+  const slides: RawSlide[] = []
   let nextId = 0
 
   for (const container of containers) {
     const containerRect = container.getBoundingClientRect()
 
-    // A print page stacks every slide into one tall viewport, so a container
-    // that is not being rendered has a zero-sized rect.
-    //
-    // Note that this does NOT implement `--range`. It does not need to: `go`
-    // puts the range in the query and `PrintContainer` renders `v-for="no of
-    // printRange"`, so an out-of-range slide is never in the DOM at all. The
-    // caller filters by slide number anyway, exactly as the image exporter
-    // does, because neither of them should depend on the print route to do it.
+    // A print page stacks every slide into one tall viewport; a container not
+    // being rendered has a zero-sized rect. `--range` is the caller's filter.
     if (containerRect.width === 0 || containerRect.height === 0)
       continue
 
@@ -285,7 +240,7 @@ export function collectSnapshot(options: {
     if (!Number.isFinite(no))
       continue
 
-    const nodes: any[] = []
+    const nodes: RawNode[] = []
 
     function relative(rect: DOMRect | { left: number, top: number, width: number, height: number }) {
       return {
@@ -299,28 +254,23 @@ export function collectSnapshot(options: {
     function walk(node: Node, parent: number, fromShadowRoot: boolean, inheritedOpacity: number): void {
       if (node.nodeType === 3) {
         const text = node.textContent ?? ''
-        // A whitespace-only node is NOT noise. Markup such as
-        // `<span>Hello</span> <span>World</span>` puts the only space between
-        // the two words in its own text node, and dropping it exports
-        // "HelloWorld". Kept when it actually occupies a line box; a collapsed
-        // space between block elements has no rects and is correctly ignored.
+        // A whitespace-only node can hold the only space between two inline
+        // elements; kept when it occupies a line box, ignored when collapsed.
         if (!text)
           return
         const range = document.createRange()
         range.selectNodeContents(node)
         const rects = Array.from(range.getClientRects())
         range.detach()
-        // A node with no boxes is still reported. A newline inside a
-        // `white-space: pre` block is exactly that, and it is the only record
-        // of where one line of a code block ends and the next begins.
+        // A rect-less node still matters when it holds a newline: inside
+        // `white-space: pre` it is the only record of where a line ends.
         if (!rects.length) {
           if (!text.includes('\n'))
             return
           nodes.push({ id: nextId++, parent, tag: '#text', style: -1, rect: { x: 0, y: 0, w: 0, h: 0 }, glyphRects: [], text })
           return
         }
-        // Glyph rects, not the element box. A text box positioned from the
-        // element rect lands offset by the padding and re-wraps.
+        // Glyph rects, not the element box: positioned from the element rect the text lands offset and re-wraps.
         const bounds = {
           left: Math.min(...rects.map(r => r.left)),
           top: Math.min(...rects.map(r => r.top)),
@@ -335,9 +285,7 @@ export function collectSnapshot(options: {
           rect: relative(bounds),
           glyphRects: rects.map(relative),
           text,
-          // A text node has no style of its own, but it does inherit the
-          // opacity compounded down the tree. Without this every run lost it,
-          // and a paragraph greyed by `opacity` exported solid black.
+          // A text node inherits the compounded opacity; without it a greyed paragraph exports solid.
           ...(inheritedOpacity < 1 ? { opacity: inheritedOpacity } : {}),
         })
         return
@@ -350,17 +298,13 @@ export function collectSnapshot(options: {
       const id = nextId++
       const computed = getComputedStyle(el)
 
-      // `display: none` has no box at all; `visibility: hidden` and
-      // `opacity: 0` do. In `print=clicks` mode a not-yet-revealed v-click
-      // element sits in the DOM at opacity 0, and without this it would be
-      // exported onto every click step of the slide.
+      // `visibility: hidden` and `opacity: 0` still have boxes: a not-yet-revealed
+      // v-click element sits at opacity 0 and would export onto every click step.
       if (computed.display === 'none' || computed.visibility === 'hidden')
         return
       const own = Number(computed.opacity)
-      // CSS `opacity` does NOT inherit: a child of a half-transparent wrapper
-      // computes 1 and would export fully opaque, because DrawingML has no
-      // group opacity to stand in for the wrapper. So it is compounded here,
-      // where the tree is still available.
+      // CSS `opacity` does not inherit, and DrawingML has no group opacity to stand
+      // in for a wrapper's, so it is compounded here while the tree is available.
       const effectiveOpacity = inheritedOpacity * (Number.isFinite(own) ? own : 1)
       if (effectiveOpacity === 0)
         return
@@ -369,15 +313,14 @@ export function collectSnapshot(options: {
       resolveStack(computed.fontFamily)
 
       const box = el.getBoundingClientRect()
-      const record: any = {
+      const record: RawNode = {
         id,
         parent,
         tag: el.tagName.toUpperCase(),
-        style: internStyle(el),
+        style: intern(computed),
         rect: relative(box),
-        // Document coordinates too. An element that overflows the slide is
-        // captured as a page clip rather than as itself, and the clip needs a
-        // page-space rectangle.
+        // Document coordinates too: an element overflowing the slide is
+        // captured as a page clip, which needs a page-space rectangle.
         pageRect: {
           x: box.left + window.scrollX,
           y: box.top + window.scrollY,
@@ -387,10 +330,8 @@ export function collectSnapshot(options: {
       }
       if (effectiveOpacity < 1)
         record.opacity = effectiveOpacity
-      // An inline box that wraps is painted once per line, so its background
-      // and borders belong to the fragments rather than to the union rect
-      // `getBoundingClientRect` reports. Only `inline` proper: an inline-block
-      // is a single box that merely sits in a line, and always has one rect.
+      // An inline box that wraps paints once per line, so backgrounds belong to
+      // the fragments. Only `inline` proper: an inline-block has one rect.
       if (computed.display === 'inline') {
         const fragments = Array.from(el.getClientRects())
         if (fragments.length > 1)
@@ -398,9 +339,7 @@ export function collectSnapshot(options: {
       }
       if (fromShadowRoot)
         record.fromShadowRoot = true
-      // KaTeX's own root. Detected by class because that is what it emits;
-      // there is no tag, and the MathML it also writes for screen readers is
-      // display:none, so it never reaches the walk.
+      // KaTeX marks its root by class; the MathML it writes for screen readers is display:none.
       if (el.classList.contains('katex'))
         record.isMath = true
       if (el.tagName.toUpperCase() === 'IMG') {
@@ -415,25 +354,20 @@ export function collectSnapshot(options: {
           record.href = href
       }
       if (el.tagName.toUpperCase() === 'SVG' && el.querySelector('foreignObject'))
-        // Mermaid puts its node labels in <foreignObject> HTML with no <text>
-        // element, so no PowerPoint renderer draws them. The normalizer routes
-        // these to a picture instead of an empty diagram.
+        // Mermaid puts its labels in <foreignObject> HTML with no <text>
+        // element; the normalizer routes these to a picture.
         record.hasForeignObject = true
 
-      // `::marker` is a pseudo-element, so a list bullet has no text node and a
-      // plain DOM walk drops every bullet glyph in the deck.
-      //
-      // Reading `content` alone is not enough: for an ordinary `<ul>` or `<ol>`
-      // Chromium reports it as `normal` and leaves the glyph to
-      // `list-style-type`, so a check for a non-normal `content` recovers ONLY
-      // custom markers and still loses every default bullet in the deck.
+      // `::marker` is a pseudo-element, so a bullet has no text node. Reading
+      // `content` alone recovers only custom markers: Chromium reports it as
+      // `normal` for ordinary lists and leaves the glyph to `list-style-type`.
       if (computed.display === 'list-item') {
         const marker = getComputedStyle(el, '::marker')
         const explicit = marker && marker.content
           && marker.content !== 'none'
           && marker.content !== 'normal'
         if (explicit) {
-          record.marker = marker.content.replace(/^["']|["']$/g, '')
+          record.marker = marker.content.replace(RE_QUOTES, '')
         }
         else if (computed.listStyleType !== 'none') {
           record.marker = markerGlyph(el, computed.listStyleType)
@@ -442,15 +376,9 @@ export function collectSnapshot(options: {
 
       nodes.push(record)
 
-      // `::before` and `::after` have no DOM node, so a walk over the tree
-      // cannot see them at all. Themes use them for decorative marks - the one
-      // that prompted this was a corporate logo drawn as a background image on
-      // an `::after` - and every one of those was silently missing from the
-      // export.
-      //
-      // Only absolutely positioned pseudos are placeable: their box resolves
-      // against the originating element when it is itself positioned. Anything
-      // else takes part in inline or block flow, where its geometry is not
+      // `::before` and `::after` have no DOM node, so a tree walk cannot see
+      // them, and themes use them for decorative marks. Only absolutely
+      // positioned pseudos are placeable: anything in flow has geometry not
       // recoverable from computed style alone, and is reported instead.
       for (const which of ['::before', '::after']) {
         const pseudo = getComputedStyle(el, which)
@@ -472,11 +400,9 @@ export function collectSnapshot(options: {
           unplaceablePseudos.push(`${el.tagName.toLowerCase()}${which}`)
           continue
         }
-        // `auto` on the opposite side too parses to NaN, which spreads through
-        // the whole `pageRect` and loses the decoration to a failed clip with
-        // nothing in the log naming it. Zero is what `auto` resolves to for an
-        // absolutely positioned box with no other constraint, so it degrades
-        // to a placed decoration rather than a missing one.
+        // `auto` parses to NaN, which spreads through the whole `pageRect` and
+        // loses the decoration to a failed clip. Zero is what `auto` resolves
+        // to for an absolutely positioned box with no other constraint.
         const px = (value: string): number => Number.parseFloat(value) || 0
         const left = pseudo.left === 'auto'
           ? own.width - px(pseudo.right) - width
@@ -491,42 +417,36 @@ export function collectSnapshot(options: {
           width,
           height,
         }
-        // DOCUMENT coordinates, not viewport ones. A clip screenshot is taken
-        // later, after other captures have scrolled the page, and the print
-        // route is far taller than the viewport once every click step has its
-        // own container. Viewport coordinates read at measurement time are
-        // stale by then, and Playwright answers "clipped area is empty",
-        // which the caller swallows and the decoration vanishes.
+        // Document coordinates, not viewport ones: the clip screenshot is taken
+        // after other captures have scrolled the page, so viewport coordinates
+        // read at measurement time are stale by then.
         const pageRect = {
           x: box.left + window.scrollX,
           y: box.top + window.scrollY,
           w: width,
           h: height,
         }
-        const text = pseudo.content.replace(/^["']|["']$/g, '')
+        const text = pseudo.content.replace(RE_QUOTES, '')
         nodes.push({
           id: nextId++,
           parent: id,
           tag: which === '::before' ? '::BEFORE' : '::AFTER',
-          style: internPseudo(pseudo),
+          style: intern(pseudo),
           rect: relative(box),
-          // Page coordinates as well: a pseudo has no element to point a
-          // screenshot at, so it is captured by clipping the page instead.
+          // A pseudo has no element to screenshot, so it is captured by clipping the page.
           pageRect,
           ...(text && pseudo.content !== 'normal' ? { text } : {}),
         })
       }
 
-      // Descend into the shadow root BEFORE the light children. Mermaid
-      // renders into one, so `querySelector('.mermaid svg')` from the document
-      // finds nothing at all.
+      // Descend into the shadow root as well; Mermaid renders into one.
       const shadow = (el as any).shadowRoot
       if (shadow) {
         for (const child of Array.from(shadow.childNodes) as Node[])
           walk(child, id, true, effectiveOpacity)
       }
 
-      // Recurse through zero-sized boxes rather than pruning them. A cover
+      // Recurse through zero-sized boxes rather than pruning them: a cover
       // slide commonly hangs its title off a wrapper that measures 0 high.
       for (const child of Array.from(el.childNodes) as Node[])
         walk(child, id, fromShadowRoot, effectiveOpacity)
@@ -538,15 +458,12 @@ export function collectSnapshot(options: {
     slides.push({
       no,
       clickIndex: Number.isFinite(clickIndex) ? clickIndex : 0,
-      // The exact id, not a pattern rebuilt from `no`. With `--with-clicks` a
-      // slide has one container per step, and a prefix match plus `.first()`
+      // The exact id: with `--with-clicks` a prefix match plus `.first()`
       // hands every step a picture of step one.
       containerId: container.id,
       size: { w: containerRect.width, h: containerRect.height },
-      // The slide's own background, which lives on the container and so is
-      // never reached by a walk that starts at its children. Without it every
-      // slide exports onto PowerPoint's default white, which on a dark theme
-      // is light text on a white page.
+      // The container's own background is never reached by a walk that starts
+      // at its children; without it a dark theme exports onto default white.
       background: backgroundOf(container),
       nodes,
     })

--- a/packages/slidev/node/commands/pptx/walker.ts
+++ b/packages/slidev/node/commands/pptx/walker.ts
@@ -378,6 +378,11 @@ export function collectSnapshot(options: {
       }
       if (fromShadowRoot)
         record.fromShadowRoot = true
+      // KaTeX's own root. Detected by class because that is what it emits;
+      // there is no tag, and the MathML it also writes for screen readers is
+      // display:none, so it never reaches the walk.
+      if (el.classList.contains('katex'))
+        record.isMath = true
       if (el.tagName.toUpperCase() === 'IMG') {
         record.src = (el as HTMLImageElement).currentSrc || (el as HTMLImageElement).src
         const alt = (el as HTMLImageElement).alt

--- a/packages/slidev/node/commands/pptx/walker.ts
+++ b/packages/slidev/node/commands/pptx/walker.ts
@@ -314,6 +314,10 @@ export function collectSnapshot(options: {
           rect: relative(bounds),
           glyphRects: rects.map(relative),
           text,
+          // A text node has no style of its own, but it does inherit the
+          // opacity compounded down the tree. Without this every run lost it,
+          // and a paragraph greyed by `opacity` exported solid black.
+          ...(inheritedOpacity < 1 ? { opacity: inheritedOpacity } : {}),
         })
         return
       }

--- a/packages/slidev/node/commands/pptx/walker.ts
+++ b/packages/slidev/node/commands/pptx/walker.ts
@@ -149,9 +149,14 @@ export function collectSnapshot(options: {
       if (GENERIC.includes(family.toLowerCase()) || family.charAt(0) === '-')
         continue
       // `@fontsource-variable` names its family "Inter Variable"; the face
-      // people actually have installed is "Inter".
+      // people actually have installed is "Inter". So the stack is probed
+      // under the name the page really registered, and only the name written
+      // into the file is stripped. Testing the stripped name first finds
+      // nothing whenever the theme ships the font as a webfont and the machine
+      // has no static copy, which is the usual case, and the whole deck then
+      // falls through to a system face the author never chose.
       const cleaned = family.replace(/\s+Variable$/, '')
-      if (isAvailable(cleaned)) {
+      if (isAvailable(family) || isAvailable(cleaned)) {
         fontResolution[stack] = cleaned
         return
       }

--- a/packages/slidev/node/commands/pptx/walker.ts
+++ b/packages/slidev/node/commands/pptx/walker.ts
@@ -262,10 +262,14 @@ export function collectSnapshot(options: {
         range.selectNodeContents(node)
         const rects = Array.from(range.getClientRects())
         range.detach()
-        // A rect-less node still matters when it holds a newline: inside
-        // `white-space: pre` it is the only record of where a line ends.
+        // A rect-less node still matters twice over: inside `white-space: pre`
+        // a newline is the only record of where a line ends, and a
+        // whitespace-only node is the only record that two inline elements are
+        // separated at all. Chromium reports no rect for the space between two
+        // inline-blocks, and without it `<kbd>shift</kbd> <kbd>space</kbd>`
+        // came out as "shiftspace".
         if (!rects.length) {
-          if (!text.includes('\n'))
+          if (text.trim())
             return
           nodes.push({ id: nextId++, parent, tag: '#text', style: -1, rect: { x: 0, y: 0, w: 0, h: 0 }, glyphRects: [], text })
           return

--- a/packages/slidev/node/commands/pptx/walker.ts
+++ b/packages/slidev/node/commands/pptx/walker.ts
@@ -62,6 +62,12 @@ export function collectSnapshot(options: {
     'transform',
     'writingMode',
     'webkitBackgroundClip',
+    'top',
+    'right',
+    'bottom',
+    'left',
+    'width',
+    'height',
     'overflow',
   ] as const
 
@@ -76,6 +82,20 @@ export function collectSnapshot(options: {
    * snapshot into megabytes crossing the CDP boundary. In practice a few
    * hundred nodes collapse to a few dozen distinct styles.
    */
+  function internPseudo(computed: CSSStyleDeclaration): number {
+    const record: Record<string, string> = {}
+    for (const key of STYLE_KEYS)
+      record[key] = computed[key as any] ?? ''
+    const key = JSON.stringify(record)
+    const existing = styleIndex.get(key)
+    if (existing !== undefined)
+      return existing
+    const index = styles.length
+    styles.push(record)
+    styleIndex.set(key, index)
+    return index
+  }
+
   function internStyle(el: Element): number {
     const computed = getComputedStyle(el)
     const record: Record<string, string> = {}
@@ -100,6 +120,7 @@ export function collectSnapshot(options: {
    * that face in the file, and every recipient would silently get a
    * substitution while the export claimed success.
    */
+  const unplaceablePseudos: string[] = []
   const fontResolution: Record<string, string> = {}
   const probeCanvas = document.createElement('canvas')
   const probeContext = probeCanvas.getContext('2d')!
@@ -357,6 +378,63 @@ export function collectSnapshot(options: {
 
       nodes.push(record)
 
+      // `::before` and `::after` have no DOM node, so a walk over the tree
+      // cannot see them at all. Themes use them for decorative marks - the one
+      // that prompted this was a corporate logo drawn as a background image on
+      // an `::after` - and every one of those was silently missing from the
+      // export.
+      //
+      // Only absolutely positioned pseudos are placeable: their box resolves
+      // against the originating element when it is itself positioned. Anything
+      // else takes part in inline or block flow, where its geometry is not
+      // recoverable from computed style alone, and is reported instead.
+      for (const which of ['::before', '::after']) {
+        const pseudo = getComputedStyle(el, which)
+        if (!pseudo || !pseudo.content || pseudo.content === 'none')
+          continue
+        const paints = pseudo.content !== 'normal'
+          || (pseudo.backgroundImage && pseudo.backgroundImage !== 'none')
+        if (!paints)
+          continue
+        if (pseudo.position !== 'absolute' || computed.position === 'static') {
+          unplaceablePseudos.push(`${el.tagName.toLowerCase()}${which}`)
+          continue
+        }
+
+        const own = el.getBoundingClientRect()
+        const width = Number.parseFloat(pseudo.width) || 0
+        const height = Number.parseFloat(pseudo.height) || 0
+        if (width <= 0 || height <= 0) {
+          unplaceablePseudos.push(`${el.tagName.toLowerCase()}${which}`)
+          continue
+        }
+        const left = pseudo.left === 'auto'
+          ? own.width - Number.parseFloat(pseudo.right || '0') - width
+          : Number.parseFloat(pseudo.left)
+        const top = pseudo.top === 'auto'
+          ? own.height - Number.parseFloat(pseudo.bottom || '0') - height
+          : Number.parseFloat(pseudo.top)
+
+        const box = {
+          left: own.left + left,
+          top: own.top + top,
+          width,
+          height,
+        }
+        const text = pseudo.content.replace(/^["']|["']$/g, '')
+        nodes.push({
+          id: nextId++,
+          parent: id,
+          tag: which === '::before' ? '::BEFORE' : '::AFTER',
+          style: internPseudo(pseudo),
+          rect: relative(box),
+          // Page coordinates as well: a pseudo has no element to point a
+          // screenshot at, so it is captured by clipping the page instead.
+          pageRect: { x: box.left, y: box.top, w: width, h: height },
+          ...(text && pseudo.content !== 'normal' ? { text } : {}),
+        })
+      }
+
       // Descend into the shadow root BEFORE the light children. Mermaid
       // renders into one, so `querySelector('.mermaid svg')` from the document
       // finds nothing at all.
@@ -392,5 +470,5 @@ export function collectSnapshot(options: {
     })
   }
 
-  return { slides, styles, fontResolution } as RawSnapshot
+  return { slides, styles, fontResolution, unplaceablePseudos } as RawSnapshot
 }

--- a/packages/slidev/node/commands/pptx/walker.ts
+++ b/packages/slidev/node/commands/pptx/walker.ts
@@ -194,11 +194,29 @@ export function collectSnapshot(options: {
    * what the audience actually sees behind the slide.
    */
   function backgroundOf(container: Element): string | undefined {
+    // Any FULLY transparent colour ends nothing and the walk continues past
+    // it. Matching only the literal `rgba(0, 0, 0, 0)` stopped on
+    // `rgba(255, 255, 255, 0)`, and on the `oklch(... / 0)` a theme authored
+    // in modern syntax computes to, and returned it as the slide background:
+    // the real painted colour further up was then never found at all.
+    //
+    // Read by asking the browser rather than by parsing, because the browser
+    // is what produced the string and knows every syntax it accepts.
+    const probe = document.createElement('canvas').getContext('2d')
     let node: Element | null = container
     while (node) {
       const color = getComputedStyle(node).backgroundColor
-      if (color && color !== 'transparent' && !/^rgba\(\s*0,\s*0,\s*0,\s*0\s*\)$/.test(color))
-        return color
+      if (color && color !== 'transparent') {
+        if (!probe)
+          return color
+        // Painting over an opaque backdrop leaves it untouched only when the
+        // colour contributes nothing at all.
+        probe.clearRect(0, 0, 1, 1)
+        probe.fillStyle = color
+        probe.fillRect(0, 0, 1, 1)
+        if (probe.getImageData(0, 0, 1, 1).data[3] !== 0)
+          return color
+      }
       node = node.parentElement
     }
     return undefined
@@ -252,9 +270,11 @@ export function collectSnapshot(options: {
     // A print page stacks every slide into one tall viewport, so a container
     // that is not being rendered has a zero-sized rect.
     //
-    // Note that this does NOT implement `--range`: the print route renders
-    // every slide whatever the `range` query says, so the caller filters by
-    // slide number, exactly as the image exporter does.
+    // Note that this does NOT implement `--range`. It does not need to: `go`
+    // puts the range in the query and `PrintContainer` renders `v-for="no of
+    // printRange"`, so an out-of-range slide is never in the DOM at all. The
+    // caller filters by slide number anyway, exactly as the image exporter
+    // does, because neither of them should depend on the print route to do it.
     if (containerRect.width === 0 || containerRect.height === 0)
       continue
 
@@ -452,12 +472,18 @@ export function collectSnapshot(options: {
           unplaceablePseudos.push(`${el.tagName.toLowerCase()}${which}`)
           continue
         }
+        // `auto` on the opposite side too parses to NaN, which spreads through
+        // the whole `pageRect` and loses the decoration to a failed clip with
+        // nothing in the log naming it. Zero is what `auto` resolves to for an
+        // absolutely positioned box with no other constraint, so it degrades
+        // to a placed decoration rather than a missing one.
+        const px = (value: string): number => Number.parseFloat(value) || 0
         const left = pseudo.left === 'auto'
-          ? own.width - Number.parseFloat(pseudo.right || '0') - width
-          : Number.parseFloat(pseudo.left)
+          ? own.width - px(pseudo.right) - width
+          : px(pseudo.left)
         const top = pseudo.top === 'auto'
-          ? own.height - Number.parseFloat(pseudo.bottom || '0') - height
-          : Number.parseFloat(pseudo.top)
+          ? own.height - px(pseudo.bottom) - height
+          : px(pseudo.top)
 
         const box = {
           left: own.left + left,

--- a/packages/slidev/node/commands/pptx/walker.ts
+++ b/packages/slidev/node/commands/pptx/walker.ts
@@ -39,6 +39,8 @@ export function collectSnapshot(options: {
     'letterSpacing',
     'lineHeight',
     'whiteSpace',
+    'paddingLeft',
+    'paddingRight',
     'borderTopWidth',
     'borderTopStyle',
     'borderTopColor',

--- a/packages/slidev/node/commands/pptx/walker.ts
+++ b/packages/slidev/node/commands/pptx/walker.ts
@@ -1,0 +1,394 @@
+import type { RawSnapshot } from './ir'
+
+/**
+ * The one function that runs inside the browser.
+ *
+ * INVARIANT: zero free variables. Everything it needs is nested inside it or
+ * passed as a parameter, because Playwright serialises this function's source
+ * and evaluates it in a context where none of this module's imports exist.
+ * `walker.test.ts` enforces this mechanically; do not rely on remembering it.
+ *
+ * The type-only import above is erased at compile time and is therefore safe.
+ *
+ * It is also deliberately DUMB. It extracts facts that only a live layout
+ * engine can supply, and makes no decisions at all. Every judgement - what is
+ * a paragraph, what has to be rasterized, what colour that really is - lives
+ * in `normalize.ts` on the Node side, where it can be unit-tested against a
+ * hand-written fixture. An earlier version of this design put ~340 lines of
+ * decision-making in here and none of it could be tested.
+ */
+export function collectSnapshot(options: {
+  containerSelector: string
+  idAttribute: string
+}): RawSnapshot {
+  const STYLE_KEYS = [
+    'display',
+    'position',
+    'visibility',
+    'opacity',
+    'color',
+    'backgroundColor',
+    'backgroundImage',
+    'fontFamily',
+    'fontSize',
+    'fontWeight',
+    'fontStyle',
+    'textAlign',
+    'textDecorationLine',
+    'textTransform',
+    'letterSpacing',
+    'lineHeight',
+    'whiteSpace',
+    'borderTopWidth',
+    'borderTopStyle',
+    'borderTopColor',
+    'borderRightWidth',
+    'borderRightStyle',
+    'borderRightColor',
+    'borderBottomWidth',
+    'borderBottomStyle',
+    'borderBottomColor',
+    'borderLeftWidth',
+    'borderLeftStyle',
+    'borderLeftColor',
+    'borderTopLeftRadius',
+    'boxShadow',
+    'filter',
+    'backdropFilter',
+    'mixBlendMode',
+    'clipPath',
+    'transform',
+    'writingMode',
+    'webkitBackgroundClip',
+    'overflow',
+  ] as const
+
+  const styles: any[] = []
+  const styleIndex = new Map<string, number>()
+
+  /**
+   * Intern a computed style.
+   *
+   * `getComputedStyle` exposes several hundred properties and a slide has a few
+   * hundred nodes, so serialising a full style per node is what turns a
+   * snapshot into megabytes crossing the CDP boundary. In practice a few
+   * hundred nodes collapse to a few dozen distinct styles.
+   */
+  function internStyle(el: Element): number {
+    const computed = getComputedStyle(el)
+    const record: Record<string, string> = {}
+    for (const key of STYLE_KEYS)
+      record[key] = computed[key as any] ?? ''
+    const key = JSON.stringify(record)
+    const existing = styleIndex.get(key)
+    if (existing !== undefined)
+      return existing
+    const index = styles.length
+    styles.push(record)
+    styleIndex.set(key, index)
+    return index
+  }
+
+  /**
+   * Which family a CSS font stack actually resolves to on this machine.
+   *
+   * Measured by rendering a probe string and comparing widths, because
+   * `document.fonts.check()` returns TRUE for families that do not exist. A
+   * deck whose CSS leads with a licensed corporate face would otherwise name
+   * that face in the file, and every recipient would silently get a
+   * substitution while the export claimed success.
+   */
+  const fontResolution: Record<string, string> = {}
+  const probeCanvas = document.createElement('canvas')
+  const probeContext = probeCanvas.getContext('2d')!
+  const PROBE = 'mmmmmmmmmmlliWWWWWW0Oo'
+  const BASES = ['monospace', 'sans-serif', 'serif']
+  const baseWidths: Record<string, number> = {}
+  for (const base of BASES) {
+    probeContext.font = `72px ${base}`
+    baseWidths[base] = probeContext.measureText(PROBE).width
+  }
+
+  function isAvailable(family: string): boolean {
+    for (const base of BASES) {
+      probeContext.font = `72px "${family}", ${base}`
+      // A family that does not exist falls through to the base, so an
+      // identical width against EVERY base means it never took effect.
+      if (probeContext.measureText(PROBE).width !== baseWidths[base])
+        return true
+    }
+    return false
+  }
+
+  // CSS keywords, not typefaces. Naming one of these in a .pptx asks
+  // PowerPoint for a font called "system-ui", which does not exist anywhere,
+  // so it substitutes its own default and the deck sets in something arbitrary.
+  const GENERIC = [
+    'system-ui',
+    'ui-sans-serif',
+    'ui-serif',
+    'ui-monospace',
+    'ui-rounded',
+    'sans-serif',
+    'serif',
+    'monospace',
+    'cursive',
+    'fantasy',
+    'math',
+    'emoji',
+    'fangsong',
+    'inherit',
+    'initial',
+    'unset',
+  ]
+
+  function resolveStack(stack: string): void {
+    if (stack in fontResolution)
+      return
+    for (const raw of stack.split(',')) {
+      const family = raw.trim().replace(/^["']|["']$/g, '')
+      if (!family)
+        continue
+      if (GENERIC.includes(family.toLowerCase()) || family.charAt(0) === '-')
+        continue
+      // `@fontsource-variable` names its family "Inter Variable", which nobody
+      // has installed under that name. The face people actually have is "Inter".
+      const cleaned = family.replace(/\s+Variable$/, '')
+      if (isAvailable(cleaned)) {
+        fontResolution[stack] = cleaned
+        return
+      }
+    }
+    fontResolution[stack] = ''
+  }
+
+  /**
+   * The nearest painted background colour at or above the slide container.
+   *
+   * Slidev puts `bg-main` on an ancestor rather than on the container itself
+   * depending on the theme, so the first non-transparent colour up the chain is
+   * what the audience actually sees behind the slide.
+   */
+  function backgroundOf(container: Element): string | undefined {
+    let node: Element | null = container
+    while (node) {
+      const color = getComputedStyle(node).backgroundColor
+      if (color && color !== 'transparent' && !/^rgba\(\s*0,\s*0,\s*0,\s*0\s*\)$/.test(color))
+        return color
+      node = node.parentElement
+    }
+    return undefined
+  }
+
+  /**
+   * The text an ordinary list marker renders, which the DOM never exposes.
+   *
+   * Ordered lists need the item's ordinal, counted over previous list-item
+   * siblings and offset by the list's `start`, because the marker is a
+   * generated glyph rather than content.
+   */
+  function markerGlyph(el: Element, listStyleType: string): string {
+    const BULLETS: Record<string, string> = {
+      'disc': '\u2022 ',
+      'circle': '\u25E6 ',
+      'square': '\u25AA ',
+      'disclosure-open': '\u25BE ',
+      'disclosure-closed': '\u25B8 ',
+    }
+    if (listStyleType in BULLETS)
+      return BULLETS[listStyleType]
+
+    let ordinal = 1
+    let sibling = el.previousElementSibling
+    while (sibling) {
+      if (getComputedStyle(sibling).display === 'list-item')
+        ordinal++
+      sibling = sibling.previousElementSibling
+    }
+    const parent = el.parentElement
+    const start = parent && parent.tagName.toUpperCase() === 'OL'
+      ? Number(parent.getAttribute('start') || '1')
+      : 1
+    const value = ordinal + (Number.isFinite(start) ? start : 1) - 1
+
+    if (listStyleType === 'lower-alpha' || listStyleType === 'lower-latin')
+      return `${String.fromCharCode(96 + ((value - 1) % 26) + 1)}. `
+    if (listStyleType === 'upper-alpha' || listStyleType === 'upper-latin')
+      return `${String.fromCharCode(64 + ((value - 1) % 26) + 1)}. `
+    return `${value}. `
+  }
+
+  const containers = Array.from(document.querySelectorAll(options.containerSelector))
+  const slides: any[] = []
+  let nextId = 0
+
+  for (const container of containers) {
+    const containerRect = container.getBoundingClientRect()
+
+    // A print page stacks every slide into one tall viewport, so a container
+    // that is not being rendered has a zero-sized rect.
+    //
+    // Note that this does NOT implement `--range`: the print route renders
+    // every slide whatever the `range` query says, so the caller filters by
+    // slide number, exactly as the image exporter does.
+    if (containerRect.width === 0 || containerRect.height === 0)
+      continue
+
+    // `003-02` is slide 3, click step 2 (1-based in the id).
+    const parts = (container.id || '').split('-')
+    const no = Number(parts[0])
+    const clickIndex = Number(parts[1]) - 1
+    if (!Number.isFinite(no))
+      continue
+
+    const nodes: any[] = []
+
+    function relative(rect: DOMRect | { left: number, top: number, width: number, height: number }) {
+      return {
+        x: rect.left - containerRect.left,
+        y: rect.top - containerRect.top,
+        w: rect.width,
+        h: rect.height,
+      }
+    }
+
+    function walk(node: Node, parent: number, fromShadowRoot: boolean): void {
+      if (node.nodeType === 3) {
+        const text = node.textContent ?? ''
+        // A whitespace-only node is NOT noise. Markup such as
+        // `<span>Hello</span> <span>World</span>` puts the only space between
+        // the two words in its own text node, and dropping it exports
+        // "HelloWorld". Kept when it actually occupies a line box; a collapsed
+        // space between block elements has no rects and is correctly ignored.
+        if (!text)
+          return
+        const range = document.createRange()
+        range.selectNodeContents(node)
+        const rects = Array.from(range.getClientRects())
+        range.detach()
+        if (!rects.length)
+          return
+        // Glyph rects, not the element box. A text box positioned from the
+        // element rect lands offset by the padding and re-wraps.
+        const bounds = {
+          left: Math.min(...rects.map(r => r.left)),
+          top: Math.min(...rects.map(r => r.top)),
+          width: Math.max(...rects.map(r => r.right)) - Math.min(...rects.map(r => r.left)),
+          height: Math.max(...rects.map(r => r.bottom)) - Math.min(...rects.map(r => r.top)),
+        }
+        nodes.push({
+          id: nextId++,
+          parent,
+          tag: '#text',
+          style: -1,
+          rect: relative(bounds),
+          glyphRects: rects.map(relative),
+          text,
+        })
+        return
+      }
+
+      if (node.nodeType !== 1)
+        return
+
+      const el = node as Element
+      const id = nextId++
+      const computed = getComputedStyle(el)
+
+      // `display: none` has no box at all; `visibility: hidden` and
+      // `opacity: 0` do. In `print=clicks` mode a not-yet-revealed v-click
+      // element sits in the DOM at opacity 0, and without this it would be
+      // exported onto every click step of the slide.
+      if (computed.display === 'none' || computed.visibility === 'hidden')
+        return
+      if (Number(computed.opacity) === 0)
+        return
+
+      el.setAttribute(options.idAttribute, String(id))
+      resolveStack(computed.fontFamily)
+
+      const record: any = {
+        id,
+        parent,
+        tag: el.tagName.toUpperCase(),
+        style: internStyle(el),
+        rect: relative(el.getBoundingClientRect()),
+      }
+      if (fromShadowRoot)
+        record.fromShadowRoot = true
+      if (el.tagName.toUpperCase() === 'IMG') {
+        record.src = (el as HTMLImageElement).currentSrc || (el as HTMLImageElement).src
+        const alt = (el as HTMLImageElement).alt
+        if (alt)
+          record.alt = alt
+      }
+      if (el.tagName.toUpperCase() === 'A') {
+        const href = (el as HTMLAnchorElement).href
+        if (href)
+          record.href = href
+      }
+      if (el.tagName.toUpperCase() === 'SVG' && el.querySelector('foreignObject'))
+        // Mermaid puts its node labels in <foreignObject> HTML with no <text>
+        // element, so no PowerPoint renderer draws them. The normalizer routes
+        // these to a picture instead of an empty diagram.
+        record.hasForeignObject = true
+
+      // `::marker` is a pseudo-element, so a list bullet has no text node and a
+      // plain DOM walk drops every bullet glyph in the deck.
+      //
+      // Reading `content` alone is not enough: for an ordinary `<ul>` or `<ol>`
+      // Chromium reports it as `normal` and leaves the glyph to
+      // `list-style-type`, so a check for a non-normal `content` recovers ONLY
+      // custom markers and still loses every default bullet in the deck.
+      if (computed.display === 'list-item') {
+        const marker = getComputedStyle(el, '::marker')
+        const explicit = marker && marker.content
+          && marker.content !== 'none'
+          && marker.content !== 'normal'
+        if (explicit) {
+          record.marker = marker.content.replace(/^["']|["']$/g, '')
+        }
+        else if (computed.listStyleType !== 'none') {
+          record.marker = markerGlyph(el, computed.listStyleType)
+        }
+      }
+
+      nodes.push(record)
+
+      // Descend into the shadow root BEFORE the light children. Mermaid
+      // renders into one, so `querySelector('.mermaid svg')` from the document
+      // finds nothing at all.
+      const shadow = (el as any).shadowRoot
+      if (shadow) {
+        for (const child of Array.from(shadow.childNodes) as Node[])
+          walk(child, id, true)
+      }
+
+      // Recurse through zero-sized boxes rather than pruning them. A cover
+      // slide commonly hangs its title off a wrapper that measures 0 high.
+      for (const child of Array.from(el.childNodes) as Node[])
+        walk(child, id, fromShadowRoot)
+    }
+
+    for (const child of Array.from(container.childNodes) as Node[])
+      walk(child, -1, false)
+
+    slides.push({
+      no,
+      clickIndex: Number.isFinite(clickIndex) ? clickIndex : 0,
+      // The exact id, not a pattern rebuilt from `no`. With `--with-clicks` a
+      // slide has one container per step, and a prefix match plus `.first()`
+      // hands every step a picture of step one.
+      containerId: container.id,
+      size: { w: containerRect.width, h: containerRect.height },
+      // The slide's own background, which lives on the container and so is
+      // never reached by a walk that starts at its children. Without it every
+      // slide exports onto PowerPoint's default white, which on a dark theme
+      // is light text on a white page.
+      background: backgroundOf(container),
+      nodes,
+    })
+  }
+
+  return { slides, styles, fontResolution } as RawSnapshot
+}

--- a/packages/slidev/node/commands/pptx/walker.ts
+++ b/packages/slidev/node/commands/pptx/walker.ts
@@ -367,6 +367,15 @@ export function collectSnapshot(options: {
       }
       if (effectiveOpacity < 1)
         record.opacity = effectiveOpacity
+      // An inline box that wraps is painted once per line, so its background
+      // and borders belong to the fragments rather than to the union rect
+      // `getBoundingClientRect` reports. Only `inline` proper: an inline-block
+      // is a single box that merely sits in a line, and always has one rect.
+      if (computed.display === 'inline') {
+        const fragments = Array.from(el.getClientRects())
+        if (fragments.length > 1)
+          record.fragments = fragments.map(relative)
+      }
       if (fromShadowRoot)
         record.fromShadowRoot = true
       if (el.tagName.toUpperCase() === 'IMG') {

--- a/packages/slidev/node/commands/pptx/walker.ts
+++ b/packages/slidev/node/commands/pptx/walker.ts
@@ -24,6 +24,7 @@ export function collectSnapshot(options: {
   const STYLE_KEYS = [
     'display',
     'position',
+    'zIndex',
     'visibility',
     'opacity',
     'color',

--- a/packages/slidev/node/commands/pptx/walker.ts
+++ b/packages/slidev/node/commands/pptx/walker.ts
@@ -275,7 +275,7 @@ export function collectSnapshot(options: {
       }
     }
 
-    function walk(node: Node, parent: number, fromShadowRoot: boolean): void {
+    function walk(node: Node, parent: number, fromShadowRoot: boolean, inheritedOpacity: number): void {
       if (node.nodeType === 3) {
         const text = node.textContent ?? ''
         // A whitespace-only node is NOT noise. Markup such as
@@ -289,8 +289,15 @@ export function collectSnapshot(options: {
         range.selectNodeContents(node)
         const rects = Array.from(range.getClientRects())
         range.detach()
-        if (!rects.length)
+        // A node with no boxes is still reported. A newline inside a
+        // `white-space: pre` block is exactly that, and it is the only record
+        // of where one line of a code block ends and the next begins.
+        if (!rects.length) {
+          if (!text.includes('\n'))
+            return
+          nodes.push({ id: nextId++, parent, tag: '#text', style: -1, rect: { x: 0, y: 0, w: 0, h: 0 }, glyphRects: [], text })
           return
+        }
         // Glyph rects, not the element box. A text box positioned from the
         // element rect lands offset by the padding and re-wraps.
         const bounds = {
@@ -324,7 +331,13 @@ export function collectSnapshot(options: {
       // exported onto every click step of the slide.
       if (computed.display === 'none' || computed.visibility === 'hidden')
         return
-      if (Number(computed.opacity) === 0)
+      const own = Number(computed.opacity)
+      // CSS `opacity` does NOT inherit: a child of a half-transparent wrapper
+      // computes 1 and would export fully opaque, because DrawingML has no
+      // group opacity to stand in for the wrapper. So it is compounded here,
+      // where the tree is still available.
+      const effectiveOpacity = inheritedOpacity * (Number.isFinite(own) ? own : 1)
+      if (effectiveOpacity === 0)
         return
 
       el.setAttribute(options.idAttribute, String(id))
@@ -337,6 +350,8 @@ export function collectSnapshot(options: {
         style: internStyle(el),
         rect: relative(el.getBoundingClientRect()),
       }
+      if (effectiveOpacity < 1)
+        record.opacity = effectiveOpacity
       if (fromShadowRoot)
         record.fromShadowRoot = true
       if (el.tagName.toUpperCase() === 'IMG') {
@@ -421,6 +436,18 @@ export function collectSnapshot(options: {
           width,
           height,
         }
+        // DOCUMENT coordinates, not viewport ones. A clip screenshot is taken
+        // later, after other captures have scrolled the page, and the print
+        // route is far taller than the viewport once every click step has its
+        // own container. Viewport coordinates read at measurement time are
+        // stale by then, and Playwright answers "clipped area is empty",
+        // which the caller swallows and the decoration vanishes.
+        const pageRect = {
+          x: box.left + window.scrollX,
+          y: box.top + window.scrollY,
+          w: width,
+          h: height,
+        }
         const text = pseudo.content.replace(/^["']|["']$/g, '')
         nodes.push({
           id: nextId++,
@@ -430,7 +457,7 @@ export function collectSnapshot(options: {
           rect: relative(box),
           // Page coordinates as well: a pseudo has no element to point a
           // screenshot at, so it is captured by clipping the page instead.
-          pageRect: { x: box.left, y: box.top, w: width, h: height },
+          pageRect,
           ...(text && pseudo.content !== 'normal' ? { text } : {}),
         })
       }
@@ -441,17 +468,17 @@ export function collectSnapshot(options: {
       const shadow = (el as any).shadowRoot
       if (shadow) {
         for (const child of Array.from(shadow.childNodes) as Node[])
-          walk(child, id, true)
+          walk(child, id, true, effectiveOpacity)
       }
 
       // Recurse through zero-sized boxes rather than pruning them. A cover
       // slide commonly hangs its title off a wrapper that measures 0 high.
       for (const child of Array.from(el.childNodes) as Node[])
-        walk(child, id, fromShadowRoot)
+        walk(child, id, fromShadowRoot, effectiveOpacity)
     }
 
     for (const child of Array.from(container.childNodes) as Node[])
-      walk(child, -1, false)
+      walk(child, -1, false, 1)
 
     slides.push({
       no,

--- a/packages/slidev/package.json
+++ b/packages/slidev/package.json
@@ -132,6 +132,7 @@
   "devDependencies": {
     "@hedgedoc/markdown-it-plugins": "catalog:prod",
     "@types/picomatch": "catalog:types",
-    "@types/plantuml-encoder": "catalog:types"
+    "@types/plantuml-encoder": "catalog:types",
+    "jszip": "catalog:dev"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,9 @@ catalogs:
     eslint-plugin-format:
       specifier: ^2.0.1
       version: 2.0.1
+    jszip:
+      specifier: ^3.10.1
+      version: 3.10.1
     lint-staged:
       specifier: ^17.3.0
       version: 17.3.0
@@ -1193,6 +1196,9 @@ importers:
       '@types/plantuml-encoder':
         specifier: catalog:types
         version: 1.4.2
+      jszip:
+        specifier: catalog:dev
+        version: 3.10.1
 
   packages/types:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -46,6 +46,7 @@ catalogs:
     cypress: ^15.20.1
     eslint: ^10.8.1
     eslint-plugin-format: ^2.0.1
+    jszip: ^3.10.1
     lint-staged: ^17.3.0
     nodemon: ^3.1.14
     ovsx: ^1.1.1

--- a/skills/slidev/references/core-cli.md
+++ b/skills/slidev/references/core-cli.md
@@ -65,7 +65,7 @@ Options:
 | Option | Default | Description |
 |--------|---------|-------------|
 | `--output` | - | Output filename |
-| `--format` | pdf | pdf / png / pptx / md |
+| `--format` | pdf | pdf / png / pptx / pptx-editable / md |
 | `--timeout` | 30000 | Timeout per slide (ms) |
 | `--range` | - | Slide range (e.g., 1,4-7) |
 | `--dark` | false | Export dark mode |

--- a/skills/slidev/references/core-exporting.md
+++ b/skills/slidev/references/core-exporting.md
@@ -30,8 +30,11 @@ slidev export --output my-slides.pdf
 ### PowerPoint Export
 
 ```bash
-slidev export --format pptx
+slidev export --format pptx           # each slide as an image
+slidev export --format pptx-editable  # native shapes, selectable text
 ```
+
+`pptx-editable` measures the rendered slides and rebuilds them as PowerPoint shapes. SVG (including Mermaid), canvas, iframes, gradients and CSS filters stay pictures, and any slide that cannot be rebuilt falls back to the image export on its own. Fonts are named, not embedded. `--per-slide` is not supported with it.
 
 ### PNG Export
 

--- a/skills/slidev/references/core-exporting.md
+++ b/skills/slidev/references/core-exporting.md
@@ -34,7 +34,7 @@ slidev export --format pptx           # each slide as an image
 slidev export --format pptx-editable  # native shapes, selectable text
 ```
 
-`pptx-editable` measures the rendered slides and rebuilds them as PowerPoint shapes. SVG (including Mermaid), canvas, iframes, gradients and CSS filters stay pictures, and any slide that cannot be rebuilt falls back to the image export on its own. Fonts are named, not embedded. `--per-slide` is not supported with it.
+`pptx-editable` measures the rendered slides and rebuilds them as PowerPoint shapes. SVG (including Mermaid), canvas, iframes, KaTeX formulas, gradients and CSS filters stay pictures, and any slide that cannot be rebuilt falls back to the image export on its own. Fonts are named, not embedded. `--per-slide` is not supported with it.
 
 ### PNG Export
 


### PR DESCRIPTION
Closes the request in #2721, which has the full reasoning. This is the implementation.

## Try it before reading any code

```bash
# once CI has run on this PR and pkg.pr.new has published
npm i https://pkg.pr.new/@slidev/cli@2722 playwright-chromium
slidev export --format pptx-editable
```

Then click on a heading in the result. It is text.

The workflows on this PR are held at `action_required`, so nothing has been published yet. Approving them is what produces that build.

If you would rather not approve workflows first, the same thing from a checkout, no CI involved:

```bash
gh pr checkout 2722
pnpm install && pnpm build
node packages/slidev/bin/slidev.mjs export demo/starter/slides.md --format pptx-editable
```

## What this does not do

- No template or `.potx` loading, no slide master synthesis, no font embedding.
- A `.pptx` names fonts rather than carrying them, and the name written is the resolved family with any `@fontsource` `Variable` suffix removed, so a theme built on `Inter Variable` asks for `Inter`. A recipient is likelier to have the static face installed, and naming the variable family would only move the substitution to their machine. The export prints which families it referenced.
- No gradients: `pptxgenjs` has none, so they rasterize.
- `--per-slide` errors for this format. It navigates one slide at a time and never renders the print page the measurement depends on.
- Decorations a theme draws with `::before` or `::after` in normal flow are left out, and named at the end of the export. Code block line numbers are the case a user is most likely to meet: they come from a CSS counter, which has neither text nor a box a computed style can report.
- PowerPoint draws a dashed underline as a solid one, so a theme that rules its links with `border-bottom: 1px dashed`, as Slidev's own do, gets a solid rule. The style is in the file as `u="dash"` and other renderers honor it.
- A long paragraph can wrap onto a different number of lines, because PowerPoint's text metrics are not Chromium's.

## What it does

`--format pptx-editable` walks the rendered DOM at export time and emits native shapes and text boxes rather than one picture per slide. On `demo/starter`, unmodified:

| | `--format pptx` | `--format pptx-editable` |
|---|---|---|
| `slide1.xml` | 770 bytes | 5,134 bytes |
| shapes | 0 | 640 |
| text runs | 0 | 1,554 |

`--format pptx` is untouched. The two ship side by side because `pptx` is pixel-exact on every theme and this cannot be.

## Shape of the change

`export.ts` changes by twenty-eight lines: one entry in the format union, one dispatch branch, the format cast, `withClicks ?? format === 'pptx'` becoming `format.startsWith('pptx')`, and a generator that guards `--per-slide`, delegates, and hands the result to a reporter. One line in `cli.ts` for `choices`. The rest is new files under `packages/slidev/node/commands/pptx/`:

- `walker.ts` runs in the page and extracts only facts that need live layout. It makes no decisions.
- `normalize.ts` holds every judgement as pure functions over plain JSON.
- `color.ts` parses computed colors in every syntax Chromium leaves in a computed style.
- `capture.ts` is the only Playwright glue.
- `build.ts` turns the result into a `.pptx` through `pptxgenjs`, already a `catalog:prod` dependency. Also pure.

115 tests, over hand-written fixtures and unzipped OOXML rather than over the calling code. `plans/022` asks for the first tests the export pipeline has ever had, is P1 and still TODO, and `plans/023` is blocked on it. The split here is the shape `023` wants, so the other exporters can be extracted later without touching this one.

One dev dependency, `jszip`, added through the catalog. It is used only to unzip and assert on the generated XML in tests.

## The safety valve

A slide that throws, times out, loses all its text, or comes out more than 60% picture with nothing recovered over it falls back to exactly today's `--format pptx` output, for that slide alone, and says why. None of the decks I have run needs it. It is there so that a theme this heuristic cannot handle degrades to current behavior, per slide and loudly, instead of producing a broken file.

## On whether it survives real themes

It did not, at first. I built it against `demo/starter`, then ran it over [`peacock0803sz/slides`](https://github.com/peacock0803sz/slides), [`lyqht/intro-to-svg-slides`](https://github.com/lyqht/intro-to-svg-slides) and two decks on custom themes of my own, written to match internal corporate templates, which I cannot share. Four distinct themes in all, none of which I wrote the exporter against. Every slide was compared to its rendered reference. Twenty-six distinct defects came out of that, each now a named test: paint order is not array order, an inline background is painted once per line fragment rather than once over their union, `locator.screenshot()` returns the wrong region on a page far taller than its viewport, KaTeX cannot be walked as text, a table cell is not a layout container, and so on.

So when a theme breaks it, `normalize.ts` is pure and the report becomes a fixture plus a test. Nobody has to reproduce it inside a browser first.

## Questions I would rather settle in review

1. Is `--format pptx-editable` the surface you want, or would you rather this arrived as a pluggable export-format API with this as its first consumer? Everything already sits behind a `PptxExportContext` and is a plugin in all but name.
2. Is the per-slide image fallback the right degradation policy?

I am happy either way, and would rather rework the surface now than after review.

