### PR TITLE
fix(client): keep the mic track alive across consecutive recordings

### DIFF
--- a/packages/client/logic/recording.ts
+++ b/packages/client/logic/recording.ts
@@ -106,6 +106,11 @@ export function useRecording() {
   async function startCameraStream() {
     await ensureDevicesListPermissions()
     await nextTick()
+
+    // Stopped tracks can never be resumed, the whole stream has to be requested again
+    if (streamCamera.value?.getTracks().some(track => track.readyState === 'ended'))
+      closeStream(streamCamera)
+
     if (!streamCamera.value) {
       if (currentCamera.value === 'none' && currentMic.value === 'none')
         return
@@ -206,7 +211,9 @@ export function useRecording() {
       const blob = recorderSlides.value!.getBlob()
       downloadBlob(blob, duration, getFilename('screen', config.mimeType))
       closeStream(streamCapture)
-      closeStream(streamSlides)
+      // `streamSlides` only borrows its tracks from `streamCapture` and `streamCamera`,
+      // stopping them here would also end the mic still used by the camera stream
+      streamSlides.value = undefined
       recorderSlides.value = undefined
     })
   }


### PR DESCRIPTION
### Problem

Audio is only captured in the first recording of a session. On the second and every subsequent recording, both the `screen-*` and `camera-*` files are written without audio.

### Reproduction

1. Enable the camera view (the avatar button in the navbar).
2. Record, stop, and confirm the downloaded files have audio.
3. Without reloading, record again and stop.
4. The second pair of files is silent.

The camera view state is persisted in localStorage (`slidev-webcam-show`) and restored on mount, so anyone who has ever turned the avatar on hits this in every later session.

### Cause

`startRecording` merges the screen video and the mic into one stream, so that the `inactive` event keeps working on the capture stream. The mic track is added to that merged stream by reference:

```ts
const audioTrack = streamCamera.value!.getAudioTracks()?.[0]
if (audioTrack)
  streamSlides.value!.addTrack(audioTrack)
```

`MediaStream.addTrack` does not clone, so `streamCamera` and `streamSlides` end up holding the very same `MediaStreamTrack`. When recording stops, `closeStream(streamSlides)` calls `stop()` on every track the merged stream contains, including that shared mic track — and `MediaStreamTrack.stop()` is irreversible, leaving `readyState` at `"ended"` forever.

The camera stream itself is only released when the avatar is hidden (`if (!showAvatar.value) closeStream(streamCamera)`). With the camera view on it therefore survives, holding a dead audio track next to a still-live video track, which is why the avatar keeps working and the breakage isn't visible in the UI. On the next recording, `startCameraStream` returns early because it only checks that the stream object exists, so no fresh `getUserMedia` call happens, the ended track is merged in again, and `MediaRecorder` produces no audio.

The merged stream was introduced in #536, which kept the existing `closeStream(streamSlides)` teardown.

### Fix

- `streamSlides` is only a container borrowing tracks from `streamCapture` and `streamCamera`, so it is now discarded instead of being passed to `closeStream`. The screen-share track is still stopped one line earlier by `closeStream(streamCapture)`.
- `startCameraStream` now drops and re-requests the camera stream when any of its tracks has already ended, so the mic recovers even if a track gets stopped elsewhere.

### Testing

`pnpm verify` passes (build, typecheck, lint, 241 tests).

This depends on browser media-device behaviour, so it isn't reachable from the automated suite. Verified manually in Chrome with the camera view enabled:

- [ ] first recording has audio in both `screen-*` and `camera-*`
- [ ] a second recording, without reloading, also has audio in both
- [ ] the avatar keeps showing video after a recording stops