### PR TITLE
fix(cli): don't crash when the public IP can't be resolved

### DIFF
--- a/packages/slidev/node/cli.ts
+++ b/packages/slidev/node/cli.ts
@@ -203,14 +203,8 @@ cli.command(
       }
 
       let publicIp: string | undefined
-      if (remote) {
-        try {
-          publicIp = await import('public-ip').then(r => r.publicIpv4())
-        }
-        catch {
-          console.log(yellow('\n  Could not determine the public IP address.\n'))
-        }
-      }
+      if (remote)
+        publicIp = await resolvePublicIp()
 
       lastRemoteUrl = printInfo(options, port, base, remote, tunnelUrl, publicIp)
       if (open)
@@ -226,6 +220,15 @@ cli.command(
       }
       catch {
         console.log(yellow(`\n  Could not open the browser automatically. Please open ${url} in your browser.\n`))
+      }
+    }
+
+    async function resolvePublicIp() {
+      try {
+        return await import('public-ip').then(r => r.publicIpv4())
+      }
+      catch {
+        console.log(yellow('\n  Could not determine the public IP address.\n'))
       }
     }
 
@@ -284,7 +287,7 @@ cli.command(
               const code = r.renderUnicodeCompact(lastRemoteUrl!)
               console.log(`\n${dim('  QR Code for remote control: ')}\n  ${blue(lastRemoteUrl!)}\n`)
               console.log(code.split('\n').map(i => `  ${i}`).join('\n'))
-              const publicIp = await import('public-ip').then(r => r.publicIpv4()).catch(() => undefined)
+              const publicIp = await resolvePublicIp()
               if (publicIp)
                 console.log(`\n${dim(' Public IP: ')}  ${blue(publicIp)}\n`)
             })

--- a/packages/slidev/node/cli.ts
+++ b/packages/slidev/node/cli.ts
@@ -203,8 +203,14 @@ cli.command(
       }
 
       let publicIp: string | undefined
-      if (remote)
-        publicIp = await import('public-ip').then(r => r.publicIpv4())
+      if (remote) {
+        try {
+          publicIp = await import('public-ip').then(r => r.publicIpv4())
+        }
+        catch {
+          console.log(yellow('\n  Could not determine the public IP address.\n'))
+        }
+      }
 
       lastRemoteUrl = printInfo(options, port, base, remote, tunnelUrl, publicIp)
       if (open)
@@ -278,7 +284,7 @@ cli.command(
               const code = r.renderUnicodeCompact(lastRemoteUrl!)
               console.log(`\n${dim('  QR Code for remote control: ')}\n  ${blue(lastRemoteUrl!)}\n`)
               console.log(code.split('\n').map(i => `  ${i}`).join('\n'))
-              const publicIp = await import('public-ip').then(r => r.publicIpv4())
+              const publicIp = await import('public-ip').then(r => r.publicIpv4()).catch(() => undefined)
               if (publicIp)
                 console.log(`\n${dim(' Public IP: ')}  ${blue(publicIp)}\n`)
             })


### PR DESCRIPTION
On a network where the public IP can't be resolved (blocked DNS, for example), `slidev --remote=<password>` dies before printing anything. `publicIpv4()` rejects there, and neither call site guards it: the dev server one takes down the process with `DOMException [TimeoutError]`, and the `c` (qrcode) shortcut leaves an unhandled rejection.

The public IP only adds one extra "remote control" URL, so both calls now go through a small helper that catches the failure and warns, the same way the failed-to-open-browser path does. `printInfo` already treats the IP as optional and still prints the LAN URLs.

There's no test harness for `cli.ts` here, so I checked it by hand against the starter demo with `public-ip` stubbed to reject with the same `TimeoutError`. On `main` it crashes at startup; on this branch it warns, serves the deck, and still renders the QR code. With the stub removed the public IP shows up as before.

Fixes #2724
