### PR TITLE
fix: match notesAutoRuby keys longest-first and literally

### DIFF
--- a/packages/slidev/node/utils.test.ts
+++ b/packages/slidev/node/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { isPathInsideRoots } from './utils'
+import { applyNotesAutoRuby, isPathInsideRoots } from './utils'
 
 describe('isPathInsideRoots', () => {
   it('accepts a path nested inside a root', () => {
@@ -20,5 +20,33 @@ describe('isPathInsideRoots', () => {
 
   it('accepts when any of several roots contains the path', () => {
     expect(isPathInsideRoots('/b/c', ['/a', '/b'])).toBe(true)
+  })
+})
+
+describe('applyNotesAutoRuby', () => {
+  it('wraps a matched key in a ruby tag', () => {
+    expect(applyNotesAutoRuby('私は勉強しています。', { 勉強: 'べんきょう' }))
+      .toBe('私は<ruby>勉強<rt>べんきょう</rt></ruby>しています。')
+  })
+
+  it('prefers the longest key when one key starts with another', () => {
+    expect(applyNotesAutoRuby('私は日本語を話す', { 日本: 'ni hon', 日本語: 'ni hon go' }))
+      .toBe('私は<ruby>日本語<rt>ni hon go</rt></ruby>を話す')
+  })
+
+  it('matches keys containing regular expression characters literally', () => {
+    expect(applyNotesAutoRuby('I write C++ code', { 'C++': 'see plus plus' }))
+      .toBe('I write <ruby>C++<rt>see plus plus</rt></ruby> code')
+    expect(applyNotesAutoRuby('the (foo) case', { '(foo)': 'ふー' }))
+      .toBe('the <ruby>(foo)<rt>ふー</rt></ruby> case')
+  })
+
+  it('only matches whole words for alphanumeric keys', () => {
+    expect(applyNotesAutoRuby('slidev slidevjs', { slidev: 'slide dev' }))
+      .toBe('<ruby>slidev<rt>slide dev</rt></ruby> slidevjs')
+  })
+
+  it('returns the input untouched when there is no key', () => {
+    expect(applyNotesAutoRuby('unchanged', {})).toBe('unchanged')
   })
 })

--- a/packages/slidev/node/utils.ts
+++ b/packages/slidev/node/utils.ts
@@ -46,6 +46,29 @@ export function stringifyMarkdownTokens(tokens: Token[]) {
     .join(' ')
 }
 
+const RE_WORD_CHARS_ONLY = /^[\w-]+$/
+const RE_REGEXP_CHARS = /[.*+?^${}()|[\]\\]/g
+
+export function applyNotesAutoRuby(md: string, notesAutoRuby: Record<string, string | undefined>) {
+  const keys = Object.keys(notesAutoRuby)
+    // Longest first, otherwise a shorter key shadows every key starting with it
+    .sort((a, b) => b.length - a.length)
+    // Add word boundaries to the keys when they are simple alphabets or numbers
+    .map(i => RE_WORD_CHARS_ONLY.test(i) ? `\\b${i}\\b` : i.replace(RE_REGEXP_CHARS, '\\$&'))
+
+  if (!keys.length)
+    return md
+
+  return md.replace(
+    new RegExp(`(${keys.join('|')})`, 'g'),
+    (match) => {
+      if (notesAutoRuby[match])
+        return `<ruby>${match}<rt>${notesAutoRuby[match]}</rt></ruby>`
+      return match
+    },
+  )
+}
+
 export function generateFontParams(options: ResolvedFontOptions) {
   const weights = options.weights
     .flatMap(i => options.italic ? [`0,${i}`, `1,${i}`] : [`${i}`])

--- a/packages/slidev/node/vite/loaders.ts
+++ b/packages/slidev/node/vite/loaders.ts
@@ -9,7 +9,7 @@ import YAML from 'yaml'
 import { createDataUtils } from '../options'
 import MarkdownItKatex from '../syntax/katex'
 import markdownItLink from '../syntax/link'
-import { createMakeAbsoluteImportGlob, getBodyJson, updateFrontmatterPatch } from '../utils'
+import { applyNotesAutoRuby, createMakeAbsoluteImportGlob, getBodyJson, updateFrontmatterPatch } from '../utils'
 import { templates } from '../virtual'
 import { templateConfigs } from '../virtual/configs'
 import { templateMonacoRunDeps } from '../virtual/monaco-deps'
@@ -17,8 +17,6 @@ import { templateMonacoTypes } from '../virtual/monaco-types'
 import { templateSlides, VIRTUAL_SLIDE_PREFIX } from '../virtual/slides'
 import { templateTitleRendererMd } from '../virtual/titles'
 import { regexSlideFacadeId, regexSlideReqPath, regexSlideSourceId } from './common'
-
-const RE_WORD_CHARS_ONLY = /^[\w-]+$/
 
 export function createSlidesLoader(
   options: ResolvedSlidevOptions,
@@ -394,32 +392,14 @@ export function createSlidesLoader(
     const notesAutoRuby: Record<string, string | undefined> = (data.headmatter as any).notesAutoRuby || {}
 
     // Apply [click] marker
-    let md = text
+    const md = text
       // replace [click] marker with span
       .replace(/\[click(?::(\d+))?\]/gi, (_, count = 1) => {
         clickCount += Number(count)
         return `<span class="slidev-note-click-mark" data-clicks="${clickCount}"></span>`
       })
 
-    // Apply notesAutoRuby
-    const keys = Object.keys(notesAutoRuby)
-      .sort((b, a) => b.length - a.length)
-      // Add word boundaries to the keys when they are simple alphabets or numbers
-      .map(i => RE_WORD_CHARS_ONLY.test(i) ? `\\b${i}\\b` : i)
-
-    if (keys.length) {
-      const regex = new RegExp(`(${keys.join('|')})`, 'g')
-      md = md.replace(
-        regex,
-        (match) => {
-          if (notesAutoRuby[match])
-            return `<ruby>${match}<rt>${notesAutoRuby[match]}</rt></ruby>`
-          return match
-        },
-      )
-    }
-
-    const html = notesMd.render(md)
+    const html = notesMd.render(applyNotesAutoRuby(md, notesAutoRuby))
     return html
   }
 


### PR DESCRIPTION
### Description

`notesAutoRuby` builds one alternation `RegExp` from the configured keys. Two things go wrong while that regex is built.

**1. Keys are sorted shortest-first.** The comparator is `(b, a) => b.length - a.length`, whose parameter names are transposed, so it sorts ascending by length. A regex alternation takes the first alternative that matches at a position, so a key that is a prefix of another key always wins and the longer key can never match:

```md
---
notesAutoRuby:
  日本: ni hon
  日本語: ni hon go
---
```

`日本語` renders as `<ruby>日本<rt>ni hon</rt></ruby>語`.

**2. Keys are interpolated into the pattern unescaped.** Keys that do not match `/^[\w-]+$/` go into the alternation verbatim, so regex metacharacters are interpreted:

* `C++` throws `SyntaxError: Invalid regular expression: /(C++)/g: Nothing to repeat`, which breaks note rendering for the whole deck.
* `(foo)` becomes a capture group, so the literal text `(foo)` is never wrapped.

### Changes

* Sort keys longest-first.
* Escape regex metacharacters in keys that do not take the `\b...\b` word-boundary path (word-only keys are already regex-safe).
* Move the replacement out of the `renderNote` closure into `applyNotesAutoRuby` in `node/utils.ts` so it can be tested directly, and add cases to the existing `node/utils.test.ts`.

Keys that already worked keep their current behaviour.

### Verification

`pnpm verify` (build, typecheck, lint, test) passes: 28 files / 246 tests.
