### PR TITLE
fix: keep --remote running when public IPv4 lookup fails

### DIFF
--- a/packages/slidev/node/cli.ts
+++ b/packages/slidev/node/cli.ts
@@ -18,6 +18,7 @@ import { createServer } from './commands/serve'
 import { getThemeMeta, resolveTheme } from './integrations/themes'
 import { resolveOptions } from './options'
 import { parser } from './parser'
+import { resolvePublicIpv4 } from './publicIp'
 import { isInstalledGlobally, resolveEntry } from './resolver'
 import setupPreparser from './setups/preparser'
 import { updateFrontmatterPatch } from './utils'
@@ -204,7 +205,7 @@ cli.command(
 
       let publicIp: string | undefined
       if (remote)
-        publicIp = await import('public-ip').then(r => r.publicIpv4())
+        publicIp = await resolvePublicIpv4()
 
       lastRemoteUrl = printInfo(options, port, base, remote, tunnelUrl, publicIp)
       if (open)
@@ -278,7 +279,7 @@ cli.command(
               const code = r.renderUnicodeCompact(lastRemoteUrl!)
               console.log(`\n${dim('  QR Code for remote control: ')}\n  ${blue(lastRemoteUrl!)}\n`)
               console.log(code.split('\n').map(i => `  ${i}`).join('\n'))
-              const publicIp = await import('public-ip').then(r => r.publicIpv4())
+              const publicIp = await resolvePublicIpv4()
               if (publicIp)
                 console.log(`\n${dim(' Public IP: ')}  ${blue(publicIp)}\n`)
             })

--- a/packages/slidev/node/publicIp.test.ts
+++ b/packages/slidev/node/publicIp.test.ts
@@ -1,0 +1,26 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { resolvePublicIpv4 } from './publicIp'
+
+const mocks = vi.hoisted(() => ({
+  publicIpv4: vi.fn(),
+}))
+
+vi.mock('public-ip', () => ({
+  publicIpv4: mocks.publicIpv4,
+}))
+
+describe('resolvePublicIpv4', () => {
+  beforeEach(() => {
+    mocks.publicIpv4.mockReset()
+  })
+
+  it('returns the public IPv4 address when lookup succeeds', async () => {
+    mocks.publicIpv4.mockResolvedValue('203.0.113.10')
+    await expect(resolvePublicIpv4()).resolves.toBe('203.0.113.10')
+  })
+
+  it('returns undefined instead of throwing when public IPv4 cannot be determined', async () => {
+    mocks.publicIpv4.mockRejectedValue(new DOMException('The operation was aborted.'))
+    await expect(resolvePublicIpv4()).resolves.toBeUndefined()
+  })
+})

--- a/packages/slidev/node/publicIp.ts
+++ b/packages/slidev/node/publicIp.ts
@@ -1,0 +1,9 @@
+export async function resolvePublicIpv4(): Promise<string | undefined> {
+  try {
+    const { publicIpv4 } = await import('public-ip')
+    return await publicIpv4()
+  }
+  catch {
+    return undefined
+  }
+}


### PR DESCRIPTION
public-ip publicIpv4() throws when the public address cannot be determined (blocked DNS, DOMException in practice). Both --remote startup and the QR shortcut awaited it unguarded, so slidev --remote=<password> crashed instead of staying on LAN URLs.

Catch the lookup and treat failure as no public IP. printInfo already omits that line when the value is missing, so remote/QR keep working.

Fixes #2724