### PR TITLE
fix(vscode): match detected server entry against existing project paths

### DIFF
--- a/packages/vscode/src/composables/useServerDetector.ts
+++ b/packages/vscode/src/composables/useServerDetector.ts
@@ -4,6 +4,7 @@ import { getPort as getPortPlease } from 'get-port-please'
 import { computed, defineService, onScopeDispose, reactive, watch } from 'reactive-vscode'
 import { config } from '../configs'
 import { activeProject, askAddProject, projects, scannedProjects } from '../projects'
+import { isSamePath } from '../utils/isSamePath'
 import { logger } from '../views/logger'
 
 const versionRE = /<meta (?:name|property)="slidev:version" content="([^"]+)">/
@@ -46,10 +47,12 @@ export const useServerDetector = defineService(() => {
         state.compatMode = !text.match(versionRE)
         const detectedEntry = text.match(entryRE)?.[1]
         if (detectedEntry) {
-          state.entry = detectedEntry
+          const entry = [...projects.keys()]
+            .find(projectEntry => isSamePath(projectEntry, detectedEntry)) ?? detectedEntry
+          state.entry = entry
           logger.info(`[Slidev] Detected Slidev server entry: ${detectedEntry} on port ${port}`)
           if (scannedProjects.value) {
-            askAddProject(detectedEntry, `A Slidev server is detected running on localhost:${port}.`)
+            askAddProject(entry, `A Slidev server is detected running on localhost:${port}.`)
           }
         }
         return true

--- a/packages/vscode/src/utils/isSamePath.test.ts
+++ b/packages/vscode/src/utils/isSamePath.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { isSamePath } from './isSamePath'
+
+describe('isSamePath', () => {
+  it('compares Windows absolute paths case-insensitively', () => {
+    expect(isSamePath('c:\\work\\deck\\slides.md', 'C:/Work/Deck/slides.md')).toBe(true)
+  })
+
+  it('normalizes Windows path separators', () => {
+    expect(isSamePath('C:\\Work/Deck\\slides.md', 'c:/work\\deck/slides.md')).toBe(true)
+  })
+
+  it('keeps distinct Windows paths separate', () => {
+    expect(isSamePath('C:/Work/Deck/slides.md', 'C:/Work/Other/slides.md')).toBe(false)
+  })
+
+  it('compares POSIX paths case-sensitively', () => {
+    expect(isSamePath('/work/deck/slides.md', '/Work/Deck/slides.md')).toBe(false)
+  })
+})

--- a/packages/vscode/src/utils/isSamePath.ts
+++ b/packages/vscode/src/utils/isSamePath.ts
@@ -1,0 +1,8 @@
+const windowsAbsolutePathRE = /^[A-Z]:[\\/]/i
+
+export function isSamePath(a: string, b: string) {
+  if (!windowsAbsolutePathRE.test(a) || !windowsAbsolutePathRE.test(b))
+    return a === b
+
+  return a.replaceAll('\\', '/').toLowerCase() === b.replaceAll('\\', '/').toLowerCase()
+}


### PR DESCRIPTION
## Summary

`useServerDetector` reads the entry path out of the served HTML and passes it straight to `askAddProject()`. `askAddProject` early-returns on `projects.has(entry)`, so that check only suppresses the prompt when the detected string matches the registered project key exactly.

On Windows the two can describe the same file and still differ, by drive-letter case (`c:\` vs `C:\`) or separator style. The lookup misses, the user is prompted to add a project they already have, and accepting registers a second entry for the same deck.

This resolves the detected entry against the existing project keys first and reuses the registered key when one refers to the same path:

```ts
const entry = [...projects.keys()]
  .find(projectEntry => isSamePath(projectEntry, detectedEntry)) ?? detectedEntry
```

`isSamePath` only relaxes comparison when both sides look like Windows absolute paths; POSIX paths keep exact case-sensitive comparison, so Linux and macOS behaviour is unchanged.

## Why this matters

Closes #2391

That thread has two distinct symptoms. The original report was a Linux `TypeError: fetch failed`, and the reporter confirmed it fixed in v52.11.0. What is still open is the Windows case: @kermanx identified it as "yet another Windows path issue", @tianq02 documented the workaround, and @AndyP01 reproduced it on Windows 10.0.26200 with v52.19.1 on 2026-08-27.

That workaround is what points at this code path. It is: wait for the "A Slidev server is detected running" popup, click Yes, observe a *duplicated* entry in the preview, then close the original. A duplicate appearing at that prompt is exactly what a missed `projects.has(entry)` produces, and that prompt is raised by the `askAddProject` call changed here.

This is deliberately scoped to the duplicate-project cause, so please treat the closing link above as covering that cause only. I could not verify it resolves every remaining report on the thread, and at least one follow-up report did not state a platform, so if anyone still reproduces after this lands the issue is worth reopening rather than assuming it is covered.

## Testing

- `npx vitest run packages/vscode/src/utils/isSamePath.test.ts` passes: 4 tests covering drive-letter case folding, mixed separators, distinct Windows paths staying distinct, and POSIX paths staying case-sensitive.
- `npx eslint` clean on all three changed files.
- Not verified: I develop on Linux/macOS and could not reproduce the original Windows duplicate-entry behaviour end to end in VS Code, so the fix is argued from the code path and the workaround above rather than from a live repro.

AI was used for assistance.
