### PR TITLE
fix(monaco): whitelist the monaco-write path the dev server actually resolves

### DIFF
--- a/packages/slidev/node/syntax/snippet.test.ts
+++ b/packages/slidev/node/syntax/snippet.test.ts
@@ -1,6 +1,7 @@
 import MarkdownExit from 'markdown-exit'
 import path from 'pathe'
 import { expect, it } from 'vitest'
+import { monacoWriterWhitelist } from '../vite/monacoWrite'
 import MarkdownItSnippet, { resolveSnippetImport } from './snippet'
 
 const fixturesRoot = path.join(__dirname, '../../../../test/fixtures/')
@@ -74,4 +75,20 @@ it('throws when a snippet path escapes the allowed roots', () => {
   const slide = { source: { filepath: path.join(fixturesRoot, 'test.md') } } as any
   expect(() => resolveSnippetImport('<<< ../../../../../outside.ts', fixturesRoot, slide, [fixturesRoot]))
     .toThrow(/escapes the project root/)
+})
+
+it('whitelists a {monaco-write} snippet under the path the writer resolves', async () => {
+  monacoWriterWhitelist.clear()
+  const md = MarkdownExit()
+  md.use(MarkdownItSnippet, options)
+
+  const result = await md.renderAsync('<<< @/snippets/snippet.ts {monaco-write}', { id: 'slides.md__slidev_1.md' })
+
+  // createMonacoWriterPlugin does path.resolve(userRoot, file), so the value it
+  // is handed has to resolve back to the file that was read.
+  expect([...monacoWriterWhitelist]).toEqual(['snippets/snippet.ts'])
+  expect(result).toContain('writable="snippets/snippet.ts"')
+  // pathe normalises separators, so this is the writer's path.resolve verbatim.
+  expect(path.resolve(fixturesRoot, [...monacoWriterWhitelist][0]))
+    .toBe(path.join(fixturesRoot, 'snippets/snippet.ts'))
 })

--- a/packages/slidev/node/syntax/snippet.ts
+++ b/packages/slidev/node/syntax/snippet.ts
@@ -177,14 +177,19 @@ export default function MarkdownItSnippet(md: MarkdownExit, { userRoot, userWork
     if (!snippet)
       return false
 
-    const { content, filepath, src } = snippet
+    const { content, src } = snippet
     let { lang, meta } = snippet
 
     if (meta.includes('{monaco-write}')) {
-      monacoWriterWhitelist.add(filepath)
+      // The writer resolves whatever it receives against `userRoot`, so hand it
+      // a userRoot-relative path. `filepath` is the raw specifier as typed, and
+      // an `@/` alias or a path relative to the slide resolves elsewhere for
+      // reading than it would for writing.
+      const writePath = slash(path.relative(userRoot, src))
+      monacoWriterWhitelist.add(writePath)
       lang = lang.trim()
       meta = meta.replace('{monaco-write}', '').trim() || '{}'
-      const safeFilepath = JSON.stringify(filepath).slice(1, -1)
+      const safeFilepath = JSON.stringify(writePath).slice(1, -1)
       const encoded = lz.compressToBase64(content)
 
       const token = state.push('html_block', '', 0)


### PR DESCRIPTION
## Problem

`resolveSnippetImport` returns two different things:

```ts
const src = slash(
  filepath.startsWith('@/')
    ? path.resolve(userRoot, filepath.slice(2))
    : path.resolve(dir, filepath),      // dir = dirname(slide.source.filepath)
)
...
return { content, filepath, lang, meta, src }
```

`filepath` is the specifier exactly as typed in the Markdown; `src` is where it actually lives. Reading uses `src`. The `{monaco-write}` branch used `filepath`:

```ts
monacoWriterWhitelist.add(filepath)
...
const safeFilepath = JSON.stringify(filepath).slice(1, -1)
token.content = `<Monaco writable="${safeFilepath}" ... />`
```

and `createMonacoWriterPlugin` resolves whatever it receives against `userRoot`:

```ts
const filepath = path.resolve(userRoot, file)
```

So the snippet is read through one resolution scheme and written back through another.

| snippet | read from | written to |
|---|---|---|
| `<<< @/snippets/x.ts {monaco-write}` | `<userRoot>/snippets/x.ts` | `<userRoot>/@/snippets/x.ts` |
| `<<< ./x.ts {monaco-write}` in `pages/deck.md` | `<userRoot>/pages/x.ts` | `<userRoot>/x.ts` |

The `@/` form — the one the docs recommend — writes into a directory literally named `@`, which does not exist, so `fs.writeFile` rejects with ENOENT inside the websocket handler and the save is lost with no feedback in the editor. The relative form silently writes to a different file than the one on screen.

## Fix

Hand the writer the `userRoot`-relative form of the resolved path, which is the scheme it resolves in:

```ts
const writePath = slash(path.relative(userRoot, src))
monacoWriterWhitelist.add(writePath)
```

`monacoWrite.ts` and `Monaco.vue` are untouched. The plugin's `rel.startsWith('..')` guard keeps working and becomes meaningful — it now compares a path that really was resolved against `userRoot`.

## Test plan

- Added a case to the existing `packages/slidev/node/syntax/snippet.test.ts`, reusing its `test/fixtures/` root and `snippets/snippet.ts` fixture. It asserts the whitelisted value, the `writable` attribute, and that `path.resolve(userRoot, whitelisted)` lands back on the file that was read — the writer's own expression.
- Ran: `vitest run packages/slidev/node/syntax/snippet.test.ts` → **6 passed**.
- Checked: reverting only `snippet.ts` fails the new test with `[ '@/snippets/snippet.ts' ]` instead of `[ 'snippets/snippet.ts' ]`.
- Ran: `eslint` on both touched files → clean.