### PR TITLE
fix(parser): merge drawings config from theme defaults and nested config key

### DIFF
--- a/packages/parser/src/config.ts
+++ b/packages/parser/src/config.ts
@@ -85,7 +85,11 @@ export function resolveConfig(headmatter: any, themeMeta: SlidevThemeMeta = {}, 
       ...headmatter.config?.fonts,
       ...headmatter?.fonts,
     }),
-    drawings: resolveDrawings(headmatter.drawings, filepath),
+    drawings: resolveDrawings({
+      ...themeMeta.defaults?.drawings,
+      ...headmatter.config?.drawings,
+      ...headmatter?.drawings,
+    }, filepath),
     htmlAttrs: {
       ...defaultConfig.htmlAttrs,
       ...themeMeta.defaults?.htmlAttrs,

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -547,6 +547,32 @@ Some content
     })
   })
 
+  describe('resolveConfig drawings', () => {
+    it('applies drawings defaults from the theme', () => {
+      const config = resolveConfig({}, { defaults: { drawings: { presenterOnly: true } } } as any)
+      expect(config.drawings).toEqual({
+        enabled: true,
+        persist: false,
+        presenterOnly: true,
+        syncAll: true,
+      })
+    })
+
+    it('applies drawings from the nested `config` headmatter key', () => {
+      const config = resolveConfig({ config: { drawings: { syncAll: false } } })
+      expect(config.drawings.syncAll).toBe(false)
+    })
+
+    it('lets headmatter override the theme defaults', () => {
+      const config = resolveConfig(
+        { drawings: { enabled: false } },
+        { defaults: { drawings: { enabled: true, presenterOnly: true } } } as any,
+      )
+      expect(config.drawings.enabled).toBe(false)
+      expect(config.drawings.presenterOnly).toBe(true)
+    })
+  })
+
   it('detects circular src imports without overflowing', async () => {
     const root = resolve(__dirname, 'fixtures/markdown/circular')
     const data = await load({ userRoot: root, roots: [root] }, resolve(root, 'a.md'))


### PR DESCRIPTION
### Description

`resolveConfig` merges every other object-valued config option from four sources (built-in defaults, theme `defaults`, the nested `config:` headmatter key, and top-level headmatter). `drawings` is the exception: it reads only `headmatter.drawings`.

https://github.com/slidevjs/slidev/blob/main/packages/parser/src/config.ts#L88

```ts
fonts: resolveFonts({
  ...defaultConfig.fonts,
  ...themeMeta.defaults?.fonts,
  ...headmatter.config?.fonts,
  ...headmatter?.fonts,
}),
drawings: resolveDrawings(headmatter.drawings, filepath),
htmlAttrs: {
  ...defaultConfig.htmlAttrs,
  ...themeMeta.defaults?.htmlAttrs,
  ...headmatter.config?.htmlAttrs,
  ...headmatter?.htmlAttrs,
},
```

Because the explicit `drawings` key comes after the `...headmatter.config` / `...headmatter` spreads, it also overwrites whatever those spreads had put there. Two consequences:

1. A theme cannot ship drawing defaults. `SlidevThemeMeta['defaults']` is `Partial<SlidevConfig>`, which includes `drawings`, and [Write a Theme](https://sli.dev/guide/write-theme) documents `slidev.defaults` as being "merged with the user's configurations". Today a theme's `drawings` value is silently dropped.
2. `config: { drawings: ... }` in the headmatter is silently dropped, unlike `config: { htmlAttrs: ... }`, `config: { fonts: ... }` or `config: { themeConfig: ... }`.

Reproduction against `main`:

```js
resolveConfig({}, { defaults: { drawings: { presenterOnly: true } } }).drawings
// { enabled: true, persist: false, presenterOnly: false, syncAll: true }

resolveConfig({ config: { drawings: { syncAll: false } } }).drawings
// { enabled: true, persist: false, presenterOnly: false, syncAll: true }

// the sibling options do honour both sources
resolveConfig({}, { defaults: { htmlAttrs: { lang: 'ja' } } }).htmlAttrs   // { lang: 'ja' }
resolveConfig({ config: { htmlAttrs: { lang: 'ja' } } }).htmlAttrs         // { lang: 'ja' }
```

### Changes

* Merge `drawings` from theme defaults, `headmatter.config` and headmatter, in the same precedence order as `fonts`, `htmlAttrs` and `themeConfig`, before handing it to `resolveDrawings`. `defaultConfig.drawings` is not part of the spread because it is an empty placeholder; `resolveDrawings` already applies the real per-field defaults.
* Add three cases to `test/parser.test.ts` covering theme defaults, the nested `config` key, and headmatter winning over theme defaults.

Decks that only set top-level `drawings:` keep their current behaviour.

### Verification

`pnpm verify` (build, typecheck, lint, test) passes: 28 files / 244 tests.

Counterfactual check: with `packages/parser/src/config.ts` restored to its pre-fix state, the three new tests fail on the dropped fields (`presenterOnly` stays `false`, `syncAll` stays `true`), and pass again once the fix is reapplied.
