### PR TITLE
fix(parser): strip the title from markdown image destinations

### DIFF
--- a/packages/parser/src/core.ts
+++ b/packages/parser/src/core.ts
@@ -104,6 +104,18 @@ function matter(code: string, options: SlidevParserOptions) {
 }
 
 const IMAGE_EXTENSIONS = /\.(?:png|jpe?g|gif|svg|webp|avif|ico|bmp|tiff?)$/i
+const RE_MD_IMAGE_TITLE = /\s+(?:"[^"]*"|'[^']*')\s*$/
+
+/**
+ * Strip the optional CommonMark title and the angle-bracket form from a
+ * markdown image destination, so `![a](/x.png "Title")` yields `/x.png`.
+ */
+function normalizeMarkdownImageTarget(target: string) {
+  const url = target.trim().replace(RE_MD_IMAGE_TITLE, '').trim()
+  return url.startsWith('<') && url.endsWith('>')
+    ? url.slice(1, -1).trim()
+    : url
+}
 
 /**
  * Extract image URLs from slide content and frontmatter.
@@ -130,10 +142,11 @@ export function extractImagesUsage(content: string, frontmatter: Record<string, 
   // Strip code blocks to avoid false positives
   const stripped = content.replace(/^```[\s\S]+?^```/gm, '')
 
-  // Markdown images: ![alt](url)
-  for (const [, url] of stripped.matchAll(/!\[[^\]]*\]\(([^)]+)\)/g)) {
+  // Markdown images: ![alt](url), ![alt](url "title"), ![alt](<url>)
+  for (const [, target] of stripped.matchAll(/!\[[^\]]*\]\(([^)]+)\)/g)) {
+    const url = normalizeMarkdownImageTarget(target)
     if (url && !url.startsWith('data:'))
-      images.add(url.trim())
+      images.add(url)
   }
 
   // Vue component props: src="url", image="url"

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -414,6 +414,19 @@ Some text
       expect(images).toEqual(['/img1.png', 'https://example.com/img2.jpg', './relative/path.svg'])
     })
 
+    it('ignores the optional title in markdown images', () => {
+      const content = `![alt](/images/photo.jpg "A photo")
+![alt](/images/other.png 'Another')`
+      const images = extractImagesUsage(content, {})
+      expect(images).toEqual(['/images/photo.jpg', '/images/other.png'])
+    })
+
+    it('unwraps angle-bracketed markdown image destinations', () => {
+      const content = '![alt](</images/my photo.jpg>)'
+      const images = extractImagesUsage(content, {})
+      expect(images).toEqual(['/images/my photo.jpg'])
+    })
+
     it('ignores data URLs in markdown images', () => {
       const content = '![inline](data:image/png;base64,abc123)'
       const images = extractImagesUsage(content, {})


### PR DESCRIPTION
## Problem

`extractImagesUsage` treats everything between the parentheses of a markdown image as the URL:

```ts
for (const [, url] of stripped.matchAll(/!\[[^\]]*\]\(([^)]+)\)/g))
```

CommonMark allows an optional title there, and markdown-it renders it fine, so a perfectly valid slide

```md
![Logo](/logo.png "Company logo")
```

is collected as `/logo.png "Company logo"`. The angle-bracket destination form keeps its brackets: `![alt](</images/my photo.jpg>)` → `</images/my photo.jpg>`.

These strings are not just metadata — they are consumed as URLs:

- `usePreloadImages` calls `preloadImage(url)` on them, so the request 404s and is then retried up to `RETRY_LIMIT` times with backoff
- the same list feeds `totalImagesCount`, so the preload progress count is inflated by images that can never load
- `setups/indexHtml.ts` emits them as `<link rel="preload">` targets

The image itself still displays (markdown-it parses the title correctly); what breaks is preloading, which is exactly what this list exists for.

## Fix

Normalise the destination before collecting it: drop a trailing quoted title, and unwrap `<…>`. Both are handled in one small helper next to the existing regex constants.

## Scope

`packages/parser/src/core.ts` — one helper plus one regex constant — and two tests in the existing `extractImagesUsage` block. Untitled images are unchanged; the pre-existing tests cover that.

## Test plan

- Ran: `vitest run test/parser.test.ts` → 102 passed.
- Checked: reverting only `core.ts` fails the two new tests with `'/images/photo.jpg "A photo"'` and `'</images/my photo.jpg>'`, so they pin the reported behaviour.
