### PR TITLE
fix: render iframe layouts at their on-screen resolution

### DIFF
--- a/cypress/e2e/examples/iframe-layout.spec.ts
+++ b/cypress/e2e/examples/iframe-layout.spec.ts
@@ -1,0 +1,25 @@
+context('Iframe layout', () => {
+  // #2281: the iframe should lay out and rasterize at its real on-screen
+  // size, so embedded canvas-based pages are not bitmap-upscaled and blurred
+  it('rasterizes at the on-screen size when the slide is scaled up', () => {
+    cy.viewport(1960, 1104) // 2x the default 980x552 slide size
+    cy.visit('/18')
+    cy.get('#slide-content iframe').should(($frame) => {
+      const el = $frame[0]
+      const rect = el.getBoundingClientRect()
+      expect(rect.width, 'displayed width').to.be.closeTo(1960, 2)
+      expect(el.offsetWidth, 'layout width').to.be.closeTo(rect.width, 2)
+    })
+  })
+
+  it('keeps the design-size layout when the slide is scaled down', () => {
+    cy.viewport(490, 276) // 0.5x the default 980x552 slide size
+    cy.visit('/18')
+    cy.get('#slide-content iframe').should(($frame) => {
+      const el = $frame[0]
+      const rect = el.getBoundingClientRect()
+      expect(rect.width, 'displayed width').to.be.closeTo(490, 2)
+      expect(el.offsetWidth, 'layout width').to.equal(980)
+    })
+  })
+})

--- a/cypress/fixtures/basic/slides.md
+++ b/cypress/fixtures/basic/slides.md
@@ -224,3 +224,8 @@ const answer = 42
 
 </v-click>
 </div>
+
+---
+layout: iframe
+url: about:blank
+---

--- a/packages/client/layouts/iframe-left.vue
+++ b/packages/client/layouts/iframe-left.vue
@@ -13,9 +13,9 @@ const scaleInvertPercent = computed(() => `${(1 / (props.scale || 1)) * 100}%`)
   <div class="grid grid-cols-2 w-full h-full">
     <div relative :style="{ width: scaleInvertPercent, height: scaleInvertPercent }">
       <iframe
-        id="frame" class="w-full h-full"
+        id="frame" class="slidev-layout-iframe"
         :src="url"
-        :style="scale ? { transform: `scale(${scale})`, transformOrigin: 'top left' } : {}"
+        :style="scale ? { '--slidev-iframe-scale': scale } : {}"
       />
     </div>
     <div class="slidev-layout default" v-bind="$attrs">

--- a/packages/client/layouts/iframe-right.vue
+++ b/packages/client/layouts/iframe-right.vue
@@ -16,9 +16,9 @@ const scaleInvertPercent = computed(() => `${(1 / (props.scale || 1)) * 100}%`)
     </div>
     <div relative :style="{ width: scaleInvertPercent, height: scaleInvertPercent }">
       <iframe
-        id="frame" class="w-full h-full"
+        id="frame" class="slidev-layout-iframe"
         :src="url"
-        :style="scale ? { transform: `scale(${scale})`, transformOrigin: 'top left' } : {}"
+        :style="scale ? { '--slidev-iframe-scale': scale } : {}"
       />
     </div>
   </div>

--- a/packages/client/layouts/iframe.vue
+++ b/packages/client/layouts/iframe.vue
@@ -13,9 +13,9 @@ const scaleInvertPercent = computed(() => `${(1 / (props.scale || 1)) * 100}%`)
   <div class="h-full w-full">
     <div relative :style="{ width: scaleInvertPercent, height: scaleInvertPercent }">
       <iframe
-        id="frame" class="w-full h-full"
+        id="frame" class="slidev-layout-iframe"
         :src="url"
-        :style="scale ? { transform: `scale(${scale})`, transformOrigin: 'top left' } : {}"
+        :style="scale ? { '--slidev-iframe-scale': scale } : {}"
       />
     </div>
   </div>

--- a/packages/client/styles/index.css
+++ b/packages/client/styles/index.css
@@ -122,6 +122,21 @@ html {
   transform: scale(calc(1 / var(--slidev-slide-scale)));
 }
 
+/*
+ * Counter the slide scale so iframes lay out and rasterize at their real
+ * on-screen resolution. Without this, canvas-based content (e.g. Excalidraw)
+ * is rendered at the slide's design size and bitmap-upscaled, which makes it
+ * blurry when the slide is scaled up. Scales below 1 are not countered, so
+ * scaled-down views like the overview keep the original layout.
+ */
+.slidev-layout-iframe {
+  --slidev-iframe-raster: max(var(--slidev-slide-scale, 1), 1);
+  width: calc(100% * var(--slidev-iframe-raster));
+  height: calc(100% * var(--slidev-iframe-raster));
+  transform: scale(calc(var(--slidev-iframe-scale, 1) / var(--slidev-iframe-raster)));
+  transform-origin: top left;
+}
+
 #twoslash-container {
   position: fixed;
 


### PR DESCRIPTION
Fixes #2281 (same underlying cause as #1271, which was closed for lack of reproduction).

### Root cause

Slidev renders slides at their design size (default `980x552`) and fits them to the window with `transform: scale(...)` on the slide container. Regular DOM content is re-rasterized by the browser under that scale, so it stays sharp. But iframe content that sizes its own raster from the embedded viewport — canvas apps like Excalidraw, which set `canvas.width = cssSize * devicePixelRatio` — renders at the slide's *design* size and is then bitmap-upscaled by the slide scale. At a 1920x1080 window the scale is ~1.9565, so every canvas pixel is smeared across ~2 screen pixels. That matches the issue screenshots: the shared Excalidraw link is sharp standalone but blurry embedded.

### Fix

Let the iframe in the `iframe` / `iframe-left` / `iframe-right` layouts lay out at its real on-screen size and counter the slide scale, using the inverse-scale idiom this codebase already uses for `.rough-annotation` and Monaco's context menu:

```css
.slidev-layout-iframe {
  --slidev-iframe-raster: max(var(--slidev-slide-scale, 1), 1);
  width: calc(100% * var(--slidev-iframe-raster));
  height: calc(100% * var(--slidev-iframe-raster));
  transform: scale(calc(var(--slidev-iframe-scale, 1) / var(--slidev-iframe-raster)));
  transform-origin: top left;
}
```

- Scales below 1 are clamped with `max(scale, 1)` on purpose, so scaled-down views (overview, presenter thumbnails) keep the current behavior.
- The layouts' `scale` prop keeps its meaning; it now feeds the same formula via `--slidev-iframe-scale`.

### Verified with the reproduction from the issue

Loaded the exact Excalidraw link from the issue in `layout: iframe`, headless Chromium at 1920x1080 (dpr 1), and measured the blue text region of the drawing in before/after screenshots:

| | iframe layout width | displayed width | net raster scale | dark (<100) ink pixels | gradient energy / px |
|---|---|---|---|---|---|
| before | 980 | 1917.4 | 1.9565 (bitmap upscale) | 4123 | 5.47 |
| after | 1917 | 1917.4 | 1.0002 | 8019 | 6.35 |

Strokes resolve to dark cores again instead of gray smears. Because Excalidraw fits the scene to its viewport, the apparent size of the drawing barely changes — only sharpness does.

I also measured with a local page that mimics Excalidraw's canvas handling (backing store = CSS size x devicePixelRatio) drawing a 1px stripe pattern: before, the pattern is stretched to a ~3.9px period (1px detail cannot survive the upscale); after, the 2px period is preserved pixel-for-pixel, and the embedded render differs from opening the same page directly in the browser by a mean of 2.8/255 per pixel.

The new Cypress spec asserts the iframe's layout width matches its displayed width at a 2x viewport and stays at the design size at 0.5x. Against the previous behavior it fails with `displayed width: expected 600 to be close to 1960 +/- 2`.

### Behavior note (intentional, please review)

When a slide is scaled up, the embedded page now sees its real on-screen viewport (e.g. 1917px at fullscreen 1920) instead of the design-size 980px. Responsive pages lay out the way they would in a standalone browser window of that size — which is what the issue reporter expected — but decks that relied on the old "980px layout blown up ~2x" look will see embedded pages render with more content at a smaller apparent size (the `scale` prop can compensate).

One remaining limit: when the fitted slide has a fractional scale/offset (e.g. 1920 window gives scale 1.9565 and a 1.3px centering offset), pixel-aligned 1px patterns lose some contrast to subpixel blending. That is inherent to non-integer compositing and far less visible than the previous 2x upscale.

Ran `pnpm verify` locally (build, typecheck, lint, unit tests all pass) plus the new Cypress spec.
