### PR TITLE
fix(parser): reject unit-less timestamps that are not numbers

### DIFF
--- a/packages/parser/src/timesplit/timestring.test.ts
+++ b/packages/parser/src/timesplit/timestring.test.ts
@@ -20,5 +20,10 @@ describe('parseTimeString', () => {
     expect(() => parseTimeString('10x')).toThrow('Invalid timestamp unit: x')
     expect(() => parseTimeString('10h:10m:10s')).toThrow('Invalid timestamp format')
     expect(() => parseTimeString('hello 1s world')).toThrow('Unknown timestamp remaining: hello  world')
+    // A unit-less value that isn't a number used to fall through to `Number()`
+    // and yield NaN, which then spread silently into the timer and timesplits.
+    expect(() => parseTimeString('30,5')).toThrow('Invalid timestamp format')
+    expect(() => parseTimeString('1 30')).toThrow('Invalid timestamp format')
+    expect(() => parseTimeString('1.2.3')).toThrow('Invalid timestamp format')
   })
 })

--- a/packages/parser/src/timesplit/timestring.ts
+++ b/packages/parser/src/timesplit/timestring.ts
@@ -58,6 +58,9 @@ export function parseTimeString(timestamp: string | number): {
   }
   else if (!RE_ALPHA.test(timestamp)) {
     seconds = Number(timestamp)
+    if (Number.isNaN(seconds)) {
+      throw new TypeError('Invalid timestamp format')
+    }
   }
   else {
     const unitMap: Record<string, number> = {


### PR DESCRIPTION
## Problem

`parseTimeString` throws a clear `TypeError` for every malformed shape it recognises:

- `10x` → `Invalid timestamp unit: x`
- `10h:10m:10s` → `Invalid timestamp format`
- `hello 1s world` → `Unknown timestamp remaining: …`

except one. A value with no unit letters and no colon falls through to `Number()` with no check, so anything `Number()` cannot parse becomes `NaN` silently:

```ts
parseTimeString('30,5')  // { seconds: NaN, relative: false }
parseTimeString('1 30')  // { seconds: NaN, relative: false }
parseTimeString('1.2.3') // { seconds: NaN, relative: false }
```

`duration: 30,5` in the headmatter is the natural way to write a decimal in much of the world, and `duration` goes straight into `useTimer`:

```ts
const duration = computed(() => parseTimeString(configs.duration).seconds)
const percentage = computed(() => passed.value / duration.value * 100)
```

so the countdown renders `NaN` and the progress percentage is `NaN`, with nothing pointing at the config line that caused it. `parseTimesplits` is affected too: it guards with `if (end < ts)`, which is always false for `NaN`, so a bad split propagates instead of throwing.

## Fix

Guard the numeric branch the same way the colon branch already guards `h`/`m`/`s`, reusing its message. A malformed `duration` now fails loudly at parse time, consistent with every other bad input this function sees.

## Scope

Three lines in `packages/parser/src/timesplit/timestring.ts`, plus three assertions in the existing invalid-timestamp test. Valid input is untouched — everything `Number()` accepts still parses.

## Test plan

- Ran: `vitest run packages/parser/src/timesplit/ test/parser.test.ts` → 103 passed.
